### PR TITLE
Fix non-mononoticity of total energy sensor

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_03_energy.ino
@@ -422,9 +422,9 @@ void Energy200ms(void) {
           Settings->energy_kWhexport_ph[i] = RtcSettings.energy_kWhexport_ph[i];
 
           Energy->period[i] -= RtcSettings.energy_kWhtoday_ph[i];     // this becomes a large unsigned, effectively a negative for EnergyShow calculation
-          Energy->kWhtoday[i] = 0;
+          Energy->kWhtoday[i] = Energy->kWhtoday[i] % 100;            // Roll fractional watt-hours into the next day since kWhtotal truncates to watt-hours.
           Energy->kWhtoday_offset[i] = 0;
-          RtcSettings.energy_kWhtoday_ph[i] = 0;
+          RtcSettings.energy_kWhtoday_ph[i] = Energy->kWhtoday[i];
           Settings->energy_kWhtoday_ph[i] = 0;
 
           Energy->start_energy[i] = 0;


### PR DESCRIPTION
## Description:

Fixes #20668 and #23081. Also loosely related to #9536.

To recap the issue here as I understand it:
- Tasmota stores a "current day" energy usage (`RtcSettings.energy_kWhtoday_ph`, which I'll abbreviate to kWhtoday), and a "total" energy usage (`RtcSettings.energy_kWhtotal_ph`, which I'll abbreviate to kWhtotal).
- kWhtotal stores an `int32_t` of watt-hours, while kWhtoday stores an `int32_t` of centiwatt-hours (100 times more precise than kWhtotal).
- When showing the total energy, Tasmota calculates it in kilowatt-hours as `kWhtotal / 1000 + kWhtoday / 100000` (stored as `Energy->total`). One would expect this to be monotonic.
- At the end of the day, Tasmota adds kWhtoday into kWhtotal and resets kWhtoday to 0.
- **The issue** is that, because of the differing precision between the two values, any fraction of a watt-hour in kWhtoday gets lost. If kWhtotal is 1.234 and kWhtoday is 0.56789, when it rolls over kWhtotal will end up at 1.801 and kWhtoday will be 0. The remaining 0.00089 watt-hours will simply vanish, causing the total energy to decrease. In applications that assume total energy to be monotonic this can cause weird issues (my own issue is unexpected giant spikes in grafana graphs, sometimes up to several hundred megawatts).

This can be fixed by simply changing the way kWhtoday gets rolled into kWhtotal. Rather than resetting kWhtoday to 0 after adding it to kWhtotal, we can just roll the fractional watt-hour portion into the next day.

Thanks to @ptlrk's description of a fast way to reproduce the issue I was able to test this before and after my fix, showing the following results (with superfluous lines removed):

Before:

```
23:59:59.621 CMD: time 1764629980
23:59:40.002 RSL: RESULT = {"Time":"2025-12-01T23:59:40","Epoch":1764629980}
23:59:45.217 CMD: energytotal
23:59:45.222 RSL: RESULT = {"EnergyTotal":{"Total":0.00018,"Yesterday":0.00000,"Today":0.00018}}
23:59:54.309 CMD: energytotal
23:59:54.315 RSL: RESULT = {"EnergyTotal":{"Total":0.00029,"Yesterday":0.00000,"Today":0.00029}}
23:59:58.501 CMD: energytotal
23:59:58.507 RSL: RESULT = {"EnergyTotal":{"Total":0.00036,"Yesterday":0.00000,"Today":0.00036}}
00:00:01.154 CMD: energytotal
00:00:01.160 RSL: RESULT = {"EnergyTotal":{"Total":0.00001,"Yesterday":0.00037,"Today":0.00001}}
```

After:

```
23:59:50.566 CMD: time 1764629980
23:59:40.003 RSL: RESULT = {"Time":"2025-12-01T23:59:40","Epoch":1764629980}
23:59:46.496 CMD: energytotal
23:59:46.502 RSL: RESULT = {"EnergyTotal":{"Total":0.00015,"Yesterday":0.00000,"Today":0.00015}}
23:59:53.724 CMD: energytotal
23:59:53.730 RSL: RESULT = {"EnergyTotal":{"Total":0.00024,"Yesterday":0.00000,"Today":0.00024}}
23:59:58.798 CMD: energytotal
23:59:58.804 RSL: RESULT = {"EnergyTotal":{"Total":0.00030,"Yesterday":0.00000,"Today":0.00030}}
00:00:02.085 CMD: energytotal
00:00:02.091 RSL: RESULT = {"EnergyTotal":{"Total":0.00034,"Yesterday":0.00031,"Today":0.00034}}
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
