### PR TITLE
BearSSL: Fix SHA1 mode setting for ESP32P4 on IDF 5.5+

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
@@ -69,6 +69,9 @@ sha_hal_process_block(void *state_buf, const void *blk,
                       size_t block_words, bool first)
 {
     SHA_ENTER();
+#if defined(CONFIG_IDF_TARGET_ESP32P4) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    sha_ll_set_mode(type); // required on P4 in IDF 5.5+
+#endif 
     if (!first) {
         sha_ll_write_digest(type, state_buf, digest_words);
     }


### PR DESCRIPTION
Add conditional compilation for ESP32P4 in IDF 5.5

## Description:

Breaking change in IDF 5.5: https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/migration-guides/release-5.x/5.5/security.html

We have to apply the same mechanism for our BearSSL implementation.
Tested on P4 with web socket handshake, which was broken with IDF 5.5 based framework.

Very likely all other SHA functions will need a similar treatment and do currently not work hardware accelerated with the very latest frameworks.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.9
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
