### PR TITLE
Fix uDisplay DSI compile with IDF 5.4 / 5.5 based Arduino frameworks

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay_DSI_panel.cpp
+++ b/lib/lib_display/UDisplay/uDisplay_DSI_panel.cpp
@@ -43,7 +43,7 @@ DSIPanel::DSIPanel(const DSIPanelConfig& config)
     esp_lcd_dsi_bus_config_t bus_config = {
         .bus_id = 0,
         .num_data_lanes = cfg.dsi_lanes,
-        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
+        .phy_clk_src = (mipi_dsi_phy_pllref_clock_source_t)MIPI_DSI_PHY_CLK_SRC_PLL_F20M,
         .lane_bit_rate_mbps = cfg.lane_speed_mbps
     };
     ret = esp_lcd_new_dsi_bus(&bus_config, &dsi_bus);

--- a/lib/lib_display/UDisplay/uDisplay_DSI_panel.cpp
+++ b/lib/lib_display/UDisplay/uDisplay_DSI_panel.cpp
@@ -43,7 +43,6 @@ DSIPanel::DSIPanel(const DSIPanelConfig& config)
     esp_lcd_dsi_bus_config_t bus_config = {
         .bus_id = 0,
         .num_data_lanes = cfg.dsi_lanes,
-        .phy_clk_src = (mipi_dsi_phy_pllref_clock_source_t)MIPI_DSI_PHY_CLK_SRC_PLL_F20M,
         .lane_bit_rate_mbps = cfg.lane_speed_mbps
     };
     ret = esp_lcd_new_dsi_bus(&bus_config, &dsi_bus);

--- a/lib/lib_display/UDisplay/uDisplay_RGB_panel.cpp
+++ b/lib/lib_display/UDisplay/uDisplay_RGB_panel.cpp
@@ -9,8 +9,6 @@
 #include <algorithm>
 #include <rom/cache.h>
 
-extern int CACHE_WRITEBACK_ADDR(uint32_t addr, uint32_t size);
-
 RGBPanel::RGBPanel(const esp_lcd_rgb_panel_config_t *config) {
     ESP_ERROR_CHECK(esp_lcd_new_rgb_panel(config, &panel_handle));
     ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_handle));


### PR DESCRIPTION
## Description:

No functional change 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
