### PR TITLE
fix: dont free BT memory when in use

### DIFF
--- a/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
+++ b/lib/libesp32_div/esp-nimble-cpp/src/NimBLEDevice.cpp
@@ -53,6 +53,11 @@
 # endif
 
 # if defined(ESP_PLATFORM) && defined(CONFIG_ENABLE_ARDUINO_DEPENDS)
+// BLE Memory management
+// https://github.com/espressif/arduino-esp32/pull/12287
+#  if __has_include("esp32-hal-bt-mem.h")
+#    include "esp32-hal-bt-mem.h"
+#  endif
 #  include "esp32-hal-bt.h"
 # endif
 


### PR DESCRIPTION
## Description:

PR https://github.com/espressif/arduino-esp32/pull/12287 changed the BT memory management.
This resulted in release of BT memory when in use / needed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
