### PR TITLE
Add special case topic override for Device Twin updates (Azure Iot Hub)

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -534,7 +534,13 @@ bool MqttPublishLib(const char* topic, const uint8_t* payload, unsigned int plen
     AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_MQTT "Invalid JSON for topic '%s', not sending to Azure IoT Hub"), topic);
     return true;
   }
-  topic = topicString.c_str();
+
+  // Handle special case for updating Azure Device Twin reported properties
+  if (topic && topic[0] == '$' && (strncmp(topic, "$iothub", 7) == 0)) {
+    topic = topic;
+  } else {
+    topic = topicString.c_str();
+  }
 #endif  // USE_MQTT_AZURE_IOT
 
   if (!MqttClient.beginPublish(topic, plength, retained)) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -524,9 +524,19 @@ bool MqttPublishLib(const char* topic, const uint8_t* payload, unsigned int plen
 #endif  // USE_TASMESH
 
 #ifdef USE_MQTT_AZURE_IOT
-  String sourceTopicString = urlEncodeBase64(String(topic));
-  String topicString = "devices/" + String(SettingsText(SET_MQTT_CLIENT));
-  topicString += "/messages/events/topic=" + sourceTopicString;
+  
+  // Set the topic
+  // Handle special case for updating Azure Device Twin reported properties
+  if (topic && topic[0] == '$' && (strncmp(topic, "$iothub", 7) == 0)) {
+    //Keep the original topic
+    //topic = topic; No-Op - Keep the original pointer
+  } else {
+    String sourceTopicString = urlEncodeBase64(String(topic));
+    String topicString = "devices/" + String(SettingsText(SET_MQTT_CLIENT));
+    topicString += "/messages/events/topic=" + sourceTopicString;
+    //Use the telemetry formatted topic
+    topic = topicString.c_str();
+  }
 
   JsonParser mqtt_message((char*) String((const char*)payload).c_str());
   JsonParserObject message_object = mqtt_message.getRootObject();
@@ -535,12 +545,6 @@ bool MqttPublishLib(const char* topic, const uint8_t* payload, unsigned int plen
     return true;
   }
 
-  // Handle special case for updating Azure Device Twin reported properties
-  if (topic && topic[0] == '$' && (strncmp(topic, "$iothub", 7) == 0)) {
-    topic = topic;
-  } else {
-    topic = topicString.c_str();
-  }
 #endif  // USE_MQTT_AZURE_IOT
 
   if (!MqttClient.beginPublish(topic, plength, retained)) {


### PR DESCRIPTION
- Azure IOT has prescribed topics for updates
- the Device Twin’s reported property update uses a different topic. Add an exception/offramp to publish a message to the Device Twin topic.

Example usage via a Rule Defintion:

Rule1 ON Power1#State DO publish $iothub/twin/PATCH/properties/reported/?$rid=1 {"powerState": "%value%"} ENDON

Without this code, the message would be published to the general telemetry topic and the Device Twin property would not be updated.

## Description:

**Related issue (if applicable):** N/A - No issue reported because I fixed it instead

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

^ Hoping this PR will trigger CI tests.... I did not see notes on how to run them. Assume they are merge-triggered
