### PR TITLE
Berry 'path.listdir(file.tapp#)' to list directory inside '.tapp' archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [15.2.0.3]
 ### Added
+- Berry `path.listdir("file.tapp#")` to list directory inside '.tapp' archives
 
 ### Breaking Changed
 

--- a/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.h
+++ b/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.h
@@ -13,6 +13,25 @@
 class ZipReadFSImpl;
 typedef std::shared_ptr<FSImpl> ZipReadFSImplPtr;
 
+/********************************************************************
+** Callback type for iterating over ZIP archive entries
+** Parameters:
+**   filename: the filename (after '#' separator processing)
+**   user_data: user-provided context pointer
+** Return: true to continue iteration, false to stop
+********************************************************************/
+typedef bool (*ZipIteratorCallback)(const char *filename, void *user_data);
+
+/********************************************************************
+** Iterate over all files in a ZIP archive
+** Parameters:
+**   zipfile: an open File object pointing to the ZIP archive
+**   callback: function to call for each file entry
+**   user_data: user-provided context pointer passed to callback
+** Returns: true if archive was parsed successfully
+********************************************************************/
+bool ZipArchiveIterator(File &zipfile, ZipIteratorCallback callback, void *user_data);
+
 
 class ZipReadFSImpl : public FSImpl {
 public:


### PR DESCRIPTION
## Description:

Berry, add ability to list the files in a ".tapp" archive with `path.listdir()`.

Example:
```berry
import path
var files = path.listdir("/.extensions/Leds_Panel.tapp#")
print(files)
# ['autoexec.be', 'leds_panel.be', 'manifest.json']
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
