### PR TITLE
[MI32 BLE] Move key status to value area

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -2387,7 +2387,7 @@ void MI32EverySecond(bool restart){
       MI32.secondsCounter = 0;
     }
   }
-  MI32.secondsCounter ++;
+  MI32.secondsCounter++;
 
   if (MI32.secondsCounter2 >= MI32.period){
     if (MI32.mqttCurrentSlot >= MIBLEsensors.size()){
@@ -2766,19 +2766,9 @@ const char HTTP_MISCALE_IMPEDANCE[] PROGMEM = "{s}%s Impedance{m}%u{e}";
 const char HTTP_MISCALE_IMPEDANCE_STABILIZED[] PROGMEM = "{s}%s Impedance stabilized{m}%s{e}";
 const char HTTP_SJWS01LM_FLOODING[] PROGMEM = "{s}%s Flooding{m}%u{e}";
 
-//const char HTTP_NEEDKEY[] PROGMEM = "{s}%s <a target=\"_blank\" href=\""
-//  "https://atc1441.github.io/TelinkFlasher.html?mac=%s&cb=http%%3A%%2F%%2F%s%%2Fmikey"
-//  "\">%s</a>{m}{e}";
+const char HTTP_NEEDKEY[] PROGMEM = "{s}%s Key{m}<a target='_blank' href='https://tasmota.github.io/ble_key_extractor?mac=%s&cb=http%%3A%%2F%%2F%s%%2Fmikey'>%s</a>{e}";
 
-//const char HTTP_NEEDKEY[] PROGMEM = "{s}%s <a target=\"_blank\" href=\""
-//  "http://127.0.0.1:8887/keys/TelinkFlasher.html?mac=%s&cb=http%%3A%%2F%%2F%s%%2Fmikey"
-//  "\">%s</a>{m}{e}";
-const char HTTP_NEEDKEY[] PROGMEM = "{s}%s <a target=\"_blank\" href=\""
-  "https://tasmota.github.io/ble_key_extractor?mac=%s&cb=http%%3A%%2F%%2F%s%%2Fmikey"
-  "\">%s</a>{m}{e}";
-
-
-const char HTTP_PAIRING[] PROGMEM = "{s}%s Pair Button Pressed{m} {e}";
+const char HTTP_PAIRING[] PROGMEM = "{s}%s Pair button pressed{m} {e}";
 
 const char HTTP_KEY_ERROR[] PROGMEM = "Key error %s";
 const char HTTP_MAC_ERROR[] PROGMEM = "MAC error %s";


### PR DESCRIPTION
## Description:
Move key status to value area.

Before PR:
<img width="435" height="87" alt="image" src="https://github.com/user-attachments/assets/af85ac28-17ff-4356-bd76-ce59637cbc6c" />

After PR:
<img width="435" height="86" alt="image" src="https://github.com/user-attachments/assets/84401071-97ab-4cba-8e59-003e5bee2b4e" />

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).