### PR TITLE
USE_EXPRESSION and SUPPORT_IF_STATEMENT in all builds with USE_RULES

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -33,8 +33,8 @@ Note: the `minimal` variant is not listed as it shouldn't be used outside of the
 | USE_SUNRISE               | x     | x / x | x     | x     | x     | x     |
 | USE_RULES                 | x     | x / x | x     | x     | x     | x     |
 | USE_SCRIPT                | -     | - / - | -     | -     | -     | -     |
-| USE_EXPRESSION            | -     | x / x | -     | -     | -     | -     |
-| SUPPORT_IF_STATEMENT      | -     | x / x | -     | -     | -     | -     |
+| USE_EXPRESSION            | x     | x / x | x     | x     | x     | x     |
+| SUPPORT_IF_STATEMENT      | x     | x / x | x     | x     | x     | x     |
 | USE_HOTPLUG               | -     | - / - | -     | -     | -     | -     |
 | USE_INFLUXDB              | -     | - / x | -     | -     | -     | -     |
 | USE_PROMETHEUS            | -     | - / - | -     | -     | -     | -     |


### PR DESCRIPTION
Should the lines just be deleted instead? Its a long time since they were actually opt-in features. Verified that the features are available with a current lite build.

The code still has `#ifdef` and I suppose that a custom build could disable them, to eek out a bit of space for other features.

Not tested as there is no code change.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
