### PR TITLE
FIX: fix closing curly bracket in f-string

### DIFF
--- a/lib/libesp32/berry_matter/generate/Matter_generate_c.be
+++ b/lib/libesp32/berry_matter/generate/Matter_generate_c.be
@@ -82,7 +82,7 @@ fprint("  const matter_command_t* commands;")
 fprint("} matter_cluster_t;")
 fprint()
 for cl:cl_ids
-  fprint(f"const matter_attribute_t matter_Attributes_{cl:04X}[] = {")
+  fprint(f"const matter_attribute_t matter_Attributes_{cl:04X}[] = {{")
   var attributes = c[cl_id_name[cl]]['attributes']
   var attr_id_name = {}
   for attr:attributes
@@ -100,7 +100,7 @@ for cl:cl_ids
   fprint("};")
   fprint()
   # commands
-  fprint(f"const matter_command_t matter_Commands_{cl:04X}[] = {")
+  fprint(f"const matter_command_t matter_Commands_{cl:04X}[] = {{")
   var commands = c[cl_id_name[cl]]['commands']
   var cmd_id_name = {}
   for cmd:commands


### PR DESCRIPTION
## Description:

Generating berry_matter is broken on my system due to the lonely curly bracket at the end of two lines, which needs to be escaped.

@s-hadinger Plz take a look.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
