### PR TITLE
fix displayrotate for i2c

### DIFF
--- a/lib/lib_display/UDisplay/include/uDisplay_I2C_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_I2C_panel.h
@@ -51,7 +51,7 @@ public:
     bool updateFrame() override;
     bool displayOnff(int8_t on) override;
     bool invertDisplay(bool invert) override;
-    bool setRotation(uint8_t rotation) override { return true; }
+    bool setRotation(uint8_t rotation) override { return false; }
     
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override { return false; }
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override { return false; }


### PR DESCRIPTION
## Description:

Wrong logic persisted from the early stages of the huge refactoring.

We must return false from the panel to signal the calling display instance, that the Renderer is responsible for this job.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
