### PR TITLE
Berry `tasmota.micros()` to get time in microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for ESP32-P4 rev.3 (#24146)
 - Support for Analog Gauges (#24153)
 - Support for MakeSkyBlue Solar Charger Energy Monitor (#24151)
+- Berry `tasmota.micros()` to get time in microseconds
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-1.2.0/package.json
+++ b/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-1.2.0/package.json
@@ -3,7 +3,7 @@
     "displayName": "Berry Script Language",
     "description": "A small embedded script language.",
     "version": "1.2.0",
-	"icon": "berry-icon.png",
+    "icon": "berry-icon.png",
     "publisher": "skiars",
     "engines": {
         "vscode": "^1.15.1"

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -21,6 +21,7 @@ extern int l_publish_rule(bvm *vm);
 extern int l_cmd(bvm *vm);
 extern int l_getoption(bvm *vm);
 extern int l_millis(bvm *vm);
+extern int l_micros(bvm *vm);
 extern int l_timereached(bvm *vm);
 extern int l_rtc(bvm *vm);
 extern int l_rtc_utc(bvm *vm);
@@ -114,7 +115,8 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     publish_rule, func(l_publish_rule)
     _cmd, func(l_cmd)
     get_option, func(l_getoption)
-    millis, func(l_millis)
+    millis, static_func(l_millis)
+    micros, static_func(l_micros)
     time_reached, func(l_timereached)
     rtc, static_func(l_rtc)
     rtc_utc, func(l_rtc_utc)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -119,16 +119,24 @@ extern "C" {
   int32_t l_millis(struct bvm *vm);
   int32_t l_millis(struct bvm *vm) {
     int32_t top = be_top(vm); // Get the number of arguments
-    if (top == 1 || (top == 2 && be_isint(vm, 2))) {  // only 1 argument of type string accepted
+    if (top == 0 || (top == 1 && be_isint(vm, 1))) {  // only 1 argument of type string accepted
       uint32_t delay = 0;
       if (top == 2) {
-        delay = be_toint(vm, 2);
+        delay = be_toint(vm, 1);
       }
       uint32_t ret_millis = millis() + delay;
       be_pushint(vm, ret_millis);
       be_return(vm); // Return
     }
     be_raise(vm, kTypeError, nullptr);
+  }
+
+  // Berry: tasmota.micros() -> int
+  //
+  int32_t l_micros(struct bvm *vm);
+  int32_t l_micros(struct bvm *vm) {
+    be_pushint(vm, micros());
+    be_return(vm); // Return
   }
 
   // Berry: tasmota.get_option(index:int) -> int


### PR DESCRIPTION
## Description:

New function to get current time in microseconds to get finer measurement than tasmota.millis(). Be careful that the counter changes sign every hour.

Also changed `tasmota.millis()` to a static method.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
