### PR TITLE
ignore BLE for S2

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -284,6 +284,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
+                          esp-nimble-cpp
                           Micro-RTSP
                           epdiy
 
@@ -294,6 +295,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
+                          esp-nimble-cpp
                           Micro-RTSP
                           epdiy
 


### PR DESCRIPTION
## Description:

prevent not needed compile and issues since S2 does not support BLE

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
