### PR TITLE
some display fixes

### DIFF
--- a/lib/lib_deprecated/Xlatb_RA8876-gemu-1.0/RA8876.cpp
+++ b/lib/lib_deprecated/Xlatb_RA8876-gemu-1.0/RA8876.cpp
@@ -947,7 +947,7 @@ void RA8876::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
 }
 
 // pixel color is swapped in contrast to other controllers
-void RA8876::pushColors(uint16_t *data, uint16_t len, boolean not_swapped) {
+void RA8876::pushColors(uint16_t *data, uint32_t len, boolean not_swapped) {
 
   if (not_swapped == false) {
     // coming from LVGL

--- a/lib/lib_deprecated/Xlatb_RA8876-gemu-1.0/RA8876.h
+++ b/lib/lib_deprecated/Xlatb_RA8876-gemu-1.0/RA8876.h
@@ -482,7 +482,7 @@ class RA8876 : public Renderer {
   int getCursorY(void);
 
   void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
-  void pushColors(uint16_t *data, uint16_t len, boolean first);
+  void pushColors(uint16_t *data, uint32_t len, boolean first);
 
   // Text
   void selectInternalFont(enum FontSize size, enum FontEncoding enc = RA8876_FONT_ENCODING_8859_1);

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
@@ -66,7 +66,7 @@ void Renderer::dim10(uint8_t contrast, uint16_t contrast_gamma) {
 
 }
 
-void Renderer::pushColors(uint16_t *data, uint16_t len, boolean first) {
+void Renderer::pushColors(uint16_t *data, uint32_t len, boolean first) {
 
 }
 

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -73,7 +73,7 @@ public:
   virtual void Updateframe();
   virtual void dim(uint8_t contrast);   // input has range 0..15
   virtual void dim10(uint8_t contrast, uint16_t contrast_gamma);  // input has range 0..255, second arg has gamma correction for PWM with 10 bits resolution
-  virtual void pushColors(uint16_t *data, uint16_t len, boolean first);
+  virtual void pushColors(uint16_t *data, uint32_t len, boolean first);
   virtual void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
   virtual void invertDisplay(boolean i);
   virtual void reverseDisplay(boolean i);

--- a/lib/lib_display/UDisplay/include/uDisplay.h
+++ b/lib/lib_display/UDisplay/include/uDisplay.h
@@ -104,7 +104,7 @@ class uDisplay : public Renderer {
   void setRotation(uint8_t m);
   void fillScreen(uint16_t color);
   void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
-  void pushColors(uint16_t *data, uint16_t len, boolean first);
+  void pushColors(uint16_t *data, uint32_t len, boolean first);
   void TS_RotConvert(int16_t *x, int16_t *y);
   void invertDisplay(boolean i);
   void SetPwrCB(pwr_cb cb) { pwr_cbp = cb; };
@@ -234,7 +234,7 @@ private:
     int32_t next_val(char **sp);
     uint32_t next_hex(char **sp);
     void setAddrWindow_int(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-    void pushColorsMono(uint16_t *data, uint16_t len, bool rgb16_swap = false);
+    void pushColorsMono(uint16_t *data, uint32_t len, bool rgb16_swap = false);
     void delay_sync(int32_t time);
     void reset_pin(int32_t delayl, int32_t delayh);
     void delay_arg(uint32_t arg);

--- a/lib/lib_display/UDisplay/include/uDisplay.h
+++ b/lib/lib_display/UDisplay/include/uDisplay.h
@@ -84,6 +84,20 @@ enum {
 #define DISPLAY_INIT_PARTIAL 1
 #define DISPLAY_INIT_FULL 2
 
+typedef union {
+  uint8_t data;
+  struct {
+    uint8_t bp_invert : 1;
+    uint8_t bp_nopwm : 1;
+    uint8_t nutu3 : 1;
+    uint8_t nutu4 : 1;
+    uint8_t nutu5 : 1;
+    uint8_t nutu6 : 1;
+    uint8_t nutu7 : 1;
+    uint8_t nutu8 : 1;  
+  };
+} BP_MODE;
+
 
 class uDisplay : public Renderer {
  public:
@@ -93,6 +107,7 @@ class uDisplay : public Renderer {
   void DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font);
   void Updateframe();
   void DisplayOnff(int8_t on);
+  void HandeBP(int8_t on);
   void Splash(void);
   char *devname(void);
   uint16_t fgcol(void);
@@ -206,12 +221,12 @@ private:
     int8_t i2c_sda;
     int8_t reset;
     int8_t splash_font;
-    int8_t bpmode;
+    BP_MODE bp_mode;
     // int8_t spi_cs;
     // int8_t spi_clk;
     // int8_t spi_mosi;
     // int8_t spi_dc;
-    int8_t bpanel;
+    int8_t bpanel; // pin
     // int8_t spi_miso;
     // int8_t busy_pin;  // MOVED to EPDPanelConfig.busy_pin (EPD-only)
 
@@ -226,9 +241,9 @@ private:
     void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
     void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
     uint32_t str2c(char **sp, char *vp, uint32_t len);
+    void clearDisplay(void);
 
     void i2c_command(uint8_t val);
-
 
     uint8_t strlen_ln(char *str);
     int32_t next_val(char **sp);
@@ -255,7 +270,7 @@ private:
 
   uint8_t ut_array[16];
   uint8_t ut_i2caddr;
-  uint8_t ut_spi_cs = -1;
+  int8_t ut_spi_cs = -1;
   int8_t ut_reset = -1;
   int8_t ut_irq = -1;
   uint8_t ut_spi_nr;

--- a/lib/lib_display/UDisplay/include/uDisplay_DSI_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_DSI_panel.h
@@ -65,7 +65,7 @@ public:
     // Core graphics API (must return bool)
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override;
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
-    bool pushColors(uint16_t *data, uint16_t len, bool not_swapped) override;
+    bool pushColors(uint16_t *data, uint32_t len, bool not_swapped) override;
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override;
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override;

--- a/lib/lib_display/UDisplay/include/uDisplay_EPD_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_EPD_panel.h
@@ -80,7 +80,7 @@ public:
     // UniversalPanel interface
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override;
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
-    bool pushColors(uint16_t *data, uint16_t len, bool first = false) override;
+    bool pushColors(uint16_t *data, uint32_t len, bool first = false) override;
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override;
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override;

--- a/lib/lib_display/UDisplay/include/uDisplay_I2C_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_I2C_panel.h
@@ -55,7 +55,7 @@ public:
     
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override { return false; }
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override { return false; }
-    bool pushColors(uint16_t *data, uint16_t len, bool first = false) override { return false; }
+    bool pushColors(uint16_t *data, uint32_t len, bool first = false) override { return false; }
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override { return false; }
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override { return false; }
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override { return false; }

--- a/lib/lib_display/UDisplay/include/uDisplay_I80_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_I80_panel.h
@@ -81,7 +81,7 @@ public:
     // UniversalPanel interface
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override;
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
-    bool pushColors(uint16_t *data, uint16_t len, bool first = false) override;
+    bool pushColors(uint16_t *data, uint32_t len, bool first = false) override;
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override;
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override;

--- a/lib/lib_display/UDisplay/include/uDisplay_RGB_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_RGB_panel.h
@@ -27,7 +27,7 @@ public:
     
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override;
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
-    bool pushColors(uint16_t *data, uint16_t len, bool first = false) override;
+    bool pushColors(uint16_t *data, uint32_t len, bool first = false) override;
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override;
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override;

--- a/lib/lib_display/UDisplay/include/uDisplay_SPI_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_SPI_panel.h
@@ -78,7 +78,7 @@ public:
     // ===== UniversalPanel Interface =====
     bool drawPixel(int16_t x, int16_t y, uint16_t color) override;
     bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) override;
-    bool pushColors(uint16_t *data, uint16_t len, bool not_swapped = false) override;
+    bool pushColors(uint16_t *data, uint32_t len, bool not_swapped = false) override;
     bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) override;
     bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) override;
     bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) override;

--- a/lib/lib_display/UDisplay/include/uDisplay_panel.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_panel.h
@@ -20,7 +20,7 @@ public:
     // Core graphics API - return true if handled, false for uDisplay fallback
     virtual bool drawPixel(int16_t x, int16_t y, uint16_t color) = 0;
     virtual bool fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) = 0;
-    virtual bool pushColors(uint16_t *data, uint16_t len, bool first = false) = 0;
+    virtual bool pushColors(uint16_t *data, uint32_t len, bool first = false) = 0;
     virtual bool setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) = 0;
     virtual bool drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) = 0;
     virtual bool drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) = 0;

--- a/lib/lib_display/UDisplay/src/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay.cpp
@@ -24,7 +24,7 @@
 #include "tasmota_options.h"
 
 
-// #define UDSP_DEBUG
+//#define UDSP_DEBUG
 
 #ifndef UDSP_LBSIZE
 #define UDSP_LBSIZE 256
@@ -69,7 +69,7 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
   sa_mode = 16;
   saw_3 = 0xff;
   dim_op = 0xff;
-  bpmode = 0;
+  bp_mode.data = 0;
   dsp_off = 0xff;
   dsp_on = 0xff;
   // busy_pin = -1;  // MOVED to EPDPanelConfig.busy_pin
@@ -757,7 +757,7 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
             rotmap_ymax = next_val(&lp1);
             break;
           case 'b':
-            bpmode = next_val(&lp1);
+            bp_mode.data = next_hex(&lp1);
             break;
 #ifdef USE_UNIVERSAL_TOUCH
           case 'U':
@@ -1005,7 +1005,7 @@ uint16_t index = 0;
       
       uint8_t args = dsp_cmds[cmd_offset++];
       index++;
-#ifdef UDSP_DEBUG
+#ifdef xUDSP_DEBUG
       AddLog(LOG_LEVEL_DEBUG, "UDisplay: cmd, args %02x, %d", iob, args & 0x1f);
 #endif
       switch (iob) {
@@ -1067,7 +1067,7 @@ uint16_t index = 0;
           }
           break;
       }
