### PR TITLE
fix redefine warning of U_SPIFFS

### DIFF
--- a/lib/libesp32/HttpClientLight/src/TasUpdate.h
+++ b/lib/libesp32/HttpClientLight/src/TasUpdate.h
@@ -23,7 +23,7 @@
 #define UPDATE_SIZE_UNKNOWN 0xFFFFFFFF
 
 #define U_FLASH   0
-#define U_SPIFFS  100
+#define U_SPIFFS  101
 #define U_AUTH    200
 
 #define ENCRYPTED_BLOCK_SIZE 16


### PR DESCRIPTION
## Description:

Silence warning. No functional change

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
