### PR TITLE
Berry: improve cam module and img class

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_img_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_img_lib.c
@@ -21,6 +21,7 @@ class be_class_img (scope: global, name: img, strings: weak) {
 
   GRAYSCALE, int(3)
   RGB565, int(0)
+  RGB565LE, int(1)
   RGB888, int(5)
   JPEG, int(4)
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -467,8 +467,13 @@ uint32_t WcSetup(int32_t fsiz) {
   bool psram = UsePSRAM();
   if (psram) {
     config.frame_size = FRAMESIZE_UXGA;
+#ifndef USE_WEBCAM_SETUP_ONLY
     config.jpeg_quality = 10;
     config.fb_count = 2;
+#else
+    config.jpeg_quality = 4; // start on the quality side for post processing
+    config.fb_count = 1; // we do not really want to stream in pure Berry
+#endif
     AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: PSRAM found"));
   } else {
     config.frame_size = FRAMESIZE_VGA;


### PR DESCRIPTION
## Description:

Optimise memory consumption in order to allow basic image manipulation on 4 MB boards for images up to 1280 x 1024 pixel in RGB565.

Uses only one framebuffer in PSRAM. Because of the ESP camera driver you must discard the first read image, if you want a fresh image after a longer pause. This is a known problem.

Supports now image type `RGB565LE` - for legacy reasons the old `RGB565` keeps its name and is basically RGB565BE.

Can handle now wrong (too large) JPEG image sizes, that may come from the image sensor and falls back to cropping mode.

Note: These Berry drivers are still not meant to be a general replacement for the dedicated webcam drivers, but may be the tinker tool for niche cases. In the same build environment we still win about 10 kB free heap in comparison.

Example code will follow in the comments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
