### PR TITLE
FM24Cxx: FRAM (I2C) console driver with block read/write/format

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -138,5 +138,6 @@ Index | Define              | Driver   | Device   | Address(es) | Bus2 | Descrip
   95  | USE_AGS02MA         | xsns_118 | AGS02MA   | 0x1A       |      | TVOC Gas sensor
   96  | USE_RX8025          | xdrv_56  | RX8025    | 0x32       | Yes  | RX8025 RTC
   97  | USE_SEN6X           | xsns_119 | SEN6X     | 0x6B       | Yes  | Gas (CO2/VOC/NOx index) and air quality (PPM <1,<2.5,<4,<10)
-
+  98  | USE_FM24CXX         | xdrv_93  | FM24CXX   | 0x50 - 0x57| Yes  | FM24CXX - External FRAM with console / berry R/W operations
+  
   NOTE: Bus2 supported on ESP32 only.

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -842,6 +842,15 @@
 //    #define USE_GRAPH                            // Enable line charts with displays
 //    #define NUM_GRAPHS     4                     // Max 16
 
+//  #define USE_FM24CXX                           // External FRAM module over I2C accesible via tasmota console / berry. be used to store super volatile data, frequently-changing settings, logs etc... (ps: shall work with AT24C32-AT24C512, but use with care - wear)
+    #define FM24CXX_I2C_ADD             0x57    // Fram I2C address.
+    #define FM24CXX_CAPACITY            8192    // FRAM Module size in bytes. 8192 = 64kbits (FM24C64), 4096 = 32kbits (FM24C32) etc..
+    #define FM24CXX_BLOCK_SIZE          256     // Parsed block size. When 256 and FRAM Size 8192, there are 8192/256 = 32 blocks per 256 bytes.
+    #define FM24CXX_I2C_CHUNK           32      // I2C Read Chunk size. For maximum compatibility, use 32. ESP32 S3,P4 works with 128 (a bit faster writes)
+    #define FM24CXX_MAX_WRITE_BYTES     4096    // Maximum bytes to be written at single cmd
+    #define FM24CXX_JSON_MAX_BYTES      4096    // Maximum bytes to get in single json response in FramReadRaw cmd. Above raise error.
+
+
 #endif  // USE_I2C
 
 //#define USE_DISPLAY                              // Add I2C/TM1637/MAX7219 Display Support (+2k code)

