### PR TITLE
Update Shift595.be to avoid failing init

### DIFF
--- a/tasmota/berry/drivers/Shift595.be
+++ b/tasmota/berry/drivers/Shift595.be
@@ -76,4 +76,4 @@ class Shift595
 
 end
 
-return Shift595() # allow using 'import' instead of 'load()'
+return Shift595 # allow using 'import' instead of 'load()'


### PR DESCRIPTION
PR https://github.com/arendst/Tasmota/pull/15468 to "simplify drivers" caused a breaking change to this specific one, as it will instantiate the class without arguments. This fails https://github.com/arendst/Tasmota/discussions/24380

Removing the empty argument list allows `import Shift595` (suggested in the code block) to work, and do the class instantiation there. Ok with this minimal fix, @s-hadinger or should more refactoring be done?

## Description:

**Related issue (if applicable):** fixes #24380

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
