### PR TITLE
BLE crashes on esp32 - similar to https://github.com/espressif/arduino-esp32/issues/12371

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
@@ -53,6 +53,11 @@
 # endif
 
 # if defined(ESP_PLATFORM) && defined(CONFIG_ENABLE_ARDUINO_DEPENDS)
+// fix for BLE crash Memory management
+// https://github.com/espressif/arduino-esp32/issues/12371
+#  if __has_include("esp32-hal-bt-mem.h")
+#    include "esp32-hal-bt-mem.h"
+#  endif
 #  include "esp32-hal-bt.h"
 # endif
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
