### PR TITLE
Berry animation remove unused solidification directives

### DIFF
--- a/lib/libesp32/berry_animation/src/animations/beacon.be
+++ b/lib/libesp32/berry_animation/src/animations/beacon.be
@@ -30,7 +30,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:beacon,weak
 class beacon : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
   

--- a/lib/libesp32/berry_animation/src/animations/breathe.be
+++ b/lib/libesp32/berry_animation/src/animations/breathe.be
@@ -10,7 +10,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:breathe,weak
 class breathe : animation.animation
   # Non-parameter instance variables only
   var breathe_provider # Internal breathe color provider

--- a/lib/libesp32/berry_animation/src/animations/comet.be
+++ b/lib/libesp32/berry_animation/src/animations/comet.be
@@ -8,7 +8,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:comet,weak
 class comet : animation.animation
   # Non-parameter instance variables only
   var head_position    # Current position of the comet head (in 1/256th pixels for smooth movement)

--- a/lib/libesp32/berry_animation/src/animations/crenel.be
+++ b/lib/libesp32/berry_animation/src/animations/crenel.be
@@ -20,7 +20,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:crenel,weak
 class crenel : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
   

--- a/lib/libesp32/berry_animation/src/animations/fire.be
+++ b/lib/libesp32/berry_animation/src/animations/fire.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:fire,weak
 class fire : animation.animation
   # Non-parameter instance variables only
   var heat_map         # bytes() buffer storing heat values for each pixel (0-255)