-#ifdef UDSP_DEBUG
+#ifdef xUDSP_DEBUG
       if (args & 1) {
         AddLog(LOG_LEVEL_DEBUG, "UDisplay: %02x", iob);
       }
@@ -1090,13 +1090,13 @@ uint16_t index = 0;
       spiController->writeCommand(iob);
       uint8_t args = dsp_cmds[cmd_offset++];
       index++;
-#ifdef UDSP_DEBUG
+#ifdef xUDSP_DEBUG
       AddLog(LOG_LEVEL_DEBUG, "UDisplay: cmd, args %02x, %d", iob, args & 0x1f);
 #endif
       for (uint32_t cnt = 0; cnt < (args & 0x1f); cnt++) {
         iob = dsp_cmds[cmd_offset++];
         index++;
-#ifdef UDSP_DEBUG
+#ifdef xUDSP_DEBUG
         AddLog(LOG_LEVEL_DEBUG, "%02x ", iob );
 #endif
         if (!allcmd_mode) {
@@ -1175,21 +1175,18 @@ Renderer *uDisplay::Init(void) {
 
 if (interface == _UDSP_SPI) {
 
-    if (bpanel >= 0) {
-#ifdef ESP32
-        analogWrite(bpanel, 32);
-#else
-        pinMode(bpanel, OUTPUT);
-        digitalWrite(bpanel, HIGH);
-#endif // ESP32
-    }
-    // spiController->beginTransaction();
+    HandeBP(-1);
 
+    spiController->beginTransaction();
+ 
     if (reset >= 0) {
       pinMode(reset, OUTPUT);
       digitalWrite(reset, HIGH);
       delay(50);
       reset_pin(50, 200);
+#ifdef UDSP_DEBUG
+      AddLog(LOG_LEVEL_DEBUG, "UDisplay: resetting device");
+#endif
     }
     
     if (ep_mode) {
@@ -1243,14 +1240,15 @@ if (interface == _UDSP_SPI) {
         panel_config->spi.all_commands_mode = allcmd_mode;
         
         send_spi_cmds(0, dsp_ncmds);  // Send init commands for regular SPI
+      
         universal_panel = new SPIPanel(panel_config->spi, spiController, frame_buffer);
 #ifdef ESP32
         spiController->initDMA(panel_config->spi.width, lvgl_param.flushlines, lvgl_param.data);
 #endif
     }
 
-    // spiController->endTransaction();
-
+    spiController->endTransaction();
+    
     // EPD LUT initialization is now handled inside EPDPanel constructor
     // so we don't need to call Init_EPD here anymore
 }
@@ -1264,9 +1262,7 @@ if (interface == _UDSP_SPI) {
       return NULL;
     }
 
-    if (bpanel >= 0) {
-      analogWrite(bpanel, 32);
-    }
+    HandeBP(-1);
 
     panel_config->rgb.clk_src = LCD_CLK_SRC_PLL160M;
     panel_config->rgb.timings.pclk_hz = spi_speed*1000000;
@@ -1311,9 +1307,7 @@ if (interface == _UDSP_SPI) {
         universal_panel = new DSIPanel(panel_config->dsi);
         rgb_fb = universal_panel->framebuffer;
                 
-        if (bpanel >= 0) {
-          analogWrite(bpanel, 32);
-        }
+        HandeBP(-1);
      }
 #endif
 
@@ -1345,9 +1339,8 @@ if (interface == _UDSP_SPI) {
       
       universal_panel = new I80Panel(panel_config->i80);
 
-      if (bpanel >= 0) {
-          analogWrite(bpanel, 32);
-      }
+      HandeBP(-1);
+
   #endif
   }
   

--- a/lib/lib_display/UDisplay/src/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay.cpp
@@ -1005,7 +1005,7 @@ uint16_t index = 0;
       
       uint8_t args = dsp_cmds[cmd_offset++];
       index++;
-#ifdef xUDSP_DEBUG
+#ifdef UDSP_DEBUG
       AddLog(LOG_LEVEL_DEBUG, "UDisplay: cmd, args %02x, %d", iob, args & 0x1f);
 #endif
       switch (iob) {
@@ -1067,7 +1067,7 @@ uint16_t index = 0;
           }
           break;
       }
-#ifdef xUDSP_DEBUG
+#ifdef UDSP_DEBUG
       if (args & 1) {
         AddLog(LOG_LEVEL_DEBUG, "UDisplay: %02x", iob);
       }
@@ -1090,13 +1090,13 @@ uint16_t index = 0;
       spiController->writeCommand(iob);
       uint8_t args = dsp_cmds[cmd_offset++];
       index++;
-#ifdef xUDSP_DEBUG
+#ifdef UDSP_DEBUG
       AddLog(LOG_LEVEL_DEBUG, "UDisplay: cmd, args %02x, %d", iob, args & 0x1f);
 #endif
       for (uint32_t cnt = 0; cnt < (args & 0x1f); cnt++) {
         iob = dsp_cmds[cmd_offset++];
         index++;
-#ifdef xUDSP_DEBUG
+#ifdef UDSP_DEBUG
         AddLog(LOG_LEVEL_DEBUG, "%02x ", iob );
 #endif
         if (!allcmd_mode) {

--- a/lib/lib_display/UDisplay/src/uDisplay_DSI_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_DSI_panel.cpp
@@ -214,7 +214,7 @@ bool DSIPanel::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
     return fillRect(x, y, 1, h, color);
 }
 
-bool DSIPanel::pushColors(uint16_t *data, uint16_t len, bool not_swapped) {
+bool DSIPanel::pushColors(uint16_t *data, uint32_t len, bool not_swapped) {
     esp_err_t ret = esp_lcd_panel_draw_bitmap(panel_handle, window_x0, window_y0, window_x1, window_y1, data);
     return (ret == ESP_OK);
 }

--- a/lib/lib_display/UDisplay/src/uDisplay_EPD_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_EPD_panel.cpp
@@ -260,7 +260,7 @@ bool EPDPanel::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t col
     return true;
 }
 
-bool EPDPanel::pushColors(uint16_t *data, uint16_t len, bool first) {
+bool EPDPanel::pushColors(uint16_t *data, uint32_t len, bool first) {
     // Convert RGB565 to monochrome and write to framebuffer
     // Pixel is white if at least one of the 3 RGB components is above 50%
     static constexpr uint16_t RGB16_TO_MONO = 0x8410;

--- a/lib/lib_display/UDisplay/src/uDisplay_I80_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_I80_panel.cpp
@@ -258,10 +258,10 @@ bool I80Panel::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
     return true;
 }
 
-bool I80Panel::pushColors(uint16_t *data, uint16_t len, bool first) {
+bool I80Panel::pushColors(uint16_t *data, uint32_t len, bool swapped) {
     // Match old code: just push pixels, no transaction management
     // Transaction is managed by setAddrWindow()
-    pb_pushPixels(data, len, true, false);  // swap_bytes=true to match old driver
+    pb_pushPixels(data, len, !swapped, false);  // swap_bytes=true to match old driver
     return true;
 }
 

--- a/lib/lib_display/UDisplay/src/uDisplay_RGB_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_RGB_panel.cpp
@@ -63,7 +63,7 @@ bool RGBPanel::setAddrWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
     return true; // Handled by RGB panel
 }
 
-bool RGBPanel::pushColors(uint16_t *data, uint16_t len, bool first) {
+bool RGBPanel::pushColors(uint16_t *data, uint32_t len, bool first) {
     esp_lcd_panel_draw_bitmap(panel_handle, window_x1, window_y1, window_x2, window_y2, data);
     return true; // Handled by RGB panel
 }

--- a/lib/lib_display/UDisplay/src/uDisplay_SPI_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_SPI_panel.cpp
@@ -105,7 +105,7 @@ bool SPIPanel::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t col
     return false; // Let uDisplay handle framebuffer cases (monochrome OLEDs)
 }
 
-bool SPIPanel::pushColors(uint16_t *data, uint16_t len, bool not_swapped) {
+bool SPIPanel::pushColors(uint16_t *data, uint32_t len, bool not_swapped) {
     // Only handle direct rendering for color displays
     if (cfg.bpp < 16) {
         return false;

--- a/lib/lib_display/UDisplay/src/uDisplay_graphics.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_graphics.cpp
@@ -67,7 +67,7 @@ void uDisplay::fillScreen(uint16_t color) {
 
 static inline void lvgl_color_swap(uint16_t *data, uint16_t len) { for (uint32_t i = 0; i < len; i++) (data[i] = data[i] << 8 | data[i] >> 8); }
 
-void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean not_swapped) {  //not_swapped is always true in call form LVGL driver!!!!
+void uDisplay::pushColors(uint16_t *data, uint32_t len, boolean not_swapped) {  //not_swapped is always true in call form LVGL driver!!!!
 
     if (lvgl_param.swap_color) {
         not_swapped = !not_swapped;
@@ -76,7 +76,7 @@ void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean not_swapped) {  
 }
 
 // convert to mono, these are framebuffer based
-void uDisplay::pushColorsMono(uint16_t *data, uint16_t len, bool rgb16_swap) {
+void uDisplay::pushColorsMono(uint16_t *data, uint32_t len, bool rgb16_swap) {
   // pixel is white if at least one of the 3 components is above 50%
   // this is tested with a simple mask, swapped if needed
   uint16_t rgb16_to_mono_mask = rgb16_swap ? RGB16_SWAP_TO_MONO : RGB16_TO_MONO;

--- a/lib/libesp32_eink/epdiy/src/epd4in7.cpp
+++ b/lib/libesp32_eink/epdiy/src/epd4in7.cpp
@@ -174,7 +174,7 @@ void Epd47::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
 
 static inline void lvgl_color_swap2(uint16_t *data, uint16_t len) { for (uint32_t i = 0; i < len; i++) (data[i] = data[i] << 8 | data[i] >> 8); }
 
-void Epd47::pushColors(uint16_t *data, uint16_t len, boolean not_swapped) {
+void Epd47::pushColors(uint16_t *data, uint32_t len, boolean not_swapped) {
 
   if (not_swapped == false) {
     lvgl_color_swap2(data, len);

--- a/lib/libesp32_eink/epdiy/src/epd4in7.h
+++ b/lib/libesp32_eink/epdiy/src/epd4in7.h
@@ -50,7 +50,7 @@ public:
     void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
     void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
     void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
-    void pushColors(uint16_t *data, uint16_t len, boolean first);
+    void pushColors(uint16_t *data, uint32_t len, boolean first);
     uint16_t GetColorFromIndex(uint8_t index);
 private:
   uint16_t width;

--- a/tasmota/tasmota_support/support_jpeg.ino
+++ b/tasmota/tasmota_support/support_jpeg.ino
@@ -24,6 +24,10 @@
 #include "img_converters.h"
 #include "jpeg_decoder.h"
 
+#define USE_NEW_JPG
+
+
+#ifndef USE_NEW_JPG
 void rgb888_to_565(uint8_t *in, uint16_t *out, uint32_t len) {
 uint8_t red, grn, blu;
 uint16_t b , g, r;
@@ -137,6 +141,8 @@ bool jpg2rgb888(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t s
     }
     return true;
 }
+#endif //USE_NEW_JPG
+
 
 // https://web.archive.org/web/20131016210645/http://www.64lines.com/jpeg-width-height
 //Gets the JPEG size from the array of data passed to the function, file reference: http://www.obrador.com/essentialjpeg/headerinfo.htm

--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -2412,10 +2412,14 @@ char ppath[16];
 #define USE_NEW_JPG
 #include "img_converters.h"
 #include "jpeg_decoder.h"
-#include "esp_jpg_decode.h"
 
+#ifndef USE_NEW_JPG
+#include "esp_jpg_decode.h"
 bool jpg2rgb888(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
 bool jpg2rgb565(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
+#endif
+
+
 char get_jpeg_size(unsigned char* data, unsigned int data_size, unsigned short *width, unsigned short *height);
 #endif // JPEG_PICTS
 #endif // ESP32

--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -553,11 +553,17 @@ void DisplayText(void)
             break;
           case 'i':
             // init display with partial update
-            DisplayInit(DISPLAY_INIT_PARTIAL);
+            //DisplayInit(DISPLAY_INIT_PARTIAL);
+            if (renderer) {
+              renderer->DisplayInit(DISPLAY_INIT_PARTIAL, Settings->display_size, Settings->display_rotate, Settings->display_font);
+            }
             break;
           case 'I':
             // init display with full refresh
-            DisplayInit(DISPLAY_INIT_FULL);
+            //DisplayInit(DISPLAY_INIT_FULL);
+            if (renderer) {
+              renderer->DisplayInit(DISPLAY_INIT_FULL, Settings->display_size, Settings->display_rotate, Settings->display_font);
+            }
             break;
           case 'o':
             DisplayOnOff(0);
@@ -2402,8 +2408,12 @@ char ppath[16];
 
 #ifdef ESP32
 #ifdef JPEG_PICTS
+
+#define USE_NEW_JPG
 #include "img_converters.h"
 #include "jpeg_decoder.h"
+#include "esp_jpg_decode.h"
+
 bool jpg2rgb888(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
 bool jpg2rgb565(const uint8_t *src, size_t src_len, uint8_t * out, jpg_scale_t scale);
 char get_jpeg_size(unsigned char* data, unsigned int data_size, unsigned short *width, unsigned short *height);
@@ -2511,12 +2521,33 @@ void Draw_RGB_Bitmap(char *file, uint16_t xp, uint16_t yp, uint8_t scale, bool i
           }
           //Serial.printf(" x,y,fs %d - %d - %d\n",xsize, ysize, size );
           if (xsize && ysize) {
+#ifdef USE_NEW_JPG
+            uint16_t *out_buf = (uint16_t *)special_malloc((xsize * ysize * 2) + 4);
+            if (out_buf) {
+              uint32_t outsize = xsize * ysize * 2;
+              esp_jpeg_image_cfg_t jpeg_cfg = {
+                .indata = (uint8_t *)mem,
+                .indata_size = size,
+                .outbuf = (uint8_t*)out_buf,
+                .outbuf_size = outsize,
+                .out_format = JPEG_IMAGE_FORMAT_RGB565,
+                .out_scale = JPEG_IMAGE_SCALE_0,
+                .flags = {  .swap_color_bytes = inverted,}
+              };
+              esp_jpeg_image_output_t outimg;
+              esp_jpeg_decode(&jpeg_cfg, &outimg);
+              renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
+              renderer->pushColors(out_buf, outsize / 2, true);
+              renderer->setAddrWindow(0, 0, 0, 0);
+              free(out_buf);
+            }
+#else
             uint8_t *out_buf = (uint8_t *)special_malloc((xsize * ysize * 3) + 4);
             if (out_buf) {
               uint16_t *pixb = (uint16_t *)special_malloc((xsize * 2) + 4);
               if (pixb) {
                 uint8_t *ob = out_buf;
-                if (jpg2rgb888(mem, size, out_buf, (jpg_scale_t)JPG_SCALE_NONE)) {
+                if (jpg2rgb888(mem, size, out_buf, (jpg_scale_t)JPG_SCALE_NONE)) {                  
                   //renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
                   for (int32_t j = 0; j < ysize; j++) {
                     if (inverted == false) {
@@ -2537,6 +2568,7 @@ void Draw_RGB_Bitmap(char *file, uint16_t xp, uint16_t yp, uint8_t scale, bool i
                 free(out_buf);
               }
             }
+#endif
           }
         }
         free(mem);
@@ -2564,14 +2596,40 @@ void Draw_jpeg(uint8_t *mem, uint16_t jpgsize, uint16_t xp, uint16_t yp, uint8_t
     uint8_t fac = 1 << scale;
     xsize /= fac;
     ysize /= fac;
-    renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
-    uint8_t *rgbmem = (uint8_t *)special_malloc(xsize * ysize * 2);
+
+#ifdef USE_NEW_JPG
+    uint32_t osize = xsize * ysize * 2;
+    uint16_t *rgbmem = (uint16_t *)special_malloc(osize);
     if (rgbmem) {
-      //jpg2rgb565(mem, jpgsize, rgbmem, JPG_SCALE_NONE);
-      jpg2rgb565(mem, jpgsize, rgbmem, (jpg_scale_t)scale);
-      renderer->pushColors((uint16_t*)rgbmem, xsize * ysize, true);
+      esp_jpeg_image_cfg_t jpeg_cfg = {
+                .indata = (uint8_t *)mem,
+                .indata_size = jpgsize,
+                .outbuf = (uint8_t*)rgbmem,
+                .outbuf_size = osize,
+                .out_format = JPEG_IMAGE_FORMAT_RGB565,
+                .out_scale = (esp_jpeg_image_scale_t)scale,
+                .flags = {  .swap_color_bytes = 0,}
+              };
+      esp_jpeg_image_output_t outimg;
+      esp_jpeg_decode(&jpeg_cfg, &outimg);
+      renderer->setAddrWindow(xp, yp, xp + xsize, yp + ysize);
+      renderer->pushColors(rgbmem, osize / 2, true);
       free(rgbmem);
     }
+#else
+    
+    uint8_t *rgbmem = (uint8_t *)special_malloc(xsize * ysize * 2);
+    if (rgbmem) {     
+      jpg2rgb565(mem, jpgsize, rgbmem, (jpg_scale_t)scale);
+      uint16_t *ob = (uint16_t*)rgbmem;
+      for (int32_t j = 0; j < ysize; j++) {
+        renderer->setAddrWindow(xp, yp + j, xp + xsize, yp + j + 1);
+        renderer->pushColors((uint16_t*)ob, xsize, true);
+        ob += xsize;
+      }
+      free(rgbmem);
+    }
+#endif
     renderer->setAddrWindow(0, 0, 0, 0);
   }
 }


### PR DESCRIPTION
## Description:

1. st77xx controllers now work
2. parallel displays push colors now work with right colors with display text
3. use latest jpeg decoder, old version still in source because one user gets strange missing pictures which do not occur with previous implementation 
4. now push pixels number of pixels changed to 32 bit to be able to push complete display
5. fix e-display full and partial update (also with old driver)

none of my waveshare e-papers works with the new driver
there were heavy changes in this section. i could not fix this in the short run and temporarily use the old driver version for these displays.

a user reports OLED color displays also no longer working

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
