### PR TITLE
Berry alternative to strnlen 2

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -285,7 +285,11 @@ static void tr_string(blexer *lexer)
         }
     }
     size_t len = dst - lexbuf(lexer);
-    lexer->buf.len = strnlen(lexbuf(lexer), len);
+    /* equivalent to strnlen() */
+    /* lexer->buf.len = strnlen(lexbuf(lexer), len); */
+    const char* str = (const char*) lexbuf(lexer);
+    const char* found = memchr(str, '\0', len);
+    lexer->buf.len = found ? (size_t)(found - str) : len;
 }
 
 static int skip_newline(blexer *lexer)


### PR DESCRIPTION
## Description:

Avoid using strnlen() which is non-standard and use an alternative implementation. This is the last `strnlen()` used in Berry.

**Related issue (if applicable):** fixes #23952

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
