### PR TITLE
Update decode-status.py, SetOption165 text for TLS ECDSA validation

### DIFF
--- a/tools/decode-status.py
+++ b/tools/decode-status.py
@@ -220,7 +220,7 @@ a_setoption = [[
     "(Energy) Do not add export energy to energy today (1)",
     "(GUI) Disable display of GUI device name (1)",
     "(WizMote) Enable WiZ Smart Remote support (1)",
-    "",
+    "(TLS) Enable ECDSA validation in addition to RSA",
     "","","","",
     "","","","",
     "","","",""


### PR DESCRIPTION
SetOption165 was missing explanation text, copied from https://github.com/arendst/Tasmota/pull/24000 update of https://github.com/arendst/Tasmota/blob/development/tasmota/include/tasmota_types.h#L202

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
