### PR TITLE
Add support for LoRaWAN sensor discovery for Home Assistant

### DIFF
--- a/tasmota/berry/lorawan/decoders/LwDecode.be
+++ b/tasmota/berry/lorawan/decoders/LwDecode.be
@@ -220,6 +220,22 @@ class lwdecode_cls
     return hash
   end
 
+  static def cleanString(s)
+   # cleans string to include only chars [a-zA-Z0-9_-]
+   # alphanumerics, underscore and hyphen
+   var cs=""
+   var c=''
+   for i : 0..size(s)-1
+    c = s[i]
+    if !((c=='-')||(c=='_')||(c>='a' && c<='z')||(c>='A' && c<='Z')||(c>='0' && c<='9'))
+     cs += '_'
+    else 
+     cs += c
+    end
+   end
+   return cs
+  end
+
   def lw_decode(data)
     import json
 
@@ -239,10 +255,60 @@ class lwdecode_cls
         load(decoder)
         if LwDeco
           self.lw_decoders[decoder] = LwDeco
-        else
-          log("LwD: Unable to load decoder",1)
-          return true
-        end
+
+          if tasmota.get_option(19) == 0          
+            #  Send Single Component HA Discovery message
+            #  Reference: https://www.home-assistant.io/integrations/mqtt/#single-component-discovery-payload
+
+            try
+              var sensors = LwDeco.HAssSensors()    # Ask decoder for details of this device ...
+              var deviceInfo = LwDeco.deviceInfo()
+              var tasDeviceName  = tasmota.cmd('_Status',true)['Status']['DeviceName']
+              var MAC=string.replace(tasmota.wifi('mac'),':','')
+              var devEUI = device_data[device_name]['DevEUIh'] + device_data[device_name]['DevEUIl']
+              var LwPrefix = tasmota.get_option(83) == 0?"['LwDecoded']":""   
+ 
+              for k : sensors.keys()
+                var sensName  = k    
+                var stateClass= sensors[sensName][0]
+                var HAName    = sensors[sensName][1]
+                var sensUnit  = sensors[sensName][2]
+                var devClass  = sensors[sensName][3]
+                var icon      = sensors[sensName][4]
+                var sensNameClean=self.cleanString(sensName)
+                var val_tpl = f"{{{{value_json{LwPrefix}['{device_name}']['{sensNameClean}']}}}}"
+                var topic = f"homeassistant/sensor/tasmota_{MAC}_{sensNameClean}/config"
+                var pl = {
+                  "dev":{"ids":MAC[6..],
+                  "name":tasDeviceName,
+                  "mf":deviceInfo['manufacturer'],
+                  "mdl":deviceInfo['model']
+                  },
+                  "o":{"name":tasDeviceName},
+                  "name":HAName,
+                  "device_cla":devClass,
+                  "state_cla":stateClass,
+                  "unit_of_meas":sensUnit,
+                  "ic":icon,
+                  "val_tpl":val_tpl,
+                  "uniq_id":f"tasmota_{MAC}_{sensNameClean}",
+                  "stat_t":f"{self.topic_cached}/{devEUI}",
+                  "avty_t":string.replace(self.topic_cached, 'SENSOR','LWT'),  
+                  "pl_avail":"Online",
+                  "pl_not_avail":"Offline"
+                }
+                mqtt.publish(topic, json.dump(pl),true) #Retain
+              end #for each sensor
+
+            except .. as e, m
+              log(format("LwD: HA Discovery warning: %s", m),1)
+            end # try
+          end # if SO19
+
+      else
+        log("LwD: Unable to load decoder",1)
+        return true
+      end
       except .. as e, m
         log(format("LwD: Decoder load error: %s", m),1)
         return true

--- a/tasmota/berry/lorawan/decoders/vendors/dragino/DDS75L.be
+++ b/tasmota/berry/lorawan/decoders/vendors/dragino/DDS75L.be
@@ -11,6 +11,31 @@ if !global.dds75lbNodes      # data survive to decoder reload
 end
 
 class LwDecoDDS75LB
+
+  static def deviceInfo()
+   return {"manufacturer":"Dragino", 
+           "model":"DDS75L"
+          }
+  end
+  
+  static def HAssSensors()
+   # The sensors in this device that are included in the MQTT messages, and
+   # should be advertised in HA Discovery MQTT message.
+   # More info: https://www.home-assistant.io/integrations/mqtt/#single-component-discovery-payload
+   # One line per sensor        [0]            [1]                [2]    [3]               [4]
+   #     [MQTT name] (note[1])  state class    HA Display name    Units  device class      icon (note[4])
+   #       
+   #
+   # Note[1]: Must match name used in decodeUplink() below
+   # Note[4]: See https://pictogrammers.com/library/mdi/
+   #
+   var sensors={}
+   sensors["RSSI"]       = ["measurement"     ,"LoRa Signal"      ,"dBm","signal strength","mdi:signal-variant"]
+   sensors["BattV"]      = ["measurement"     ,"Battery Voltage"  ,"V"  ,"voltage"        ,"mdi:current-dc"]
+   sensors["Distance"]   = ["measurement"     ,"Distance"         ,"mm" ,"distance"       ,"mdi:arrow-left-right"]
+   return sensors
+  end
+
   static def decodeUplink(Name, Node, RSSI, FPort, Bytes)
     var data = {"Device":"Dragino DDS75-LB/LS"}
     

--- a/tasmota/berry/lorawan/decoders/vendors/dragino/LHT52.be
+++ b/tasmota/berry/lorawan/decoders/vendors/dragino/LHT52.be
@@ -11,6 +11,32 @@ if !global.lht52Nodes      # data survive to decoder reload
 end
 
 class LwDecoLHT52
+
+  static def deviceInfo()
+   return {"manufacturer":"Dragino", 
+           "model":"LHT52"
+          }
+  end
+  
+  static def HAssSensors()
+   # The sensors in this device that are included in the MQTT messages, and
+   # should be advertised in HA Discovery MQTT message.
+   # More info: https://www.home-assistant.io/integrations/mqtt/#single-component-discovery-payload
+   # One line per sensor        [0]            [1]                [2]    [3]               [4]
+   #     [MQTT name] (note[1])  state class    HA Display name    Units  device class      icon (note[4])
+   #       
+   #
+   # Note[1]: Must match name used in decodeUplink() below
+   # Note[4]: See https://pictogrammers.com/library/mdi/
+   #
+   var sensors={}
+   sensors["RSSI"]           = ["measurement", "LoRa Signal"      ,"dBm","signal strength","mdi:signal-variant"]
+   sensors["TempC_Internal"] = ["measurement", "Internal Temp"    ,"°C" ,"temperature"    ,"mdi:thermometer"]
+   sensors["Hum_Internal"]   = ["measurement", "Internal Humidity","%"  ,"humidity"       ,"mdi:water-percent"]
+   sensors["BattV"]          = ["measurement", "Battery Voltage"  ,"V"  ,"voltage"        ,"mdi:current-dc"]
+   return sensors
+  end
+
   static def decodeUplink(Name, Node, RSSI, FPort, Bytes)
     var data = {"Device":"Dragino LHT52"}
     


### PR DESCRIPTION
See https://github.com/arendst/Tasmota/discussions/24398#discussioncomment-15649631

## Description:
Add support for LoRaWAN device sensors Discovery to Home Assistant

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [X] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
See: https://github.com/arendst/Tasmota/discussions/24398#discussioncomment-15649631