### PR TITLE
Platform 2026.01.30 Tasmota Arduino Core 3.1.9 based on IDF 5.3.4.20251226

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.8
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.9
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,7 +138,7 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2025.12.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2026.01.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,7 +97,7 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2025.12.31/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.01.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

Update Platforms for esp32 and esp8266:
- removed OS dependent filesystem App binaries, replaced with native python modules
- updated esptool v5.1.2
- updated Tasmota Arduino core 3.1.9 (based on espressif32 Arduino core 3.3.6-rc1)
- updated Tasmota IDF 5.3.4.20251226

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
