### PR TITLE
Fix Zigbee compilation warning in Berry mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - GDK101 power on detection (#24242)
 - Udisplay backlight with SPI displays (#24277)
 - ESP8266 KNX unwanted reply (#24267)
+- Zigbee compilation warning in Berry mapping
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -361,7 +361,7 @@ extern "C" {
   void zfn_set_bytes(void* sbuf_ptr, const uint8_t* bytes, size_t len_bytes) {
     if (sbuf_ptr == NULL || bytes == NULL) { return; }
 
-    SBuffer &sbuf = (SBuffer&) sbuf_ptr;
+    SBuffer& sbuf = *reinterpret_cast<SBuffer*>(sbuf_ptr);  // Cast pointer first, then dereference
 
     sbuf.reserve(len_bytes);  // make sure it's large enough
     sbuf.setLen(0);           // clear content


### PR DESCRIPTION
## Description:

Fix Zigbee compilation warning in Berry mapping

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
