### PR TITLE
fix GDK101 init after powercycle

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_106_gdk101.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_106_gdk101.ino
@@ -273,6 +273,10 @@ bool Xsns106(uint32_t function) {
         break;
 #endif  // USE_WEBSERVER
     }
+  } else {
+    if (FUNC_EVERY_SECOND == function) {
+      Gdk101Detect();
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #24242

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
