### PR TITLE
Update platform URL to version 2026.02.00

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -138,7 +138,7 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2026.01.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2026.02.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:

** Update esp8266 Platform to be align with esp32 platform. No changes in Arduino esp8266

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
