### PR TITLE
Save some ram in esp8266

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -268,7 +268,9 @@ struct TasmotaGlobal_t {
   uint32_t zc_code_offset;                  // Zero cross moment offset due to executing power code (microseconds)
   uint32_t zc_interval;                     // Zero cross interval around 8333 (60Hz) or 10000 (50Hz) (microseconds)
   GpioOptionABits gpio_optiona;             // GPIO Option_A flags
+#ifdef ESP32
   void *log_buffer_mutex;                   // Control access to log buffer
+#endif
 
   power_t power;                            // Current copy of Settings->power
   power_t power_latching;                   // Current state of single pin latching power

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -1096,7 +1096,6 @@ bool HasIP(void) {
  */
 void WifiCheckIp(void) {
   AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_WIFI D_CHECKING_CONNECTION));
-  Wifi.counter = WIFI_CHECK_SEC;
 
   if ((WL_CONNECTED == WiFi.status()) && WifiHasIP()) {
     WifiSetState(1);

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -1096,10 +1096,10 @@ bool HasIP(void) {
  */
 void WifiCheckIp(void) {
   AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_WIFI D_CHECKING_CONNECTION));
+  Wifi.counter = WIFI_CHECK_SEC;
 
   if ((WL_CONNECTED == WiFi.status()) && WifiHasIP()) {
     WifiSetState(1);
-    Wifi.counter = WIFI_CHECK_SEC;
     Wifi.retry = Wifi.retry_init;
     Wifi.max_retry = 0;
     if (Wifi.status != WL_CONNECTED) {


### PR DESCRIPTION
This will exclude the mutex variable not used by esp8266, this should save some ram bytes.

Also removed a double initialization. Variable is initialized at the beginning of the function but it's also reinitialized inside 'if' and 'else' branches (I double checked code but give a third check)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
