### PR TITLE
Fix Wireguard crash on RISC-V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - ESP8266 KNX unwanted reply (#24267)
 - Zigbee compilation warning in Berry mapping (#24333)
 - ScrubDNS() function (#23886)
+- Wireguard crash on RISC-V (esp32c3, esp32c6)
 
 ### Removed
 


### PR DESCRIPTION
## Description:

EC25519 multiplication needs often more stack size than available. The previous implementation used `esp_execute_shared_stack_function()` to temporarily increase the stack size, but this calls seems to be broken on ESP32C3/C6.

We now use a more generic implementation, launching an additional FreeRTOS task with appropriate stack size, and wait for it to complete via Semaphore.

**Related issue (if applicable):** fixes #23877

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
