### PR TITLE
Zigbee support for `int24` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [15.2.0.2]
 ### Added
 - Support for Adafruit I2C QT Rotary Encoder (#24270)
+- Zigbee support for `int24` type
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -303,12 +303,12 @@ int32_t encodeSingleAttribute(SBuffer &buf, double val_d, const char *val_str, u
     case Zmap16:      // map16
       buf.add16(u32);
       break;
-    // unisgned 32
+    // unisgned 24
     case Zuint24:
       buf.add16(u32);
       buf.add8(u32 >> 16);
       break;
-    // unisgned 24
+    // unisgned 32
     case Zuint32:     // uint32
     case Zdata32:     // data32
     case Zmap32:      // map32
@@ -320,9 +320,16 @@ int32_t encodeSingleAttribute(SBuffer &buf, double val_d, const char *val_str, u
     case Zint8:      // int8
       buf.add8(nan ? 0x80 : i32);
       break;
+    // signed 16
     case Zint16:      // int16
       buf.add16(nan ? 0x8000 : i32);
       break;
+    // signed 24
+    case Zint24:
+      buf.add16(nan ? 0x0000 : i32);
+      buf.add8(nan ? 0x80 : i32 >> 16);
+      break;
+    // signed 32
     case Zint32:      // int32
       buf.add32(nan ? 0x80000000 : i32);
       break;
@@ -468,6 +475,16 @@ uint32_t parseSingleAttribute(Z_attribute & attr, const SBuffer &buf,
         // i += 2;
         if (0x8000 != int16_val) {
           attr.setInt(int16_val);
+        }
+      }
+      break;
+    case Zint24:
+      {
+        uint32_t uint24_val = buf.get16(i) + (buf.get8(i+2) >> 16);
+        int32_t int24_val = (int32_t)(uint24_val << 8) >> 8;    // extend sign
+        // i += 3;
+        if (0x800000 != int24_val) {
+          attr.setInt(int24_val);
         }
       }
       break;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #24288

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
