### PR TITLE
update lib JPEGDEC to v1.8.4

### DIFF
--- a/lib/libesp32/JPEGDEC/library.json
+++ b/lib/libesp32/JPEGDEC/library.json
@@ -1,6 +1,6 @@
 {
   "name": "JPEGDEC",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A fast JPEG library with a unique set of functions to make viewing image on microcontrollers easy. Includes fast downscaling options and the ability to view Exif embedded thumbnails. Supports baseline grayscale and color images with Huffman encoding.",
   "repository":
   {

--- a/lib/libesp32/JPEGDEC/library.properties
+++ b/lib/libesp32/JPEGDEC/library.properties
@@ -1,5 +1,5 @@
 name=JPEGDEC
-version=1.8.3
+version=1.8.4
 author=Larry Bank
 maintainer=Larry Bank
 sentence=Optimized JPEG decoder for MCUs with 32K+ RAM.

--- a/lib/libesp32/JPEGDEC/linux/examples/jpeg_perf_test/Makefile
+++ b/lib/libesp32/JPEGDEC/linux/examples/jpeg_perf_test/Makefile
@@ -1,0 +1,13 @@
+CFLAGS=-ggdb -D__LINUX__ -Wall -O2 -I../../
+LIBS=-g -lJPEGDEC 
+
+all: jpeg_perf_test
+
+jpeg_perf_test: main.o
+	$(CXX) main.o $(LIBS) -o jpeg_perf_test
+
+main.o: main.cpp
+	$(CXX) $(CFLAGS) -c main.cpp
+
+clean:
+	rm -rf *.o jpeg_perf_test

--- a/lib/libesp32/JPEGDEC/linux/examples/jpeg_perf_test/main.cpp
+++ b/lib/libesp32/JPEGDEC/linux/examples/jpeg_perf_test/main.cpp
@@ -1,0 +1,62 @@
+//
+// Perf Test
+//
+#include <JPEGDEC.h>
+#include <time.h>
+#include "../../../test_images/tulips.h" // 640x480 56k byte test image
+JPEGDEC jpeg;
+
+long micros(void)
+{
+int iTime;
+struct timespec res;
+
+    clock_gettime(CLOCK_MONOTONIC, &res);
+    iTime = 1000000*res.tv_sec + res.tv_nsec/1000;
+
+    return (long)iTime;
+} /* micros() */
+
+int JPEGDraw(JPEGDRAW *pDraw)
+{
+  // do nothing
+  return 1; // continue decode
+} /* JPEGDraw() */
+
+int main(int argc, char *argv[]) {
+long lTime;
+
+  if (jpeg.openFLASH((uint8_t *)tulips, sizeof(tulips), JPEGDraw)) {
+    lTime = micros();
+    if (jpeg.decode(0,0,0)) { // full sized decode
+      lTime = micros() - lTime;
+      printf("full sized decode in %d us\n", (int)lTime);
+    }
+    jpeg.close();
+  }
+  if (jpeg.openFLASH((uint8_t *)tulips, sizeof(tulips), JPEGDraw)) {
+    lTime = micros();
+    if (jpeg.decode(0,0,JPEG_SCALE_HALF)) { // 1/2 sized decode
+      lTime = micros() - lTime;
+      printf("half sized decode in %d us\n", (int)lTime);
+    }
+    jpeg.close();
+  }
+  if (jpeg.openFLASH((uint8_t *)tulips, sizeof(tulips), JPEGDraw)) {
+    lTime = micros();
+    if (jpeg.decode(0,0,JPEG_SCALE_QUARTER)) { // 1/4 sized decode
+      lTime = micros() - lTime;
+      printf("quarter sized decode in %d us\n", (int)lTime);
+    }
+    jpeg.close();
+  }
+  if (jpeg.openFLASH((uint8_t *)tulips, sizeof(tulips), JPEGDraw)) {
+    lTime = micros();
+    if (jpeg.decode(0,0,JPEG_SCALE_EIGHTH)) { // 1/8 sized decode
+      lTime = micros() - lTime;
+      printf("eighth sized decode in %d us\n", (int)lTime);
+    }
+    jpeg.close();
+  }
+  return 0;
+} /* main() */


### PR DESCRIPTION
## Description:

Fixed pointer overwrite when using full sized framebuffer

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
