### PR TITLE
Dingtian: add inverted outputs and support shared PL/RCK pin

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1113,7 +1113,6 @@
 //  #define HX711_CAL_PRECISION     1              // When HX711 calibration is to course, raise this value
 
 //#define USE_DINGTIAN_RELAY                       // Add support for the Dingian board using 74'595 et 74'165 shift registers
-//  #define DINGTIAN_INPUTS_INVERTED               // Invert input states (Hi => OFF, Low => ON)
 //  #define DINGTIAN_USE_AS_BUTTON                 // Inputs as Tasmota's virtual Buttons
 //  #define DINGTIAN_USE_AS_SWITCH                 // Inputs as Tasmota's virtual Switches
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
@@ -16,6 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+// SetOption133: Inverts 74HC595 shift register outputs at runtime
+// SetOption81: Inverts 74HC165 shift register inputs at runtime
 
 #ifdef ESP32
 #ifdef USE_DINGTIAN_RELAY
@@ -55,9 +57,10 @@ struct DINGTIAN_DATA {
 
 uint32_t DingtianReadWrite(uint32_t outputs)
 {
-  #ifdef DINGTIAN_OUTPUTS_INVERTED
+  // SetOption133: invert outputs (74HC595)
+  if (Settings->flag5.shift595_invert_outputs) {
     outputs = ~outputs;
-  #endif
+  }
   
   uint32_t inputs = 0;
   uint32_t in_bit = 1;
@@ -86,11 +89,12 @@ uint32_t DingtianReadWrite(uint32_t outputs)
     Dingtian->outputs_initialized = true;
   }
 
-#ifdef DINGTIAN_INPUTS_INVERTED
-  return ~inputs;
-#else
-  return inputs;
-#endif
+  // SetOption81: invert inputs (74HC165)
+  if (Settings->flag3.pcf8574_ports_inverted) {
+    return ~inputs;
+  } else {
+    return inputs;
+  }
 }
 
 /********************************************************************************************************
@@ -117,6 +121,9 @@ void DingtianInit(void) {
 
       AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: clk:%d, sdi:%d, q7:%d, pl:%d, oe:%d, rck:%d, count:%d"),
         Dingtian->pin_clk, Dingtian->pin_sdi, Dingtian->pin_q7, Dingtian->pin_pl, Dingtian->pin_oe, Dingtian->pin_rck, Dingtian->count);
+      
+      AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: SetOption133 (Output invert): %d, SetOption81 (Input invert): %d"),
+        Settings->flag5.shift595_invert_outputs, Settings->flag3.pcf8574_ports_inverted);
 
       DINGTIAN_SET_OUTPUT(Dingtian->pin_clk, 0);
       DINGTIAN_SET_OUTPUT(Dingtian->pin_sdi, 0);

--- a/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
@@ -55,6 +55,10 @@ struct DINGTIAN_DATA {
 
 uint32_t DingtianReadWrite(uint32_t outputs)
 {
+  #ifdef DINGTIAN_OUTPUTS_INVERTED
+    outputs = ~outputs;
+  #endif
+  
   uint32_t inputs = 0;
   uint32_t in_bit = 1;
 
@@ -95,17 +99,19 @@ uint32_t DingtianReadWrite(uint32_t outputs)
 
 void DingtianInit(void) {
   if (PinUsed(GPIO_DINGTIAN_CLK, GPIO_ANY) && PinUsed(GPIO_DINGTIAN_SDI) && PinUsed(GPIO_DINGTIAN_Q7)
-   && (PinUsed(GPIO_DINGTIAN_PL) || PinUsed(GPIO_DINGTIAN_OE)) && PinUsed(GPIO_DINGTIAN_RCK)) {
+   && (PinUsed(GPIO_DINGTIAN_PL) || PinUsed(GPIO_DINGTIAN_OE))
+   && (PinUsed(GPIO_DINGTIAN_PL) || PinUsed(GPIO_DINGTIAN_RCK))) {
     // allocate Dingtian data structure
     Dingtian = (struct DINGTIAN_DATA*)calloc(1, sizeof(struct DINGTIAN_DATA));
     if (Dingtian) {
       // get pins
-      Dingtian->pin_clk = Pin(GPIO_DINGTIAN_CLK, GPIO_ANY);                     // shift clock   : 595's SCLK & 165's CLK
-      Dingtian->pin_sdi = Pin(GPIO_DINGTIAN_SDI);                               // Serial out    : 595's SER
-      Dingtian->pin_q7  = Pin(GPIO_DINGTIAN_Q7);                                // Serial in     : 165's Q7
-      if (PinUsed(GPIO_DINGTIAN_PL)) Dingtian->pin_pl  = Pin(GPIO_DINGTIAN_PL); // Input load    : 595's nOE  & 165's PL (or SH/LD on some datasheet)
-      if (PinUsed(GPIO_DINGTIAN_OE)) Dingtian->pin_oe  = Pin(GPIO_DINGTIAN_OE); // Output enable : 595's nOE (v3.6.10)
-      Dingtian->pin_rck = Pin(GPIO_DINGTIAN_RCK);                               // Output load   : 595's RCLK & 165's CLKINH
+      Dingtian->pin_clk = Pin(GPIO_DINGTIAN_CLK, GPIO_ANY);                       // shift clock   : 595's SCLK & 165's CLK
+      Dingtian->pin_sdi = Pin(GPIO_DINGTIAN_SDI);                                 // Serial out    : 595's SER
+      Dingtian->pin_q7  = Pin(GPIO_DINGTIAN_Q7);                                  // Serial in     : 165's Q7
+      if (PinUsed(GPIO_DINGTIAN_PL)) Dingtian->pin_pl  = Pin(GPIO_DINGTIAN_PL);   // Input load    : 595's nOE  & 165's PL (or SH/LD on some datasheet)
+      if (PinUsed(GPIO_DINGTIAN_OE)) Dingtian->pin_oe  = Pin(GPIO_DINGTIAN_OE);   // Output enable : 595's nOE & 165's nCE (v3.6.10)
+      if (PinUsed(GPIO_DINGTIAN_RCK)) Dingtian->pin_rck = Pin(GPIO_DINGTIAN_RCK); // Output load   : 595's RCLK & 165's CLKINH
+      else Dingtian->pin_rck = Dingtian->pin_pl;                                  // Use PL as RCK if not defined (shared pin boards)
       // number of shift registers is the CLK index
       Dingtian->count   = ((GetPin(Dingtian->pin_clk) - AGPIO(GPIO_DINGTIAN_CLK)) + 1) * 8;
 


### PR DESCRIPTION
## Description:

Add support for the **esp32_relay_x8_modbus** (303E32DC812) board by
allowing inverted relay outputs and shared PL/RCK control pins in the
ESP32 Dingtian driver.

#### GPIO Mapping

| GPIO | 74HC595        | 74HC165 |Tasmota |
|------|----------------|----------|----------|
| 33   | SIN       | –        |Dingtian SDI|
| 25   | RCK            | !PL      |Dingtian PL|
| 26   | SCK            | CP       |Dingtian CLK|
| 27   | –              | Q7       |Dingtian Q7|
| 13   | !OE            | !CE      |Dingtian OE|

This fixes incorrect relay behavior caused by the board-specific GPIO
mapping.

**Related issue (if applicable):** n/a

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
