### PR TITLE
MI32: add pin, some fixes

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -64,8 +64,8 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_reg_adv_cb, "", "c[c]");
 extern void be_BLE_reg_server_cb(void* function, uint8_t *buffer);
 BE_FUNC_CTYPE_DECLARE(be_BLE_reg_server_cb, "", "c[c]");
 
-extern void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
-BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[i]");
+extern void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type, uint32_t pin);
+BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[ii]");
 
 extern void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
 BE_FUNC_CTYPE_DECLARE(be_BLE_set_characteristic, "", "@s");

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -178,6 +178,7 @@ struct MI32connectionContextBerry_t{
   uint8_t addrType;
   int error;
   int32_t arg1;
+  uint32_t pin;
   bool hasArg1;
   bool oneOp;
   bool response;

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -110,7 +110,7 @@ extern "C" {
   extern bool MI32runBerryConnection(uint8_t operation, bbool response, int32_t *arg1);
   extern bool MI32setBerryCtxSvc(const char *Svc, bbool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
-  extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type);
+  extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type, uint32_t pin);
   extern bool MI32addMACtoWatchList(uint8_t *MAC, uint8_t type);
   extern void MI32setBerryStoreRec(uint8_t *buffer, size_t size);
 
@@ -159,8 +159,8 @@ extern "C" {
     return true;
   }
 
-  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
-  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){
+  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type, uint32_t pin);
+  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type, uint32_t pin){
     if(!be_BLE_MAC_size(vm, size)){
       return;
     }
@@ -168,7 +168,11 @@ extern "C" {
     if(type){
       _type = type;
     }
-    if (MI32setBerryCtxMAC(buf,_type)) return;
+    uint32_t _pin = 0;
+    if (pin){
+      _pin = pin;
+    }
+    if (MI32setBerryCtxMAC(buf,_type, _pin)) return;
 
     be_raisef(vm, "ble_error", "BLE: could not set MAC");
   }


### PR DESCRIPTION
## Description:

Fix reintroduced logging glitch again, that is an unresolved issue in esp-nimble for years now.

Change logic of conversion of 128-bit to 16-bit address UUID to the version, that will be correct in 95% of the cases fur 128-bit custom UUID in the callback. 

Fix crash, that could happen if we disconnect from BLE server and then receive a notification (initiated in the old session) without subscribing again.

Add passkey (aka pin) option when connecting to a BLE server (tested i.e. for EQ3 thermostat with newer firmware >= 1.48). Is passed as optional argument in form of a number to `set_MAC()`.

`BLE.set_MAC(bytes("AABBCCDDEEFF"),0,123456)` #MAC, type, pin


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
