### PR TITLE
MI32: use always 128-bit UUID for characteristics as peripheral

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -885,7 +885,7 @@ extern "C" {
 
   bool MI32setBerryCtxChr(const char *Chr){
     if(MI32.conCtx != nullptr){
-      MI32.conCtx->charUUID = NimBLEUUID(Chr);
+      MI32.conCtx->charUUID = NimBLEUUID(Chr).to128();
       AddLog(LOG_LEVEL_DEBUG,PSTR("M32: CHR: %s"),MI32.conCtx->charUUID.toString().c_str());
       uint16_t _uuid = *reinterpret_cast<const uint16_t*>(MI32.conCtx->charUUID.getValue() + 12); //if not "notify op" -> present requested characteristic as return UUID
       MI32.conCtx->returnCharUUID = _uuid;


### PR DESCRIPTION
## Description:

Fix wrong return value in Berry callback when 16-bit UUID was used for BLE characteristic.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
