### PR TITLE
Conditionalize USE_ENERGY_SENSOR and USE_SHELLY_PRO

### DIFF
--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -357,8 +357,10 @@
 
 #define USE_DS18x20                              // Add support for DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
 
-#define USE_ENERGY_SENSOR                      // Add energy to support Shelly Pro 4PM display (+38k code)
-#define USE_SHELLY_PRO
+#ifdef CONFIG_IDF_TARGET_ESP32
+  #define USE_ENERGY_SENSOR                      // Add energy to support Shelly Pro 4PM display (+38k code)
+  #define USE_SHELLY_PRO
+#endif
 
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
 #undef USE_MLX90614


### PR DESCRIPTION
## Description:

C3 and C6 LVGL builds has become too big.
Disable Energy Sensors and Shelly pro support for all MCUs except ESP32 in variant Tasmota32-lvgl

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
