### PR TITLE
Berry fix infinite loop in rare situations

### DIFF
--- a/lib/libesp32/berry/src/be_code.c
+++ b/lib/libesp32/berry/src/be_code.c
@@ -867,7 +867,7 @@ static void package_suffix(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k)
     c->v.ss.idx = key;
 }
 
-int be_code_nglobal(bfuncinfo *finfo, bexpdesc *k)
+int be_code_resolve(bfuncinfo *finfo, bexpdesc *k)
 {
     return exp2anyreg(finfo, k);
 }

--- a/lib/libesp32/berry/src/be_code.h
+++ b/lib/libesp32/berry/src/be_code.h
@@ -31,7 +31,7 @@ void be_code_closure(bfuncinfo *finfo, bexpdesc *e, int idx);
 void be_code_close(bfuncinfo *finfo, int isret);
 void be_code_class(bfuncinfo *finfo, bexpdesc *dst, bclass *c);
 void be_code_ret(bfuncinfo *finfo, bexpdesc *e);
-int be_code_nglobal(bfuncinfo *finfo, bexpdesc *k);
+int be_code_resolve(bfuncinfo *finfo, bexpdesc *k);
 void be_code_member(bfuncinfo *finfo, bexpdesc *e1, bexpdesc *e2);
 void be_code_index(bfuncinfo *finfo, bexpdesc *c, bexpdesc *k);
 void be_code_setsuper(bfuncinfo *finfo, bexpdesc *c, bexpdesc *s);

--- a/lib/libesp32/berry/tests/parser.be
+++ b/lib/libesp32/berry/tests/parser.be
@@ -23,3 +23,6 @@ def parse_022025()
     end
 end
 assert(parse_022025() == 0)
+
+# bug #371 - fix an infinite loop
+def f() 1 || print(2) end


### PR DESCRIPTION
## Description:

Apply fix from upstream https://github.com/berry-lang/berry/pull/495

Some specific syntax would compile to code causing an infinite loop, although it never appeared in Tasmota code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