--- a/tasmota/tasmota_xdrv_driver/xdrv_93_fm24cxx.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_93_fm24cxx.ino
@@ -1,0 +1,702 @@
+/*
+  xdrv_93_fm24cxx.ino - External FRAM over I2C with console / berry R/W operations
+
+  Copyright (C) 2026 by Martin Macák - HexaMaster <hexamaster@icloud.com>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_FM24CXX
+
+#define XDRV_93 93
+#define XI2C_98 98
+
+#ifndef FM24CXX_I2C_ADD
+#define FM24CXX_I2C_ADD 0x57
+#endif
+
+#ifndef FM24CXX_BLOCK_SIZE
+#define FM24CXX_BLOCK_SIZE 0
+#endif
+
+#ifndef FM24CXX_CAPACITY
+#define FM24CXX_CAPACITY 8192 
+#endif
+
+#ifndef FM24CXX_I2C_CHUNK
+#define FM24CXX_I2C_CHUNK 32
+#endif
+
+#ifndef FM24CXX_MAX_WRITE_BYTES
+#define FM24CXX_MAX_WRITE_BYTES 4096
+#endif
+
+#ifndef FM24CXX_JSON_MAX_BYTES
+#define FM24CXX_JSON_MAX_BYTES 4096
+#endif
+
+#ifndef FM24CXX_JSON_MAX_STRING
+#define FM24CXX_JSON_MAX_STRING 4096
+#endif
+
+// TX payload must also include 2 address bytes in the same Wire transmission.
+// Typical Wire TX buffer is 32 bytes -> 30 bytes payload + 2 bytes addr.
+#define FM24CXX_TX_PAYLOAD_MAX  (FM24CXX_I2C_CHUNK > 2 ? (FM24CXX_I2C_CHUNK - 2) : 1)
+
+struct {
+  bool    detected = false;
+  uint8_t address  = (uint8_t)FM24CXX_I2C_ADD;
+  uint8_t bus      = 0;
+
+  uint32_t total_bytes = (uint32_t)FM24CXX_CAPACITY;
+
+  uint32_t block_size  = (uint32_t)FM24CXX_BLOCK_SIZE;  // 0 => whole chip
+  uint16_t block_count = 1;
+
+  uint32_t last_block_size = 0;  // if total_bytes not divisible
+} fm24;
+
+// ---------- Helpers ----------
+
+static char* Fm24_JsonEscapeAlloc(const char *in, uint32_t len) {
+  // worst-case: every char -> \u00XX (6 chars)
+  uint32_t need = 0;
+  for (uint32_t i = 0; i < len; i++) {
+    uint8_t c = (uint8_t)in[i];
+    if (c == '\"' || c == '\\' || c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t') need += 2;
+    else if (c < 0x20) need += 6;   // control char -> \u00XX
+    else need += 1;
+  }
+
+  char *out = (char*)malloc(need + 1);
+  if (!out) return nullptr;
+
+  static const char kHex[] = "0123456789ABCDEF";
+  char *d = out;
+
+  for (uint32_t i = 0; i < len; i++) {
+    uint8_t c = (uint8_t)in[i];
+    switch (c) {
+      case '\"': *d++='\\'; *d++='\"'; break;
+      case '\\': *d++='\\'; *d++='\\'; break;
+      case '\b': *d++='\\'; *d++='b';  break;
+      case '\f': *d++='\\'; *d++='f';  break;
+      case '\n': *d++='\\'; *d++='n';  break;
+      case '\r': *d++='\\'; *d++='r';  break;
+      case '\t': *d++='\\'; *d++='t';  break;
+      default:
+        if (c < 0x20) {
+          *d++='\\'; *d++='u'; *d++='0'; *d++='0';
+          *d++=kHex[(c >> 4) & 0x0F];
+          *d++=kHex[c & 0x0F];
+        } else {
+          *d++ = (char)c;
+        }
+        break;
+    }
+  }
+
+  *d = 0;
+  return out;
+}
+
+static void Fm24_RecalcBlocks(void) {
+  uint32_t bs = fm24.block_size;
+
+  if (bs == 0 || bs >= fm24.total_bytes) {
+    fm24.block_size = fm24.total_bytes;
+    fm24.block_count = 1;
+    fm24.last_block_size = fm24.total_bytes;
+    return;
+  }
+
+  uint32_t full = fm24.total_bytes / bs;
+  uint32_t rem  = fm24.total_bytes % bs;
+
+  fm24.block_count = (uint16_t)full;
+  if (rem) fm24.block_count++;
+
+  fm24.last_block_size = rem ? rem : bs;
+}
+
+static bool Fm24_GetBlockParams(uint32_t block, uint32_t *start, uint32_t *len) {
+  if (!fm24.detected) return false;
+  if (block >= fm24.block_count) return false;
+
+  uint32_t s = block * fm24.block_size;
+  uint32_t l = fm24.block_size;
+
+  if ((block == (uint32_t)(fm24.block_count - 1)) && (fm24.last_block_size != fm24.block_size)) {
+    l = fm24.last_block_size;
+  }
+
+  if (s + l > fm24.total_bytes) return false;
+  *start = s;
+  *len   = l;
+  return true;
+}
+
+// Robust hex parser: accepts "AABBCC", "AA BB CC", "0xAA,0xBB,0xCC", etc.
+static uint32_t Fm24_ParseHexBytes(const char *s, uint8_t *out, uint32_t out_max) {
+  uint32_t n = 0;
+  int hi = -1;
+
+  while (*s && n < out_max) {
+
+    // Skip 0x / 0X prefix as a whole token (do NOT consume '0' as a nibble)
+    if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+      s += 2;
+      continue;
+    }
+
+    char c = *s++;
+    int v = -1;
+
+    if (c >= '0' && c <= '9') v = c - '0';
+    else if (c >= 'a' && c <= 'f') v = 10 + (c - 'a');
+    else if (c >= 'A' && c <= 'F') v = 10 + (c - 'A');
+    else continue; // separators
+
+    if (hi < 0) hi = v;
+    else {
+      out[n++] = (uint8_t)((hi << 4) | v);
+      hi = -1;
+    }
+  }
+
+  return n;
+}
+
+static void Fm24_LogHexLine(uint32_t addr, const uint8_t *buf, uint32_t len) {
+  AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: 0x%04X: %*_H"), (uint16_t)addr, (int)len, buf);
+}
+
+// ---------- Low-level I2C FRAM access (16-bit address, MSB first) ----------
+
+static bool Fm24_I2cRead(uint16_t mem_addr, uint8_t *buf, uint32_t len) {
+
+  TwoWire& myWire = I2cGetWire(fm24.bus);
+  if (&myWire == nullptr) { return false; }
+
+  uint32_t done = 0;
+  while (done < len) {
+    uint32_t chunk = len - done;
+    if (chunk > FM24CXX_I2C_CHUNK) chunk = FM24CXX_I2C_CHUNK;
+
+    // Set internal address pointer
+    myWire.beginTransmission(fm24.address);
+    myWire.write((uint8_t)(mem_addr >> 8));       // MSB
+    myWire.write((uint8_t)(mem_addr & 0xFF));     // LSB
+    if (myWire.endTransmission(true) != 0) {      // STOP
+      return false;
+    }
+
+    // Read data
+    if (chunk != (uint32_t)myWire.requestFrom((uint8_t)fm24.address, (uint8_t)chunk)) {
+      // Drain
+      while (myWire.available()) (void)myWire.read();
+      return false;
+    }
+
+    for (uint32_t i = 0; i < chunk; i++) {
+      if (!myWire.available()) return false;
+      buf[done + i] = (uint8_t)myWire.read();
+    }
+
+    done += chunk;
+    mem_addr = (uint16_t)(mem_addr + chunk);
+    yield();
+  }
+
+  return true;
+}
+
+static bool Fm24_I2cWrite(uint16_t mem_addr, const uint8_t *buf, uint32_t len) {
+
+  TwoWire& myWire = I2cGetWire(fm24.bus);
+  if (&myWire == nullptr) { return false; }
+
+  uint32_t done = 0;
+  while (done < len) {
+    uint32_t chunk = len - done;
+    if (chunk > FM24CXX_TX_PAYLOAD_MAX) chunk = FM24CXX_TX_PAYLOAD_MAX;
+
+    myWire.beginTransmission(fm24.address);
+    myWire.write((uint8_t)(mem_addr >> 8));       // MSB
+    myWire.write((uint8_t)(mem_addr & 0xFF));     // LSB
+    for (uint32_t i = 0; i < chunk; i++) {
+      myWire.write(buf[done + i]);
+    }
+
+    if (myWire.endTransmission(true) != 0) {
+      return false;
+    }
+
+    done += chunk;
+    mem_addr = (uint16_t)(mem_addr + chunk);
+    yield();
+  }
+
+  return true;
+}
+
+static bool Fm24_WriteFill(uint16_t mem_addr, uint8_t fill, uint32_t len) {
+  uint8_t tmp[FM24CXX_TX_PAYLOAD_MAX];
+  memset(tmp, fill, sizeof(tmp));
+
+  uint32_t done = 0;
+  while (done < len) {
+    uint32_t chunk = len - done;
+    if (chunk > sizeof(tmp)) chunk = sizeof(tmp);
+
+    if (!Fm24_I2cWrite((uint16_t)(mem_addr + done), tmp, chunk)) {
+      return false;
+    }
+    done += chunk;
+    yield();
+  }
+  return true;
+}
+
+// ---------- Detect ----------
+
+static void Fm24_Detect(void) {
+  if (fm24.detected) return;
+  if (!I2cEnabled(XI2C_98)) return;
+
+  fm24.address     = (uint8_t)FM24CXX_I2C_ADD;
+  fm24.total_bytes = (uint32_t)FM24CXX_CAPACITY;
+  fm24.block_size  = (uint32_t)FM24CXX_BLOCK_SIZE;
+  Fm24_RecalcBlocks();
+
+  for (fm24.bus = 0; fm24.bus < 2; fm24.bus++) {
+    if (!I2cSetDevice(fm24.address, fm24.bus)) continue;
+
+    uint8_t b = 0;
+    fm24.detected = Fm24_I2cRead(0x0000, &b, 1);
+
+    if (fm24.detected) {
+      I2cSetActiveFound(fm24.address, "FM24CXX", fm24.bus);
+      AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: detected bus=%d addr=0x%02X size=%u block=%u blocks=%u"),
+            fm24.bus, fm24.address,
+            (unsigned)fm24.total_bytes,
+            (unsigned)fm24.block_size,
+            (unsigned)fm24.block_count);
+      return;
+    }
+  }
+
+  AddLog(LOG_LEVEL_DEBUG, PSTR("FM24CXX: not detected (addr=0x%02X)"), (uint8_t)FM24CXX_I2C_ADD);
+}
+
+// ---------- Tasmota console command handling ----------
+
+#define D_PRFX_FRAM             "Fram"
+#define D_CMND_FRAM_INFO        "Info"              // General info (etc... {"FramInfo":{"bus":1,"addr":"0x50","size":65535,"block":1024,"blocks":64}})
+#define D_CMND_FRAM_READ_FORMAT "ReadFormat"        // Read HEX values from block and format them in tasmota console (STREAM)
+#define D_CMND_FRAM_READ        "Read"              // Read HEX values from block to result map (easy access from Berry)
+#define D_CMND_FRAM_WRITE       "Write"             // Write HEX values to block. Unused block bytes are filled with zeros
+#define D_CMND_FRAM_FORMAT      "Erase"             // Erase selected block or whole fram (if "all") - fill with zeros
+#define D_CMND_FRAM_READ_STRING  "ReadString"       // Read block data as STRING - json output
+#define D_CMND_FRAM_WRITE_STRING "WriteString"      // Write data to block as STRING. 
+
+static void CmndFramInfo(void);
+static void CmndFramReadFormat(void);
+static void CmndFramRead(void);
+static void CmndFramWrite(void);
+static void CmndFramErase(void);
+static void CmndFramReadString(void);
+static void CmndFramWriteString(void);
+
+const char kFramCommands[] PROGMEM =
+  D_PRFX_FRAM "|" D_CMND_FRAM_INFO "|" D_CMND_FRAM_READ_FORMAT "|" D_CMND_FRAM_READ "|" D_CMND_FRAM_WRITE "|" D_CMND_FRAM_FORMAT "|" D_CMND_FRAM_READ_STRING "|" D_CMND_FRAM_WRITE_STRING;
+
+void (*const FramCommand[])(void) PROGMEM = {
+  &CmndFramInfo, &CmndFramReadFormat, &CmndFramRead, &CmndFramWrite, &CmndFramErase, &CmndFramReadString, &CmndFramWriteString
+};
+
+static void CmndFramInfo(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramInfo\":\"not detected\"}"));
+    return;
+  }
+
+  Response_P(PSTR("{\"FramInfo\":{\"bus\":%d,\"addr\":\"0x%02X\",\"size\":%u,\"block\":%u,\"blocks\":%u}}"),
+             fm24.bus, fm24.address,
+             (unsigned)fm24.total_bytes,
+             (unsigned)fm24.block_size,
+             (unsigned)fm24.block_count);
+}
+
+static void CmndFramReadFormat(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramReadFormat\":\"not detected\"}"));
+    return;
+  }
+
+  if (!XdrvMailbox.data_len) { ResponseCmndFailed(); return; }
+
+  uint32_t block = (uint32_t)strtoul(XdrvMailbox.data, nullptr, 0);
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) { ResponseCmndFailed(); return; }
+
+  AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: READ block=%u start=0x%04X len=%u"),
+         (unsigned)block, (uint16_t)start, (unsigned)len);
+
+  uint8_t tmp[16];
+  for (uint32_t off = 0; off < len; off += sizeof(tmp)) {
+    uint32_t chunk = len - off;
+    if (chunk > sizeof(tmp)) chunk = sizeof(tmp);
+
+    if (!Fm24_I2cRead((uint16_t)(start + off), tmp, chunk)) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: READ failed at 0x%04X"), (uint16_t)(start + off));
+      ResponseCmndFailed();
+      return;
+    }
+    Fm24_LogHexLine(start + off, tmp, chunk);
+    yield();
+  }
+
+  Response_P(PSTR("{\"FramReadFormat\":{\"block\":%u,\"bytes\":%u}}"), (unsigned)block, (unsigned)len);
+}
+
+static void CmndFramRead(void) {
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramRead\":\"not detected\"}"));
+    return;
+  }
+
+  char *p = XdrvMailbox.data;
+  while (p && (*p == ' ' || *p == '\t' || *p == ',')) p++;
+
+  if (!p || *p == 0) {
+    Response_P(PSTR("{\"FramRead\":\"usage: FramRead <block>\"}"));
+    return;
+  }
+
+  uint32_t block = (uint32_t)strtoul(p, nullptr, 0);
+
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) {
+    ResponseCmndFailed();
+    return;
+  }
+
+  // buffer protection
+  if (len > FM24CXX_JSON_MAX_BYTES) {
+    Response_P(PSTR("{\"FramRead\":{\"error\":\"too big\",\"block\":%u,\"bytes\":%u,\"max\":%u}}"),
+               (unsigned)block, (unsigned)len, (unsigned)FM24CXX_JSON_MAX_BYTES);
+    return;
+  }
+
+  uint8_t *buf = (uint8_t*)malloc(len);
+  if (!buf) { ResponseCmndFailed(); return; }
+
+  if (!Fm24_I2cRead((uint16_t)start, buf, len)) {
+    free(buf);
+    ResponseCmndFailed();
+    return;
+  }
+
+  char *hex = (char*)malloc((len * 2) + 1);
+  if (!hex) { free(buf); ResponseCmndFailed(); return; }
+  hex[len * 2] = 0;
+
+  static const char kHex[] = "0123456789ABCDEF";
+  for (uint32_t i = 0; i < len; i++) {
+    uint8_t v = buf[i];
+    hex[i * 2 + 0] = kHex[v >> 4];
+    hex[i * 2 + 1] = kHex[v & 0x0F];
+  }
+
+  Response_P(PSTR("{\"FramRead\":{\"block\":%u,\"bytes\":%u,\"data\":\"%s\"}}"),
+             (unsigned)block, (unsigned)len, hex);
+
+  free(hex);
+  free(buf);
+}
+
+static void CmndFramWrite(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramWrite\":\"not detected\"}"));
+    return;
+  }
+
+  if (!XdrvMailbox.data_len) { ResponseCmndFailed(); return; }
+
+  char *p = XdrvMailbox.data;
+  while (p && (*p == ' ' || *p == '\t' || *p == ',')) p++;
+
+  char *save = nullptr;
+  char *a1 = strtok_r(p, " \t,", &save);
+  if (!a1) { ResponseCmndFailed(); return; }
+
+  uint32_t block = (uint32_t)strtoul(a1, nullptr, 0);
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) { ResponseCmndFailed(); return; }
+
+  char *hex = save;
+  while (hex && (*hex == ' ' || *hex == '\t' || *hex == ',')) hex++;
+
+  if (!hex || *hex == 0) {
+    Response_P(PSTR("{\"FramWrite\":\"write needs hex payload\"}"));
+    return;
+  }
+
+  uint32_t max_write = len;
+  if (max_write > FM24CXX_MAX_WRITE_BYTES) max_write = FM24CXX_MAX_WRITE_BYTES;
+
+  uint8_t *data = (uint8_t*)malloc(max_write);
+  if (!data) { ResponseCmndFailed(); return; }
+
+  uint32_t n = Fm24_ParseHexBytes(hex, data, max_write);
+  if (n == 0) {
+    free(data);
+    Response_P(PSTR("{\"FramWrite\":\"no hex bytes parsed\"}"));
+    return;
+  }
+
+  AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: WRITE block=%u start=0x%04X len=%u parsed=%u (fill rest with 0x00)"),
+         (unsigned)block, (uint16_t)start, (unsigned)len, (unsigned)n);
+
+  if (!Fm24_I2cWrite((uint16_t)start, data, n)) {
+    free(data);
+    AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: WRITE failed at 0x%04X"), (uint16_t)start);
+    ResponseCmndFailed();
+    return;
+  }
+  free(data);
+
+  if (n < len) {
+    if (!Fm24_WriteFill((uint16_t)(start + n), 0x00, (len - n))) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: FILL failed at 0x%04X"), (uint16_t)(start + n));
+      ResponseCmndFailed();
+      return;
+    }
+  }
+
+  Response_P(PSTR("{\"FramWrite\":{\"block\":%u,\"bytes\":%u,\"filled\":%u}}"),
+             (unsigned)block, (unsigned)n, (unsigned)(len - (n < len ? n : len)));
+}
+
+static void CmndFramErase(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramErase\":\"not detected\"}"));
+    return;
+  }
+
+  if (!XdrvMailbox.data_len) { ResponseCmndFailed(); return; }
+
+  char *p = XdrvMailbox.data;
+  while (p && (*p == ' ' || *p == '\t' || *p == ',')) p++;
+
+  if (!strcasecmp(p, "all")) {
+    AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: FORMAT all blocks (%u), fill=0x00"), (unsigned)fm24.block_count);
+
+    for (uint32_t b = 0; b < fm24.block_count; b++) {
+      uint32_t start = 0, len = 0;
+      if (!Fm24_GetBlockParams(b, &start, &len)) { ResponseCmndFailed(); return; }
+
+      if (!Fm24_WriteFill((uint16_t)start, 0x00, len)) {
+        AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: FORMAT failed at block=%u addr=0x%04X"), (unsigned)b, (uint16_t)start);
+        ResponseCmndFailed();
+        return;
+      }
+      yield();
+    }
+
+    Response_P(PSTR("{\"FramErase\":\"all\"}"));
+    return;
+  }
+
+  uint32_t block = (uint32_t)strtoul(p, nullptr, 0);
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) { ResponseCmndFailed(); return; }
+
+  AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: FORMAT block=%u start=0x%04X len=%u fill=0x00"),
+         (unsigned)block, (uint16_t)start, (unsigned)len);
+
+  if (!Fm24_WriteFill((uint16_t)start, 0x00, len)) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: FORMAT failed at 0x%04X"), (uint16_t)start);
+    ResponseCmndFailed();
+    return;
+  }
+
+  Response_P(PSTR("{\"FramErase\":%u}"), (unsigned)block);
+}
+
+static void CmndFramReadString(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramReadString\":\"not detected\"}"));
+    return;
+  }
+
+  char *p = XdrvMailbox.data;
+  while (p && (*p == ' ' || *p == '\t' || *p == ',')) p++;
+
+  if (!p || *p == 0) {
+    Response_P(PSTR("{\"FramReadString\":\"usage: FramReadString <block>\"}"));
+    return;
+  }
+
+  uint32_t block = (uint32_t)strtoul(p, nullptr, 0);
+
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) { ResponseCmndFailed(); return; }
+
+  // chunked read
+  uint32_t max_raw = len;
+  if (max_raw > FM24CXX_JSON_MAX_STRING) max_raw = FM24CXX_JSON_MAX_STRING;
+
+  char *raw = (char*)malloc(max_raw + 1);
+  if (!raw) { ResponseCmndFailed(); return; }
+
+  uint32_t raw_len = 0;
+  bool zero_found = false;
+
+  uint8_t tmp[FM24CXX_I2C_CHUNK];
+
+  for (uint32_t off = 0; off < len && raw_len < max_raw && !zero_found; ) {
+    uint32_t chunk = len - off;
+    if (chunk > sizeof(tmp)) chunk = sizeof(tmp);
+
+    if (!Fm24_I2cRead((uint16_t)(start + off), tmp, chunk)) {
+      free(raw);
+      ResponseCmndFailed();
+      return;
+    }
+
+    for (uint32_t i = 0; i < chunk && raw_len < max_raw; i++) {
+      uint8_t c = tmp[i];
+      if (c == 0x00) { zero_found = true; break; }
+      raw[raw_len++] = (char)c;
+    }
+
+    off += chunk;
+    yield();
+  }
+
+  raw[raw_len] = 0;
+
+  bool truncated = (!zero_found) && (raw_len == max_raw) && (max_raw < len);
+
+  char *esc = Fm24_JsonEscapeAlloc(raw, raw_len);
+  if (!esc) {
+    free(raw);
+    ResponseCmndFailed();
+    return;
+  }
+
+  Response_P(PSTR("{\"FramReadString\":{\"block\":%u,\"bytes\":%u,\"truncated\":%u,\"data\":\"%s\"}}"),
+             (unsigned)block, (unsigned)raw_len, (unsigned)(truncated ? 1 : 0), esc);
+
+  free(esc);
+  free(raw);
+}
+
+static void CmndFramWriteString(void) {
+  Fm24_Detect();
+  if (!fm24.detected) {
+    Response_P(PSTR("{\"FramWriteString\":\"not detected\"}"));
+    return;
+  }
+
+  if (!XdrvMailbox.data_len) { ResponseCmndFailed(); return; }
+
+  char *p = XdrvMailbox.data;
+  while (p && (*p == ' ' || *p == '\t' || *p == ',')) p++;
+
+  char *save = nullptr;
+  char *a1 = strtok_r(p, " \t,", &save);
+  if (!a1) { ResponseCmndFailed(); return; }
+
+  uint32_t block = (uint32_t)strtoul(a1, nullptr, 0);
+
+  uint32_t start = 0, len = 0;
+  if (!Fm24_GetBlockParams(block, &start, &len)) { ResponseCmndFailed(); return; }
+
+  char *str = save;
+  while (str && (*str == ' ' || *str == '\t' || *str == ',')) str++;
+
+  if (!str || *str == 0) {
+    Response_P(PSTR("{\"FramWriteString\":\"write needs string payload\"}"));
+    return;
+  }
+
+  // quote string support ("")
+  if (str[0] == '\"') {
+    str++;
+    char *endq = strrchr(str, '\"');
+    if (endq) *endq = 0;
+  }
+
+  uint32_t max_write = len;
+  if (max_write > FM24CXX_MAX_WRITE_BYTES) max_write = FM24CXX_MAX_WRITE_BYTES;
+
+  uint32_t n = (uint32_t)strnlen(str, max_write);
+  bool truncated = (str[n] != 0);   // strnlen hitol limit
+
+  AddLog(LOG_LEVEL_INFO, PSTR("FM24CXX: WRITE_STRING block=%u start=0x%04X str_len=%u (fill rest with 0x00)"),
+         (unsigned)block, (uint16_t)start, (unsigned)n);
+
+  if (n > 0) {
+    if (!Fm24_I2cWrite((uint16_t)start, (const uint8_t*)str, n)) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: WRITE_STRING failed at 0x%04X"), (uint16_t)start);
+      ResponseCmndFailed();
+      return;
+    }
+  }
+
+  if (n < len) {
+    if (!Fm24_WriteFill((uint16_t)(start + n), 0x00, (len - n))) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("FM24CXX: WRITE_STRING fill failed at 0x%04X"), (uint16_t)(start + n));
+      ResponseCmndFailed();
+      return;
+    }
+  }
+
+  Response_P(PSTR("{\"FramWriteString\":{\"block\":%u,\"bytes\":%u,\"filled\":%u,\"truncated\":%u}}"),
+             (unsigned)block, (unsigned)n, (unsigned)(len - (n < len ? n : len)), (unsigned)(truncated ? 1 : 0));
+}
+
+// ---------- Interface ----------
+
+bool Xdrv93(uint32_t function) {
+  bool result = false;
+
+  switch (function) {
+    case FUNC_INIT:
+      Fm24_Detect();
+      break;
+
+    case FUNC_COMMAND:
+      result = DecodeCommand(kFramCommands, FramCommand);
+      break;
+
+    case FUNC_ACTIVE:
+      result = fm24.detected;
+      break;
+  }
+
+  return result;
+}
+
+#endif  // USE_FM24CXX
+#endif  // USE_I2C

--- a/tasmota/tasmota_xdrv_driver/xdrv_93_fm24cxx.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_93_fm24cxx.ino
@@ -6,7 +6,7 @@
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+  (at your option) any later version. 
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
## Description:

**Usecase:**

FRAM is particularly suitable for highly volatile, frequently updated data where Flash/EEPROM wear would be a concern:

- fast-changing device states (relays, switches, mode flags)
- frequently modified configuration values and runtime parameters
- lightweight log / event data and counters written often

This driver provides a simple console interface to validate wiring, test read/write behavior, and manage FRAM contents during development and troubleshooting.

**Driver Features:**

- Add XDRV_93 console driver for FM24Cxx FRAM over I2C (16-bit address, MSB first).
- Auto-detect FRAM on I2C bus 0/1 at configurable address (default 0x57).
- Provide commands: FramInfo, FramReadFormat, FramRead, FramWrite, FramErase, plus text helpers FramReadString / FramWriteString.
- Chunked I2C transfers and write payload sizing compatible with typical Wire TX buffer constraints.
- Robust hex input parser for write command (supports separators and 0x.. tokens).
- JSON-safe string output via escaping; block writes optionally fill remainder with 0x00.

**Driver Compatibility:**
- FM24C16,32,64,128,256,512 FRAM Modules trought I2C
- AT24C16,32,64,128,256,512 EEPROM Modules (not very suitable for high volatile data because of EEPROM limited lifespan) 

**Short Manual:**

_Build options and configuration_

```
#DEFINE USE_I2C
#DEFINE USE_FM24CXX
```

Optional compile-time configuration macros:

`#DEFINE FM24CXX_I2C_ADD`
FRAM I2C address (default: 0x57)

`#DEFINE FM24CXX_CAPACITY`
Total FRAM size in bytes (default: 8192)

`#DEFINE FM24CXX_BLOCK_SIZE`
Block size in bytes. If set to 0, the whole chip is a single block.

`#DEFINE FM24CXX_I2C_CHUNK`
I2C read chunk size (default: 32).
Write payload is automatically limited to FM24CXX_I2C_CHUNK - 2 (because 16-bit address must be sent in the same I2C transaction).

`#DEFINE FM24CXX_MAX_WRITE_BYTES`
Hard cap for write payload (default: 4096).

`#DEFINE FM24CXX_JSON_MAX_BYTES`
Maximum bytes returned by FramRead as hex in JSON (default: 4096).

`#DEFINE FM24CXX_JSON_MAX_STRING`
Maximum bytes returned by FramReadString (default: 4096).

**Block model**

The FRAM memory is split into blocks:

If FM24CXX_BLOCK_SIZE == 0 → one block spanning the entire chip.

Otherwise → multiple blocks of size FM24CXX_BLOCK_SIZE, with the last block possibly smaller.

All commands that accept <block> operate on the block start address and block length derived from this model.

Command reference
FramInfo

Shows detection and configuration.

Example

FramInfo
FramReadFormat <block>

Reads a block and prints a formatted hex dump to the log (16 bytes per line). Returns a summary JSON.

Example

```
FramReadFormat 0
FramRead <block>
```

Reads an entire block and returns the result as a hex string in JSON ("data":"AABBCC...").
This is the recommended command for binary-safe dumps.

Example

```
FramRead 0
FramWrite <block> <hex-bytes>
```

Writes bytes parsed from the provided hex payload to the start of the block, then fills the remaining block bytes with 0x00.

Accepts flexible hex formats: AABBCC, AA BB CC, 0xAA,0xBB,0xCC

Example

```
FramWrite 0 AABBCCDD0011
FramWrite 0 0xAA 0xBB 0xCC
FramWriteString <block> <text>
```

Writes the provided text bytes directly to FRAM, then fills the remaining block bytes with 0x00 (including a terminating 0x00).

Supports quoted input for spaces:

FramWriteString 0 "Hello World!"

Examples

```
FramWriteString 0 Hello
FramWriteString 0 "Hello World!"
FramReadString <block>
```

Reads bytes from the start of the block until the first 0x00 byte (C-string style) or until FM24CXX_JSON_MAX_STRING is reached.

The returned text is JSON-escaped to prevent invalid JSON output.

Example

```
FramReadString 0
FramErase <block> / FramFormat all
```

Fills the target block (or all blocks) with 0x00.

Examples

```
FramErase 0
FramErase all
```

Console read output example:

```
23:13:44.942 CMD: Grp 0, Cmd 'FRAMREADFORMAT', Idx 1, Len 1, Pld 1, Data '1'
23:13:44.943 FM24CXX: READ block=1 start=0x0100 len=256
23:13:44.945 FM24CXX: 0x0100: 4C6F72656D20697073756D2069732061
23:13:44.947 FM24CXX: 0x0110: 2064756D6D79206F7220706C61636568
23:13:44.950 FM24CXX: 0x0120: 6F6C646572207465787420636F6D6D6F
23:13:44.952 FM24CXX: 0x0130: 6E6C79207573656420696E2067726170
23:13:44.954 FM24CXX: 0x0140: 6869632064657369676E2C207075626C
23:13:44.956 FM24CXX: 0x0150: 697368696E672C20616E642077656220
23:13:44.958 FM24CXX: 0x0160: 646576656C6F706D656E742E20497473
23:13:44.960 FM24CXX: 0x0170: 20707572706F736520697320746F2070
23:13:44.963 FM24CXX: 0x0180: 65726D697420612070616765206C6179
23:13:44.965 FM24CXX: 0x0190: 6F757420746F2062652064657369676E
23:13:44.967 FM24CXX: 0x01A0: 65642C20696E646570656E64656E746C
23:13:44.970 FM24CXX: 0x01B0: 79206F662074686520636F7079207468
23:13:44.972 FM24CXX: 0x01C0: 61742077696C6C207375627365717565
23:13:44.975 FM24CXX: 0x01D0: 6E746C7920706F70756C617465206974
23:13:44.977 FM24CXX: 0x01E0: 2C206F7220746F2064656D6F6E737472
23:13:44.979 FM24CXX: 0x01F0: 61746520766172696F757320666F6E74
23:13:44.980 RSL: RESULT = {"FramReadFormat":{"block":1,"bytes":256}}
23:14:02.555 CMD: framread 1
23:14:02.555 SRC: WebConsole from 10.0.4.226
23:14:02.555 CMD: Grp 0, Cmd 'FRAMREAD', Idx 1, Len 1, Pld 1, Data '1'
23:14:02.585 RSL: RESULT = {"FramRead":{"block":1,"bytes":256,"data":"4C6F72656D20697073756D20697320612064756D6D79206F7220706C616365686F6C646572207465787420636F6D6D6F6E6C79207573656420696E20677261706869632064657369676E2C207075626C697368696E672C20616E642077656220646576656C6F706D656E742E2049747320707572706F736520697320746F207065726D697420612070616765206C61796F757420746F2062652064657369676E65642C20696E646570656E64656E746C79206F662074686520636F707920746861742077696C6C2073756273657175656E746C7920706F70756C6174652069742C206F7220746F2064656D6F6E73747261746520766172696F757320666F6E74"}}
23:14:09.483 CMD: framreadstring 1
23:14:09.484 SRC: WebConsole from 10.0.4.226
23:14:09.484 CMD: Grp 0, Cmd 'FRAMREADSTRING', Idx 1, Len 1, Pld 1, Data '1'
23:14:09.513 RSL: RESULT = {"FramReadString":{"block":1,"bytes":256,"truncated":0,"data":"Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development. Its purpose is to permit a page layout to be designed, independently of the copy that will subsequently populate it, or to demonstrate various font"}}
```

**Notes and limitations**

Binary vs text

- Use FramRead/FramWrite (hex) for binary-safe operations.
- Use FramReadString/FramWriteString for text only.
- FramReadString stops at the first 0x00. Data containing embedded zeros is not representable as a “string”.

Response size

FramRead returns hex, which is 2× the byte count. Large blocks may exceed Tasmota’s response buffer limits even if FM24CXX_JSON_MAX_BYTES allows it.

I2C framing

Low-level access uses 16-bit memory addressing (MSB first), with chunked reads/writes and yield() calls to remain watchdog-friendly.


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
