### PR TITLE
Move custom envs on top

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,11 +19,11 @@ src_dir                     = tasmota
 lib_dir                     = lib/default
 boards_dir                  = boards
 build_cache_dir             = .cache
-extra_configs               = platformio_tasmota32.ini
+extra_configs               = platformio_tasmota_cenv.ini
+                              platformio_tasmota32.ini
                               platformio_tasmota_env.ini
                               platformio_tasmota_env32.ini
                               platformio_override.ini
-                              platformio_tasmota_cenv.ini
 
 [common]
 platform                    = ${core.platform}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -101,5 +101,3 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-
-


### PR DESCRIPTION
## Description:

Move custom envs on top. There is an high probability that if someone add them he will often choose them, so putting in top of list helps.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
