### PR TITLE
Fix ESP32 reset during WiFi reconnect when mDNS is active

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -318,7 +318,7 @@ void WifiBegin(uint8_t flag, uint8_t channel) {
 #endif
 
 #ifdef USE_WIFI_RANGE_EXTENDER
-  }
+  if (WiFi.getMode() != WIFI_AP_STA || !RgxApUp()) {  // Preserve range extender connections (#17103)
 #endif  // USE_WIFI_RANGE_EXTENDER
 
 #if defined(ESP32) && defined(USE_DISCOVERY)

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -318,8 +318,12 @@ void WifiBegin(uint8_t flag, uint8_t channel) {
 #endif
 
 #ifdef USE_WIFI_RANGE_EXTENDER
-  if (WiFi.getMode() != WIFI_AP_STA || !RgxApUp()) {  // Preserve range extender connections (#17103)
+  }
 #endif  // USE_WIFI_RANGE_EXTENDER
+
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  MDNS.end();
+#endif
   WiFi.disconnect(true);  // Delete SDK wifi config
   delay(200);
   WifiSetMode(WIFI_STA);  // Disable AP mode


### PR DESCRIPTION
## Description:

Explicitly call MDNS.end() before WiFi.disconnect() in support_wifi.ino. This prevents a race condition or crash where the mDNS service attempts to query or use the network interface while it is being torn down.

**Related issue (if applicable): #24345
During investigation of that issue I had lots of reboots: 
I used to stop the wifi and started it again lots of times.
It looks like a race condition with my test and mdns: 
Calling MDNS.end() before calling WiFi.disconnect(true) was a simple solution and it seems to be a good place for me.

In the end, it is not required to fix my problem of the Issue: see the second PR for this.

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

