### PR TITLE
Minor Berry Animation bug fixes and cleanup

### DIFF
--- a/lib/libesp32/berry_animation/src/animation.be
+++ b/lib/libesp32/berry_animation/src/animation.be
@@ -173,6 +173,10 @@ register_to_animation(rich_palette)
 # It keeps track of previously created engines and strips to reuse
 # when called with the same arguments
 #
+# Animation brightness is scaled by the bri value saved in `Leds` that is set
+# when `Leds` is initialized. Use engine.strip.set_bri(value) [0-255] to change
+# the brightness scaling applied by `Leds`.
+#
 # Parameters:
 #   l - list of arguments (vararg)
 #

--- a/lib/libesp32/berry_animation/src/animations/breathe.be
+++ b/lib/libesp32/berry_animation/src/animations/breathe.be
@@ -38,26 +38,18 @@ class breathe : animation.animation
     self.values["color"] = self._breathe
   end
   
-  # Handle parameter changes - propagate to internal breathe provider
+  # Handle parameter changes
   def on_param_changed(name, value)
     super(self).on_param_changed(name, value)
-    # Propagate relevant parameters to the breathe provider
     if name == "color"
       # When color is set, update the _breathe's color
       # but keep the _breathe as the actual color source for rendering
-      if type(value) == 'int'
-        self._breathe.color = value
-        # Restore the _breathe as the color source (bypass on_param_changed)
-        self.values["color"] = self._breathe
-      end
-    elif name == "min_brightness"
-      self._breathe.min_brightness = value
-    elif name == "max_brightness"
-      self._breathe.max_brightness = value
-    elif name == "period"
-      self._breathe.period = value
-    elif name == "curve_factor"
-      self._breathe.curve_factor = value
+      self._breathe.color = value
+      self.values["color"] = self._breathe
+    elif name == "min_brightness" || name == "max_brightness" ||
+         name == "period" || name == "curve_factor"
+      # Forward other parameters to internal breathe color provider
+      self._breathe.set_param(name, value)
     end
   end
   

--- a/lib/libesp32/berry_animation/src/animations/rich_palette.be
+++ b/lib/libesp32/berry_animation/src/animations/rich_palette.be
@@ -47,9 +47,6 @@ class rich_palette : animation.animation
        name == "brightness"
       # Set parameter on internal color provider
       self.color_provider.set_param(name, value)
-    else
-      # Let parent handle animation-specific parameters
-      super(self).on_param_changed(name, value)
     end
   end
   

--- a/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
+++ b/lib/libesp32/berry_animation/src/providers/breathe_color_provider.be
@@ -42,13 +42,11 @@ class breathe_color : animation.color_provider
   
   # Handle parameter changes - sync period to internal oscillator
   def on_param_changed(name, value)
+    super(self).on_param_changed(name, value)
     # Sync period changes to the internal oscillator's duration
     if name == "period"
       self._oscillator.duration = value
     end
-    
-    # Call parent's parameter change handler
-    super(self).on_param_changed(name, value)
   end
   
   # Produce color value based on current time

--- a/lib/libesp32/berry_animation/src/tests/breathe_animation_test.be
+++ b/lib/libesp32/berry_animation/src/tests/breathe_animation_test.be
@@ -21,7 +21,7 @@ var anim = animation.breathe(engine)
 print("Created breathe animation with defaults")
 
 # Test default values
-print(f"Default color: 0x{anim.breathe_provider.color :08x}")
+print(f"Default color: 0x{anim._breathe.color :08x}")
 print(f"Default min_brightness: {anim.min_brightness}")
 print(f"Default max_brightness: {anim.max_brightness}")
 print(f"Default period: {anim.period}")
@@ -35,7 +35,7 @@ blue_breathe.max_brightness = 200
 blue_breathe.period = 4000
 blue_breathe.curve_factor = 3
 blue_breathe.priority = 15
