### PR TITLE
Add functionality to handle new LoRaWAN nodes

### DIFF
--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -445,6 +445,11 @@ class webPageLoRaWAN : Driver
       tasmota.cmd(format('LoRaWanNode%i %s', inode, cmdArg), true)
     end
 
+    if webserver.has_arg('add')
+     inode = int(webserver.arg('node'))
+     tasmota.cmd(format('LoRaWanappkey%i', inode), true)
+    end 
+
     var appKey, decoder, name, enabled
     var hintAK = '32 character Application Key'
     var hintDecoder = 'Decoder file, ending in .be'
@@ -523,6 +528,16 @@ class webPageLoRaWAN : Driver
        "<input type='hidden' name='node' value='%i'>"
       "</form>"
       "</div>", node, enabled, hintAK, hintAK, appKey, hintAN, name, hintDecoder, hintDecoder, decoder, node))
+    end
+
+    if maxnode < 16  ### HARDCODED NUMBER. Don't like this. But not sure how to get max number of LoRaWAN nodes at run time in Berry
+     webserver.content_send(format(
+     "<div>"
+      "<form action='' method='post'>"
+       "<button name='add' class='button bgrn'>Add node</button>"
+       "<input type='hidden' name='node' value='%i'>"
+      "</form>"
+     "</div>", maxnode+1))
     end
 
     webserver.content_send("</fieldset>")


### PR DESCRIPTION
GUI support for adding new LoRaWAN node

## Description:
Prior to V15.2.0:
The `Configuration/LoRaWAN` page showed all 16 possible nodes for editing

Now: 
If no nodes have been created/defined, there is pretty much a blank `Configuration/LoRaWAN` page . 
If a user issues a CONSOLE command to create a node (e.g. LoRaWANAppKey1) then `Configuration/LoRaWAN` shows at least one node.

This proposal adds a new 'Add Node' button

BUT ... the number 16 is hard coded as the max number of LoRaWAN nodes. I don't like that - but unsure how to get the max mumber of allowed nodes at run time in berry???

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
