### PR TITLE
Fix condition check for FPort and Bytes size

### DIFF
--- a/tasmota/berry/lorawan/decoders/vendors/dragino/DDS75L.be
+++ b/tasmota/berry/lorawan/decoders/vendors/dragino/DDS75L.be
@@ -30,7 +30,7 @@ class LwDecoDDS75LB
     end
 
     ## SENSOR DATA ##
-    if 2 == FPort && 8 == Bytes.size() &&  0 == ( Bytes[0] & 0x10 )
+    if 2 == FPort && 8 == Bytes.size() 
       last_seen = tasmota.rtc('local')
 	  	  
 	  battery_last_seen = tasmota.rtc('local')


### PR DESCRIPTION
The LS (Solar) version can have BattV >=0x0010 0000 (4096) mV

So remove the check "&&  0 == ( Bytes[0] & 0x10 )"

## Description:
If BattV > 4095 mV, distance & battery voltage are not reported.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [ X Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
