### PR TITLE
Berry 'tcp.write()' add 'offset' and 'len'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Berry `gc_heap` and `gc_time` to `tasmota.memory()` (#24054)
 - Scripter array transfer via UFS (#24060)
 - ESP8266 GPIOViewer memory map if enabled with `#define GV_USE_ESPINFO`
+- Berry `tcp.write()` add `offset` and `len`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
@@ -38,7 +38,7 @@ extern "C" {
       if (top >= 5) {
         if (!is_binary) { be_raise(vm, "argument_error", "start and len are not allowed with string payloads"); }
         payload_start = be_toint(vm, 5);
-        if (payload_start < 0) payload_start = 0;
+        if (payload_start < 0) { payload_start = 0; }
       }
       if (top >= 6) { len = be_toint(vm, 6); }
       const char * topic = be_tostring(vm, 2);


### PR DESCRIPTION
## Description:

Berry, add optional parameters to `tcp.write(bytes | string[, offset:int = 0, len:int = -1]) -> int`, to specify the offset in bytes and the length in bytes to send.

**Related issue (if applicable):** fixes #24025

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
