### PR TITLE
MI32: fix onStatus(), improve stability for Matter network commissioning with Bluetooth

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -236,11 +236,12 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
           BLERingBufferItem_t header;
           uint8_t buffer[4];
         } item;
-        item.header.length = 4;
+        item.header.length = sizeof(item.buffer);
         item.header.type = BLE_OP_ON_STATUS;
         item.header.returnCharUUID = *(uint16_t*)pCharacteristic->getUUID().getValue();
         item.header.handle = pCharacteristic->getHandle();
-        xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + 4, pdMS_TO_TICKS(1));
+        memcpy(item.buffer,&code,item.header.length);
+        xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + item.header.length, pdMS_TO_TICKS(1));
     };
 
     void onSubscribe(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo, uint16_t subValue) {
@@ -1539,7 +1540,7 @@ void MI32ConnectionTask(void *pvParameters){
 bool MI32StartServerTask(){
   AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Server task ... start"));
   if (BLERingBufferQueue == nullptr){
-    BLERingBufferQueue = xRingbufferCreate(2048, RINGBUF_TYPE_NOSPLIT);
+    BLERingBufferQueue = xRingbufferCreate(4096, RINGBUF_TYPE_NOSPLIT);
     if(!BLERingBufferQueue) {
       AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed to create ringbuffer queue"));
       return false;


### PR DESCRIPTION
## Description:

- increase ring buffer queue size when acting as BLE central device / server
- fix onStatus() callback and really send error code to Berry's BLE module

Matter network commissioning with Bluetooth Low Energy in Tasmota is possible with some additional effort. Tested with chip-tool and Apples Home app.
Definitely not recommended as the primary way to do the WiFi setup for a Tasmota device as it is a lengthy process and of course adds more chances for failure.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
