### PR TITLE
Adjust reset signal timing for i2c touch controller

### DIFF
--- a/lib/lib_display/UDisplay/src/uDisplay_touch.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_touch.cpp
@@ -22,9 +22,9 @@ bool uDisplay::utouch_Init(char **name) {
       digitalWrite(ut_reset, HIGH);
       delay(10);
       digitalWrite(ut_reset, LOW);
-      delay(5);
-      digitalWrite(ut_reset, HIGH);
       delay(10);
+      digitalWrite(ut_reset, HIGH);
+      delay(50);
     }
     
     if (ut_irq >= 0) {


### PR DESCRIPTION
## Description:

Increase delay duration for reset signal in uDisplay.
https://github.com/arendst/Tasmota/discussions/23737#discussioncomment-15187060


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
