### PR TITLE
I2S: full duplex, auto rx sample rate

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_0_i2s_0_config_idf51.ino
@@ -73,7 +73,7 @@ typedef struct{
     uint8_t   version = AUDIO_SETTINGS_VERSION;    // B00
 
     // runtime options, will be saved but ignored on setting read
-    bool      duplex = 0;           // B01 - depends on GPIO setting and SOC caps, DIN and DOUT on same port in GPIO means -> try to use duplex if possible
+    bool      full_duplex = 0;      // B01 - depends on GPIO setting and SOC caps, DIN and DOUT on same port in GPIO means ->  use full duplex
     bool      tx = 0;               // B02 - depends on GPIO setting
     bool      rx = 0;               // B03 - depends on GPIO setting
     bool      exclusive = 0;        // B04 - depends on GPIO setting, if WS is shared between 2 ports, drivers needs to be reinstalled before being used (Yuck... but we don't have a choice)


### PR DESCRIPTION
## Description:

Key changes:
- Properly enables full-duplex I2S (simultaneous TX+RX on one I2S channel) which is used on most ESP32-P4 boards with a codec like the ES8311.

- For microphone recordings:  automatic fallback to a compatible sampling rate

Smaller fixes and cosmetic changes:
- Rename sys.duplex → sys.full_duplex; makes intent clearer
- Fix I2SPrepareRx() returning wrong error code
- mic_stop marked volatile
- Remove duplicate break in Xdrv42() FUNC_LOOP

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
