### PR TITLE
revert breaking PR #24192

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -21,7 +21,6 @@ extern int l_publish_rule(bvm *vm);
 extern int l_cmd(bvm *vm);
 extern int l_getoption(bvm *vm);
 extern int l_millis(bvm *vm);
-extern int l_micros(bvm *vm);
 extern int l_timereached(bvm *vm);
 extern int l_rtc(bvm *vm);
 extern int l_rtc_utc(bvm *vm);
@@ -115,8 +114,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     publish_rule, func(l_publish_rule)
     _cmd, func(l_cmd)
     get_option, func(l_getoption)
-    millis, static_func(l_millis)
-    micros, static_func(l_micros)
+    millis, func(l_millis)
     time_reached, func(l_timereached)
     rtc, static_func(l_rtc)
     rtc_utc, func(l_rtc_utc)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -119,24 +119,16 @@ extern "C" {
   int32_t l_millis(struct bvm *vm);
   int32_t l_millis(struct bvm *vm) {
     int32_t top = be_top(vm); // Get the number of arguments
-    if (top == 0 || (top == 1 && be_isint(vm, 1))) {  // only 1 argument of type string accepted
+    if (top == 1 || (top == 2 && be_isint(vm, 2))) {  // only 1 argument of type string accepted
       uint32_t delay = 0;
       if (top == 2) {
-        delay = be_toint(vm, 1);
+        delay = be_toint(vm, 2);
       }
       uint32_t ret_millis = millis() + delay;
       be_pushint(vm, ret_millis);
       be_return(vm); // Return
     }
     be_raise(vm, kTypeError, nullptr);
-  }
-
-  // Berry: tasmota.micros() -> int
-  //
-  int32_t l_micros(struct bvm *vm);
-  int32_t l_micros(struct bvm *vm) {
-    be_pushint(vm, micros());
-    be_return(vm); // Return
   }
 
   // Berry: tasmota.get_option(index:int) -> int


### PR DESCRIPTION
## Description:

it breaks the Haspmota Watch 480x480 Demo with Berry error:

```
00:00:08.188 BRY: Exception> 'timeout_error' - Berry code running for too long
00:00:08.188 stack traceback:
00:00:08.188 .<unknown source>: in function `run_timers`
00:00:08.199 .<unknown source>: in function `event`
00:00:18.711 BRY: Exception> 'timeout_error' - Berry code running for too long
00:00:18.712 stack traceback:
00:00:18.712 .<unknown source>: in function `setmember`
00:00:18.722 .<unknown source>: in function `set_watch`
00:00:18.723 .<unknown source>: in function `run_watch`
00:00:18.733 .<unknown source>: in function `run_timers`
00:00:18.733 .<unknown source>: in function `event
```

@s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