-print(f"Blue breathe animation color: 0x{blue_breathe.breathe_provider.color :08x}")
+print(f"Blue breathe animation color: 0x{blue_breathe._breathe.color :08x}")
 print(f"Blue breathe animation min_brightness: {blue_breathe.min_brightness}")
 print(f"Blue breathe animation max_brightness: {blue_breathe.max_brightness}")
 print(f"Blue breathe animation period: {blue_breathe.period}")
@@ -48,7 +48,16 @@ red_breathe.min_brightness = 10
 red_breathe.max_brightness = 180
 red_breathe.period = 3000
 red_breathe.curve_factor = 2
-print(f"Red breathe animation color: 0x{red_breathe.breathe_provider.color :08x}")
+print(f"Red breathe animation color: 0x{red_breathe._breathe.color :08x}")
+
+# Create green breathe animation with color as a closure value provider
+var green_breathe = animation.breathe(engine)
+green_breathe.color = animation.create_closure_value(engine, def (engine) return 0xFF00FF00 end)
+green_breathe.min_brightness = 10
+green_breathe.max_brightness = 180
+green_breathe.period = 3000
+green_breathe.curve_factor = 2
+print(f"Green breathe animation color: 0x{green_breathe._breathe.color :08x}")
 
 # Test parameter updates using virtual member assignment
 blue_breathe.min_brightness = 30
@@ -131,9 +140,14 @@ print("✓ Animation added to engine successfully")
 
 # Validate key test results
 assert(anim != nil, "Default breathe animation should be created")
-assert(blue_breathe != nil, "Custom breathe animation should be created")
+assert(blue_breathe != nil, "Blue breathe animation should be created")
 assert(red_breathe != nil, "Red breathe animation should be created")
-assert(blue_breathe.breathe_provider.color == 0xFF0000FF, "Blue breathe should have correct color")
+assert(green_breathe != nil, "Green breathe animation should be created")
+assert(red_breathe._breathe.color == 0xFFFF0000, "Red breathe should have correct color")
+assert(red_breathe.curve_factor == 2, "Red breathe should have curve factor of 2")
+assert(animation.is_value_provider(green_breathe._breathe.get_param("color")), "Green breathe should have color as a value provider")
+assert(green_breathe._breathe.color == 0xFF00FF00, "Green breathe should have correct color")
+assert(blue_breathe._breathe.color == 0xFF0000FF, "Blue breathe should have correct color")
 assert(blue_breathe.min_brightness == 30, "Min brightness should be updated to 30")
 assert(blue_breathe.max_brightness == 220, "Max brightness should be updated to 220")
 assert(blue_breathe.period == 3500, "Breathe period should be updated to 3500")
@@ -141,7 +155,7 @@ assert(blue_breathe.curve_factor == 4, "Curve factor should be updated to 4")
 assert(blue_breathe.is_running, "Blue breathe should be running after start")
 assert(frame.get_pixel_color(0) != 0x00000000, "First pixel should not be black after rendering")
 assert(blue_breathe.engine == engine, "Animation should have correct engine reference")
-assert(blue_breathe.breathe_provider != nil, "Animation should have internal breathe provider")
+assert(blue_breathe._breathe != nil, "Animation should have internal breathe provider")
 
 print("All tests completed successfully!")
 return true


### PR DESCRIPTION
## Description:

- Bug fix to remove type check for 'int' in `breathe.be` color so ValueProviders are supported alongside integer colors (same as #24284 which was removed in later commits)
- Fix existing tests in `breath_animation_test.be` and add tests for color as a ValueProvider
- Style clean up in `breathe.be` `on_param_changed` to use `set_param()` instead of individual assignments like `rich_palette.be`
- Fix to remove duplicate `super().on_param_changed()` call in `rich_palette.be`
- Move `super()` call to top of `on_param_changed` in `breathe_color_provider.be` to be consistent with others
- Add comment about brightness scaling applied by `Leds` to `animation.be` init_strip

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
