### PR TITLE
Remove movmem_P

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -176,7 +176,6 @@ typedef int SerConfu8;
 
 // memmove ...
 #define memcpy_P memcpy
-#define memmove_P memmove
 #define strncpy_P strncpy
 #define strcmp_P strcmp
 #define memccpy_P memccpy

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -670,10 +670,10 @@ bool SettingsUpdateText(uint32_t index, const char* replace_me) {
 
     if (diff != 0) {
       // Shift Settings->text up or down
-      memmove_P(Settings->text_pool + start_pos + replace_len, Settings->text_pool + end_pos, char_len - end_pos);
+      memmove(Settings->text_pool + start_pos + replace_len, Settings->text_pool + end_pos, char_len - end_pos);
     }
     // Replace text
-    memmove_P(Settings->text_pool + start_pos, replace, replace_len);
+    memmove(Settings->text_pool + start_pos, replace, replace_len);
     // Fill for future use
     memset(Settings->text_pool + char_len + diff, 0x00, settings_text_size - char_len - diff);
 
@@ -1696,8 +1696,8 @@ void SettingsDelta(void) {
     if (Settings->version < 0x09050002) {
       if (Settings->cfg_size != sizeof(TSettings)) {
         // Fix onetime Settings layout due to changed ESP32-C3 myio and mytmplt types sizes
-        memmove_P((uint8_t*)&Settings->user_template, (uint8_t*)&Settings->free_esp32c3_3D8, sizeof(TSettings) - 0x3FC);
-        memmove_P((uint8_t*)&Settings->eth_type, (uint8_t*)&Settings->free_esp32c3_42A, sizeof(TSettings) - 0x446);
+        memmove((uint8_t*)&Settings->user_template, (uint8_t*)&Settings->free_esp32c3_3D8, sizeof(TSettings) - 0x3FC);
+        memmove((uint8_t*)&Settings->eth_type, (uint8_t*)&Settings->free_esp32c3_42A, sizeof(TSettings) - 0x446);
         // Reset for future use
         memset(&Settings->free_esp32c3_3D8, 0x00, sizeof(Settings->free_esp32c3_3D8));
         memset(&Settings->free_esp32c3_42A, 0x00, sizeof(Settings->free_esp32c3_42A));
@@ -1876,18 +1876,18 @@ void SettingsDelta(void) {
     }
     if (Settings->version < 0x0E030007) {  // 14.3.0.7
       // move up uint8_t knx_CB_registered from 4A8 to 533
-      memmove_P((uint8_t*)&Settings->knx_CB_registered, (uint8_t*)&Settings->switchmode, 1);
+      memmove((uint8_t*)&Settings->knx_CB_registered, (uint8_t*)&Settings->switchmode, 1);
       // move up uint8_t global_sensor_index[3] from 4C5 to 53C
-      memmove_P((uint8_t*)&Settings->global_sensor_index, (uint8_t*)&Settings->switchmode +29, 3);
+      memmove((uint8_t*)&Settings->global_sensor_index, (uint8_t*)&Settings->switchmode +29, 3);
       // move dn uint8_t switchmode[MAX_SWITCHES_SET] from 4A9 to 4A8
-      memmove_P((uint8_t*)&Settings->switchmode, (uint8_t*)&Settings->switchmode +1, 28);
+      memmove((uint8_t*)&Settings->switchmode, (uint8_t*)&Settings->switchmode +1, 28);
       for (uint32_t i = 28; i < MAX_SWITCHES_SET; i++) {
         Settings->switchmode[i] = SWITCH_MODE;
       }
       // move up int8_t shutter_tilt_pos[MAX_SHUTTERS], uint16_t influxdb_period and uint16_t rf_duplicate_timefrom 51C to 534
-      memmove_P((uint8_t*)&Settings->shutter_tilt_pos, (uint8_t*)&Settings->shutter_tilt_config +12, 8);
+      memmove((uint8_t*)&Settings->shutter_tilt_pos, (uint8_t*)&Settings->shutter_tilt_config +12, 8);
       // move up int8_t shutter_tilt_config[5][MAX_SHUTTERS] from 508 to 510
-      memmove_P((uint8_t*)&Settings->shutter_tilt_config, (uint8_t*)&Settings->shutter_tilt_config -8, 20);
+      memmove((uint8_t*)&Settings->shutter_tilt_config, (uint8_t*)&Settings->shutter_tilt_config -8, 20);
       for (uint32_t i = 14; i < MAX_INTERLOCKS_SET; i++) {
         Settings->interlock[i] = 0;
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -696,7 +696,7 @@ void RulesVarReplace(String &commands, const String &sfind, const String &replac
   char *found_at;
   while ((found_at = strstr(read_from, find)) != nullptr) {
     write_to += (found_at - read_from);
-    memmove_P(write_to, find, flen);                      // Make variable Uppercase
+    memmove(write_to, find, flen);                        // Make variable Uppercase
     write_to += flen;
     read_from = found_at + flen;
   }


### PR DESCRIPTION
## Description:

If I didn't have an oversight all memory in these calls is from ram to ram so no need to use _P version. This should also speed up code and maybe reduce footprint if function is not linked

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
