### PR TITLE
Platform 2025.12.31

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.7
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.8
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ platform_packages           = ${core.platform_packages}
 framework                   = arduino
 board                       = esp8266_1M
 board_build.filesystem      = littlefs
+board_build.littlefs_version = 2.0
 board_build.variants_dir    = variants/tasmota
 custom_unpack_dir           = unpacked_littlefs
 build_unflags               = ${core.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,13 +138,10 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.10.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.12.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
-
-
-

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,7 +97,7 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.12.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.12.31/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- IDF 5.3.4.251223
- Tasmota Arduino core 3.1.8 (based on Arduino 3.3.5 from 251219)

- Platform refactor: removed mklittlefs binaries now a native LittleFS python module is used
- Platform new feature: LittleFS image download and unpack

- Fix esp32 BT crash

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
