### PR TITLE
prepare for esp32-p4 rev.300

### DIFF
--- a/boards/esp32p4.json
+++ b/boards/esp32p4.json
@@ -9,6 +9,7 @@
     "f_psram": "200000000L",
     "flash_mode": "qio",
     "mcu": "esp32p4",
+    "chip_variant": "esp32p4_es",
     "variant": "esp32p4",
     "partitions": "partitions/esp32_partition_app3904k_fs11584k.csv"
   },

--- a/boards/esp32p4ser.json
+++ b/boards/esp32p4ser.json
@@ -9,6 +9,7 @@
     "f_psram": "200000000L",
     "flash_mode": "qio",
     "mcu": "esp32p4",
+    "chip_variant": "esp32p4_es",
     "variant": "esp32p4",
     "partitions": "partitions/esp32_partition_app3904k_fs11584k.csv"
   },


### PR DESCRIPTION
## Description:

Prepare build system for use of the two different P4 variants.
The new upcoming rev.300 is not compatible to the earlier versions and needs different precompiled Arduino libs.
The P4 before rev.300 will be named as chip variant `esp32p4_es` Therefore a new entry in boards manifest is needed

Actualy no impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