--- a/lib/libesp32/berry_animation/src/animations/gradient.be
+++ b/lib/libesp32/berry_animation/src/animations/gradient.be
@@ -15,7 +15,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:gradient,weak
 class gradient : animation.beacon
   # Parameter definitions - gradient-specific parameters
   static var PARAMS = animation.enc_params({

--- a/lib/libesp32/berry_animation/src/animations/palette_gradient.be
+++ b/lib/libesp32/berry_animation/src/animations/palette_gradient.be
@@ -6,7 +6,6 @@
 import "./core/param_encoder" as encode_constraints
 
 # Gradient pattern animation - creates shifting gradient patterns
-#@ solidify:palette_gradient
 class palette_gradient : animation.animation
   var value_buffer     # Buffer to store values for each pixel (bytes object)
   var _spatial_period  # Cached spatial_period for static pattern optimization

--- a/lib/libesp32/berry_animation/src/animations/palette_meter.be
+++ b/lib/libesp32/berry_animation/src/animations/palette_meter.be
@@ -12,7 +12,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:palette_meter,weak
 class palette_meter : animation.palette_gradient
   # Instance variables for peak tracking
   var peak_level        # Current peak level (0-255)

--- a/lib/libesp32/berry_animation/src/animations/palettes.be
+++ b/lib/libesp32/berry_animation/src/animations/palettes.be
@@ -2,8 +2,6 @@
 # This file contains predefined color palettes for use with animations
 # All palettes are in VRGB format: Value, Red, Green, Blue
 
-#@ solidify:animation_palettes,weak
-
 # Define common palette constants (in VRGB format: Value, Red, Green, Blue)
 # These palettes are compatible with the rich_palette_color
 

--- a/lib/libesp32/berry_animation/src/animations/rich_palette.be
+++ b/lib/libesp32/berry_animation/src/animations/rich_palette.be
@@ -9,7 +9,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:rich_palette,weak
 class rich_palette : animation.animation
   # Non-parameter instance variables only
   var color_provider   # Internal rich_palette_color instance

--- a/lib/libesp32/berry_animation/src/animations/twinkle.be
+++ b/lib/libesp32/berry_animation/src/animations/twinkle.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:twinkle,weak
 class twinkle : animation.animation
   # NO instance variables for parameters - they are handled by the virtual parameter system
   

--- a/lib/libesp32/berry_animation/src/animations/wave.be
+++ b/lib/libesp32/berry_animation/src/animations/wave.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:wave,weak
 class wave : animation.animation
   # Non-parameter instance variables only
   var current_colors     # Array of current colors for each pixel

--- a/lib/libesp32/berry_animation/src/animations_future/bounce.be
+++ b/lib/libesp32/berry_animation/src/animations_future/bounce.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:BounceAnimation,weak
 class BounceAnimation : animation.animation
   # Non-parameter instance variables only
   var current_position   # Current position in 1/256th pixels

--- a/lib/libesp32/berry_animation/src/animations_future/jitter.be
+++ b/lib/libesp32/berry_animation/src/animations_future/jitter.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:JitterAnimation,weak
 class JitterAnimation : animation.animation
   # Non-parameter instance variables only
   var random_seed        # Seed for random number generation

--- a/lib/libesp32/berry_animation/src/animations_future/plasma.be
+++ b/lib/libesp32/berry_animation/src/animations_future/plasma.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:PlasmaAnimation,weak
 class PlasmaAnimation : animation.animation
   # Non-parameter instance variables only
   var current_colors     # Array of current colors for each pixel

--- a/lib/libesp32/berry_animation/src/animations_future/scale.be
+++ b/lib/libesp32/berry_animation/src/animations_future/scale.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:ScaleAnimation,weak
 class ScaleAnimation : animation.animation
   # Non-parameter instance variables only
   var scale_phase        # Current phase for animated scaling

--- a/lib/libesp32/berry_animation/src/animations_future/shift.be
+++ b/lib/libesp32/berry_animation/src/animations_future/shift.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:ShiftAnimation,weak
 class ShiftAnimation : animation.animation
   # Non-parameter instance variables only
   var current_offset     # Current shift offset in 1/256th pixels

--- a/lib/libesp32/berry_animation/src/animations_future/sparkle.be
+++ b/lib/libesp32/berry_animation/src/animations_future/sparkle.be
@@ -5,7 +5,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:SparkleAnimation,weak
 class SparkleAnimation : animation.animation
   # Non-parameter instance variables only
   var current_colors     # Array of current colors for each pixel

--- a/lib/libesp32/berry_animation/src/core/event_handler.be
+++ b/lib/libesp32/berry_animation/src/core/event_handler.be
@@ -57,7 +57,6 @@ class EventHandler
   # end
 end
 
-#@ solidify:EventManager,weak
 class EventManager
   var handlers        # Map of event_name -> list of handlers
   var global_handlers # Handlers that respond to all events

--- a/lib/libesp32/berry_animation/src/core/math_functions.be
+++ b/lib/libesp32/berry_animation/src/core/math_functions.be
@@ -10,7 +10,6 @@ class AnimationMath
   #
   # @param *args: number - Values to compare
   # @return number - Minimum value
-  #@ solidify:min,weak
   static def min(*args)
     import math
     return call(math.min, args)
@@ -20,7 +19,6 @@ class AnimationMath
   #
   # @param *args: number - Values to compare
   # @return number - Maximum value
-  #@ solidify:max,weak
   static def max(*args)
     import math
     return call(math.max, args)
@@ -30,7 +28,6 @@ class AnimationMath
   #
   # @param x: number - Input value
   # @return number - Absolute value
-  #@ solidify:abs,weak
   static def abs(x)
     import math
     return math.abs(x)
@@ -40,7 +37,6 @@ class AnimationMath
   #
   # @param x: number - Input value
   # @return int - Rounded value
-  #@ solidify:round,weak
   static def round(x)
     import math
     return int(math.round(x))
@@ -51,7 +47,6 @@ class AnimationMath
   #
   # @param x: number - Input value
   # @return number - Square root
-  #@ solidify:sqrt,weak
   static def sqrt(x)
     import math
     # If x is an integer in 0-255 range, scale to 0-1 for sqrt, then back
@@ -71,7 +66,6 @@ class AnimationMath
   # @param to_min: number - Target range minimum
   # @param to_max: number - Target range maximum
   # @return int - Scaled value
-  #@ solidify:scale,weak
   static def scale(v, from_min, from_max, to_min, to_max)
     return tasmota.scale_int(v, from_min, from_max, to_min, to_max)
   end
@@ -82,7 +76,6 @@ class AnimationMath
   #
   # @param angle: number - Angle in 0-255 range (0-360 degrees)
   # @return int - Sine value in -255 to 255 range
-  #@ solidify:sin,weak
   static def sin(angle)
     # Map angle from 0-255 to 0-32767 (tasmota.sine_int input range)
     var tasmota_angle = tasmota.scale_int(angle, 0, 255, 0, 32767)
@@ -101,7 +94,6 @@ class AnimationMath
   #
   # @param angle: number - Angle in 0-255 range (0-360 degrees)
   # @return int - Cosine value in -255 to 255 range
-  #@ solidify:cos,weak
   static def cos(angle)
     # Map angle from 0-255 to 0-32767 (tasmota.sine_int input range)
     var tasmota_angle = tasmota.scale_int(angle, 0, 255, 0, 32767)

--- a/lib/libesp32/berry_animation/src/dsl/lexer.be
+++ b/lib/libesp32/berry_animation/src/dsl/lexer.be
@@ -6,7 +6,6 @@
 import "dsl/token.be" as token_module
 var Token = token_module["Token"]
 
-#@ solidify:Lexer,weak
 class Lexer
   var source          # String - DSL source code
   var position        # Integer - current character position

--- a/lib/libesp32/berry_animation/src/dsl/symbol_table.be
+++ b/lib/libesp32/berry_animation/src/dsl/symbol_table.be
@@ -2,7 +2,6 @@
 # Enhanced symbol caching and management for the Animation DSL
 
 # Symbol table entry class for enhanced symbol caching
-#@ solidify:SymbolEntry,weak
 class SymbolEntry
   # Type constants
   static var TYPE_PALETTE_CONSTANT = 1
@@ -318,7 +317,6 @@ class MockEngine
 end
 
 # Enhanced symbol table class for holistic symbol management and caching
-#@ solidify:SymbolTable,weak
 class SymbolTable
   var entries        # Map of name -> SymbolEntry
   var mock_engine    # MockEngine for validation

--- a/lib/libesp32/berry_animation/src/dsl/token.be
+++ b/lib/libesp32/berry_animation/src/dsl/token.be
@@ -1,7 +1,6 @@
 # Token Types and Token Class for Animation DSL
 # Defines all token types and the Token class with line/column tracking
 
-#@ solidify:Token,weak
 class Token
   # Basic token types
   # static var KEYWORD = 0        # strip, color, animation, sequence, etc.

--- a/lib/libesp32/berry_animation/src/dsl/transpiler.be
+++ b/lib/libesp32/berry_animation/src/dsl/transpiler.be
@@ -2,7 +2,6 @@
 # Single-pass transpiler with minimal complexity
 # Leverages Berry's runtime for symbol resolution
 
-#@ solidify:SimpleDSLTranspiler,weak
 class SimpleDSLTranspiler
   var pull_lexer      # Pull lexer instance
   var output          # Generated Berry code lines
@@ -28,7 +27,6 @@ class SimpleDSLTranspiler
   static var CONTEXT_COLOR_PROVIDER = 11
   
   # Helper class to track expression metadata for closure detection
-  #@ solidify:ExpressionResult,weak
   static class ExpressionResult
     var expr              # The expression string
     var has_dynamic       # Boolean: true if contains dynamic content that may change over time, hence needs to wrap into a closure

--- a/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
@@ -11,7 +11,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:breathe_color,weak
 class breathe_color : animation.oscillator_value
   # Additional parameter definitions for color-specific functionality
   # The oscillator parameters (min_value, max_value, duration, form, etc.) are inherited

--- a/lib/libesp32/berry_animation/src/providers/closure_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/closure_value_provider.be
@@ -17,7 +17,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:closure_value,weak
 class closure_value : animation.value_provider
   var _closure                # We keep the closure as instance variable for faster dereferencing, in addition to PARAMS
 

--- a/lib/libesp32/berry_animation/src/providers/color_cycle_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/color_cycle_color_provider.be
@@ -13,7 +13,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:color_cycle,weak
 class color_cycle : animation.color_provider
   # Non-parameter instance variables only
   var current_index   # Current color index for next functionality

--- a/lib/libesp32/berry_animation/src/providers/color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/color_provider.be
@@ -12,7 +12,6 @@
 # - Constructor takes only 'engine' parameter
 # - All other parameters set via virtual member assignment after creation
 
-#@ solidify:color_provider,weak
 class color_provider : animation.value_provider
   # LUT (Lookup Table) management for color providers
   # Subclasses can use this to cache pre-computed colors for performance

--- a/lib/libesp32/berry_animation/src/providers/iteration_number_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/iteration_number_provider.be
@@ -21,7 +21,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:iteration_number,weak
 class iteration_number : animation.value_provider
   # Produce the current iteration number from the animation engine
   #

--- a/lib/libesp32/berry_animation/src/providers/oscillator_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/oscillator_value_provider.be
@@ -23,7 +23,6 @@ var EASE_OUT = 7
 var ELASTIC = 8
 var BOUNCE = 9
 
-#@ solidify:oscillator_value,weak
 class oscillator_value : animation.value_provider
   # Non-parameter instance variables only
   var value             # current calculated value

--- a/lib/libesp32/berry_animation/src/providers/rich_palette_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/rich_palette_color_provider.be
@@ -30,7 +30,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:rich_palette_color,weak
 class rich_palette_color : animation.color_provider
   # Non-parameter instance variables only
   var _slots_arr        # Constructed array of timestamp slots, based on period

--- a/lib/libesp32/berry_animation/src/providers/static_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/static_color_provider.be
@@ -9,7 +9,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:static_color,weak
 class static_color : animation.color_provider
   # Parameter definitions
   static var PARAMS = animation.enc_params({

--- a/lib/libesp32/berry_animation/src/providers/static_value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/static_value_provider.be
@@ -13,7 +13,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:static_value,weak
 class static_value : animation.value_provider
   # Parameter definitions
   static var PARAMS = animation.enc_params({

--- a/lib/libesp32/berry_animation/src/providers/strip_length_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/strip_length_provider.be
@@ -11,7 +11,6 @@
 # - Constructor takes only 'engine' parameter
 # - No additional parameters needed since strip length is obtained from engine
 
-#@ solidify:strip_length,weak
 class strip_length : animation.value_provider
   # Produce the strip length value
   #

--- a/lib/libesp32/berry_animation/src/providers/value_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/value_provider.be
@@ -14,7 +14,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:value_provider,weak
 class value_provider : animation.parameterized_object
   
   # Produce a value for a specific parameter name and time

--- a/lib/libesp32/berry_animation/src/providers_future/composite_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers_future/composite_color_provider.be
@@ -9,7 +9,6 @@
 
 import "./core/param_encoder" as encode_constraints
 
-#@ solidify:CompositeColorProvider,weak
 class CompositeColorProvider : animation.color_provider
   # Non-parameter instance variables only
   var providers        # List of color providers


### PR DESCRIPTION
## Description:

Berry animation remove unused solidification directives

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
