### PR TITLE
Update BLE MI and TRV

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -634,6 +634,7 @@ void setup(void) {
         Settings->rule_enabled = 0;                  // Disable all rules
         Settings->flag3.shutter_mode = 0;            // disable shutter support
         TasmotaGlobal.no_autoexec = true;
+        Settings->flag5.mi32_enable = false;         // disable BLE
       }
       if (RtcReboot.fast_reboot_count > Settings->param[P_BOOT_LOOP_OFFSET] +3) {  // Restarted 5 times
         for (uint32_t i = 0; i < nitems(Settings->my_gp.io); i++) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -158,6 +158,15 @@ i.e. the Bluetooth of the ESP can be shared without conflict.
 #include "NimBLEEddystoneTLM.h"
 #include "NimBLEBeacon.h"
 
+// The LOG_LEVEL macros are used to set the log level for the NimBLE stack, but they pollute the global namespace and would override the loglevel enum of Tasmota.
+// So we undefine them here to avoid conflicts.
+#undef LOG_LEVEL_DEBUG
+#undef LOG_LEVEL_INFO
+#undef LOG_LEVEL_WARN
+#undef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_CRITICAL
+#undef LOG_LEVEL_NONE
+
 // assume this hack is still valid.
 #define DEPENDSONNIMBLEARDUINO 1
 #ifdef DEPENDSONNIMBLEARDUINO        

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -1000,12 +1000,10 @@ const char HTTP_EQ3_BATTERY[]      PROGMEM = "{s}%s " D_BATTERY "{m}%s{e}";
 
 void EQ3Show(void)
 {
+  if (!Settings->flag5.mi32_enable) return;
+
   char c_unit = D_UNIT_CELSIUS[0]; // ToDo: Check if fahrenheit is possible -> temp_format==TEMP_CELSIUS ? D_UNIT_CELSIUS[0] : D_UNIT_FAHRENHEIT[0];
   bool FirstSensorShown = false;
-
-  if (!Settings->flag5.mi32_enable) {
-    return;
-  }
 
   for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
     if (EQ3Devices[i].timeoutTime) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -19,6 +19,8 @@
   --------------------------------------------------------------------------------------------
   Version yyyymmdd  Action    Description
   --------------------------------------------------------------------------------------------
+  1.0.1.1 20251204  changed - display RSSI in general format "xx% (-yy dBm)"
+                              view on UI only when BLE enabled
   1.0.1.0 20240113  publish - Add some values to WebUI; code cleanup
   1.0.0.0 20210910  publish - renamed to xdrv_85, and checked with TAS latest dev branch
   0.0.0.0 20201213  created - initial version
@@ -991,7 +993,7 @@ int EQ3SendResult(char *requested, const char *result){
 #ifdef USE_WEBSERVER
 const char HTTP_EQ3_TYPE[]         PROGMEM = "{s}%s " D_NEOPOOL_TYPE "{m}EQ3{e}";
 const char HTTP_EQ3_MAC[]          PROGMEM = "{s}%s " D_MAC_ADDRESS "{m}%s{e}";
-const char HTTP_EQ3_RSSI[]         PROGMEM = "{s}%s " D_RSSI "{m}%d dBm{e}";
+const char HTTP_EQ3_RSSI[]         PROGMEM = "{s}%s " D_RSSI "{m}%d%% (%d dBm){e}";
 const char HTTP_EQ3_TEMPERATURE[]  PROGMEM = "{s}%s " D_THERMOSTAT_SET_POINT "{m}%*_f " D_UNIT_DEGREE "%c{e}";
 const char HTTP_EQ3_DUTY_CYCLE[]   PROGMEM = "{s}%s " D_THERMOSTAT_VALVE_POSITION "{m}%d " D_UNIT_PERCENT "{e}";
 const char HTTP_EQ3_BATTERY[]      PROGMEM = "{s}%s " D_BATTERY "{m}%s{e}";
@@ -1000,6 +1002,10 @@ void EQ3Show(void)
 {
   char c_unit = D_UNIT_CELSIUS[0]; // ToDo: Check if fahrenheit is possible -> temp_format==TEMP_CELSIUS ? D_UNIT_CELSIUS[0] : D_UNIT_FAHRENHEIT[0];
   bool FirstSensorShown = false;
+
+  if (!Settings->flag5.mi32_enable) {
+    return;
+  }
 
   for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
     if (EQ3Devices[i].timeoutTime) {
@@ -1016,7 +1022,7 @@ void EQ3Show(void)
         label = tlabel;
       }
       WSContentSend_P(HTTP_EQ3_MAC, label, addrStr(EQ3Devices[i].addr));
-      WSContentSend_PD(HTTP_EQ3_RSSI, label, EQ3Devices[i].RSSI);
+      WSContentSend_PD(HTTP_EQ3_RSSI, label, WifiGetRssiAsQuality(EQ3Devices[i].RSSI), EQ3Devices[i].RSSI);
       WSContentSend_PD(HTTP_EQ3_TEMPERATURE, label, Settings->flag2.temperature_resolution, &EQ3Devices[i].TargetTemp, c_unit);
       WSContentSend_P(HTTP_EQ3_DUTY_CYCLE, label, EQ3Devices[i].DutyCycle);
       WSContentSend_P(HTTP_EQ3_BATTERY, label, EQ3Devices[i].Battery ? D_NEOPOOL_LOW : D_OK);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -3530,15 +3530,13 @@ void MI32Show(bool json)
 
 #ifdef USE_WEBSERVER
   } else {
+    if (!Settings->flag5.mi32_enable) return;
+
     static  uint16_t _page = 0;
     static  uint16_t _counter = 0;
     int32_t i = _page * MI32.perPage;
     uint32_t j = i + MI32.perPage;
 
-    if (!Settings->flag5.mi32_enable) {
-      return;
-    }
-    
     if (j+1 > numsensors){
       j = numsensors;
     }

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -20,11 +20,14 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#define MI32_VERSION "V0.9.2.6"
+#define MI32_VERSION "V0.9.2.7"
 /*
   --------------------------------------------------------------------------------------------
   Version yyyymmdd  Action    Description
   --------------------------------------------------------------------------------------------
+  0.9.2.7 20251204  changed - display RSSI in general format "xx% (-yy dBm)"
+                              view on UI only when BLE enabled
+  -------
   0.9.2.6 20250503  changed - display alias instead of type, when present
   -------
   0.9.2.5 20250319  changed - added support for MI LYWSD02MMC with different device ID
@@ -2749,7 +2752,7 @@ void CmndMi32Keys(void){
 const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 " MI32_VERSION "{m}%u%s / %u{e}";
 const char HTTP_MI32_TYPE[] PROGMEM = "{s}%s " D_SENSOR"{m}%s{e}";
 const char HTTP_MI32_MAC[] PROGMEM = "{s}%s " D_MAC_ADDRESS "{m}%s{e}";
-const char HTTP_MI32_RSSI[] PROGMEM = "{s}%s " D_RSSI "{m}%d dBm{e}";
+const char HTTP_MI32_RSSI[] PROGMEM = "{s}%s " D_RSSI "{m}%d%% (%d dBm){e}";
 const char HTTP_MI32_BATTERY[] PROGMEM = "{s}%s " D_BATTERY "{m}%u %%{e}";
 const char HTTP_MI32_LASTBUTTON[] PROGMEM = "{s}%s Last Button{m}%u{e}";
 const char HTTP_MI32_EVENTS[] PROGMEM = "{s}%s Events{m}%u{e}";
@@ -3532,6 +3535,10 @@ void MI32Show(bool json)
     int32_t i = _page * MI32.perPage;
     uint32_t j = i + MI32.perPage;
 
+    if (!Settings->flag5.mi32_enable) {
+      return;
+    }
+    
     if (j+1 > numsensors){
       j = numsensors;
     }
@@ -3559,7 +3566,7 @@ void MI32Show(bool json)
       char _MAC[18];
       ToHex_P(p->MAC,6,_MAC,18);//,':');
       WSContentSend_P(HTTP_MI32_MAC, label, _MAC);
-      WSContentSend_PD(HTTP_MI32_RSSI, label, p->RSSI);
+      WSContentSend_PD(HTTP_MI32_RSSI, label, WifiGetRssiAsQuality(p->RSSI), p->RSSI);
 
       // for some reason, display flora differently
       switch(p->type){


### PR DESCRIPTION
## Description:
- Changed RSSI display format to 'xx% (-yy dBm)' in EQ3 TRV and MI BLE sensor WebUI
- Show BLE data in WebUI only when BLE is enabled
- Disable BLE when device is in boot loop
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

