### PR TITLE
Add support for multi-byte chars like emojis (💡) in light device toggle buttons

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2952,7 +2952,6 @@ String HtmlEscape(const String unescaped) {
 String SettingsTextEscaped(uint32_t index) {
   return HtmlEscape(SettingsText(index));
 }
-
 // Truncate src to max UTF-8 codepoints with optional max visual width.
 // max_codepoints limits codepoints (0 = no limit)
 // max_width limits *approximated* visual width (0 = no limit):
@@ -2961,6 +2960,7 @@ String SettingsTextEscaped(uint32_t index) {
 // Multi-byte characters are never split mid-sequence
 // ZWJ sequences and skin tone modifiers are not recognized as single glyphs and may be split
 String Utf8Truncate(const char *src, uint32_t max_codepoints, uint32_t max_width = 0) {
+  if (!src) { return String(); }
   if (!max_codepoints && !max_width) {
     return String(src);
   }
@@ -2972,14 +2972,15 @@ String Utf8Truncate(const char *src, uint32_t max_codepoints, uint32_t max_width
     if (max_codepoints && chars >= max_codepoints) { break; }
     uint8_t lead = (uint8_t)src[bytes];
     size_t clen = 1;
-    if (lead >= 0xF0) { clen = 4; }
-    else if (lead >= 0xE0) { clen = 3; }
-    else if (lead >= 0xC0) { clen = 2; }
+    if      (lead >= 0xF0 && lead <= 0xF4) { clen = 4; }   // valid 4-byte lead
+    else if (lead >= 0xE0)                 { clen = 3; }   // 3-byte lead
+    else if (lead >= 0xC2)                 { clen = 2; }   // 2-byte lead (skip overlong 0xC0/0xC1)
+    // else: ASCII or stray continuation byte -> treat as 1 byte
+    if (bytes + clen > slen) { break; }
     size_t cwidth = (clen >= 3) ? 2 : 1;
     if (max_width && (width + cwidth > max_width)) { break; }
-    if (bytes + clen > slen) { break; }
-    width += cwidth;
     bytes += clen;
+    width += cwidth;
     chars++;
   }
   if (!bytes) {

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2953,15 +2953,15 @@ String SettingsTextEscaped(uint32_t index) {
   return HtmlEscape(SettingsText(index));
 }
 
-// Truncate src to max_chars UTF-8 codepoints with optional max visual width.
-// max_chars limits codepoints (0 = no limit)
-// max_width limits visual width (0 = no limit):
-//    narrow chars (1-2 byte: ASCII, Latin, Cyrillic) cost 1 unit
-//    wide chars (3-4 byte: CJK, emoji) cost 2 units
+// Truncate src to max UTF-8 codepoints with optional max visual width.
+// max_codepoints limits codepoints (0 = no limit)
+// max_width limits *approximated* visual width (0 = no limit):
+//    narrow chars (1-2 byte: ASCII, Latin, Cyrillic) approximated to cost 1 width unit
+//    wide chars (3-4 byte: CJK, emoji) approximated to cost 2 width units
 // Multi-byte characters are never split mid-sequence
 // ZWJ sequences and skin tone modifiers are not recognized as single glyphs and may be split
-String Utf8Truncate(const char *src, uint32_t max_chars, uint32_t max_width = 0) {
-  if (!max_chars && !max_width) {
+String Utf8Truncate(const char *src, uint32_t max_codepoints, uint32_t max_width = 0) {
+  if (!max_codepoints && !max_width) {
     return String(src);
   }
   size_t slen = strlen(src);
@@ -2969,7 +2969,7 @@ String Utf8Truncate(const char *src, uint32_t max_chars, uint32_t max_width = 0)
   size_t width = 0;
   size_t chars = 0;
   while (bytes < slen) {
-    if (max_chars && chars >= max_chars) { break; }
+    if (max_codepoints && chars >= max_codepoints) { break; }
     uint8_t lead = (uint8_t)src[bytes];
     size_t clen = 1;
     if (lead >= 0xF0) { clen = 4; }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2953,6 +2953,44 @@ String SettingsTextEscaped(uint32_t index) {
   return HtmlEscape(SettingsText(index));
 }
 
+// Truncate src to max_chars UTF-8 codepoints with optional max visual width.
+// max_chars limits codepoints (0 = no limit)
+// max_width limits visual width (0 = no limit):
+//    narrow chars (1-2 byte: ASCII, Latin, Cyrillic) cost 1 unit
+//    wide chars (3-4 byte: CJK, emoji) cost 2 units
+// Multi-byte characters are never split mid-sequence
+// ZWJ sequences and skin tone modifiers are not recognized as single glyphs and may be split
+String Utf8Truncate(const char *src, uint32_t max_chars, uint32_t max_width = 0) {
+  if (!max_chars && !max_width) {
+    return String(src);
+  }
+  size_t slen = strlen(src);
+  size_t bytes = 0;
+  size_t width = 0;
+  size_t chars = 0;
+  while (bytes < slen) {
+    if (max_chars && chars >= max_chars) { break; }
+    uint8_t lead = (uint8_t)src[bytes];
+    size_t clen = 1;
+    if (lead >= 0xF0) { clen = 4; }
+    else if (lead >= 0xE0) { clen = 3; }
+    else if (lead >= 0xC0) { clen = 2; }
+    size_t cwidth = (clen >= 3) ? 2 : 1;
+    if (max_width && (width + cwidth > max_width)) { break; }
+    if (bytes + clen > slen) { break; }
+    width += cwidth;
+    bytes += clen;
+    chars++;
+  }
+  if (!bytes) {
+    return String();
+  }
+  String result;
+  result.reserve(bytes);
+  result.concat(src, bytes);
+  return result;
+}
+
 String UrlEscape(const char *unescaped) {
   static const char *hex = "0123456789ABCDEF";
   String result;

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -429,7 +429,7 @@ const char HTTP_END[] PROGMEM =
   "</body>"
   "</html>";
 
-const char HTTP_DEVICE_CONTROL[] PROGMEM = "<td style='width:%d%%'><button id='o%d' onclick='la(\"&o=%d\");'>%s%s</button></td>";  // ?o is related to WebGetArg(PSTR("o"), tmp, sizeof(tmp))
+const char HTTP_DEVICE_CONTROL[] PROGMEM = "<td style='width:%d%%;max-width:0;'><button id='o%d' onclick='la(\"&o=%d\");'><span style='display:block;overflow:hidden;white-space:nowrap'>%s%s</span></button></td>";  // ?o is related to WebGetArg(PSTR("o"), tmp, sizeof(tmp))
 const char HTTP_DEVICE_STATE[] PROGMEM = "<td style='width:%d%%;text-align:center;font-weight:%s;font-size:%dpx'>%s</td>";
 
 const char HTTP_STATUS_STICKER[] PROGMEM =
@@ -1596,14 +1596,10 @@ void HandleRoot(void) {
         }
 
         bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
-        char first[2];
-        snprintf_P(first, sizeof(first), PSTR("%s"), PSTR(D_BUTTON_TOGGLE));
-        char butt_txt[4];
-        snprintf_P(butt_txt, sizeof(butt_txt), PSTR("%s"), (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : first);
         char number[8];
         WSContentSend_P(PSTR("<tr>"));
         WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-          butt_txt,
+          (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
           (set_button) ? "" : itoa(button_idx, number, 10));
         button_idx++;
 
@@ -1628,13 +1624,9 @@ void HandleRoot(void) {
 
           if (button_idx < (light_device + light_devices)) {
             bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
-            char first[2];
-            snprintf_P(first, sizeof(first), PSTR("%s"), PSTR(D_BUTTON_TOGGLE));
-            char butt_txt[4];
-            snprintf_P(butt_txt, sizeof(butt_txt), PSTR("%s"), (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : first);
             char number[8];
             WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-              butt_txt,
+              (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
               (set_button) ? "" : itoa(button_idx, number, 10));
             button_idx++;
             width = 85;
@@ -1655,15 +1647,10 @@ void HandleRoot(void) {
         stemp[0] = 'e'; stemp[1] = '0'; stemp[2] = '\0';  // e0
         for (uint32_t i = 0; i < light_devices; i++) {
           bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
-          char first[2];
-          snprintf_P(first, sizeof(first), PSTR("%s"), PSTR(D_BUTTON_TOGGLE));
-          char butt_txt[4];
-          snprintf_P(butt_txt, sizeof(butt_txt), PSTR("%s"),
-            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : first);
           char number[8];
           WSContentSend_P(PSTR("<tr>"));
           WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-            butt_txt,
+            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
             (set_button) ? "" : itoa(button_idx, number, 10));
           button_idx++;
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -429,7 +429,7 @@ const char HTTP_END[] PROGMEM =
   "</body>"
   "</html>";
 
-const char HTTP_DEVICE_CONTROL[] PROGMEM = "<td style='width:%d%%;max-width:0;'><button id='o%d' onclick='la(\"&o=%d\");'><span style='display:block;overflow:hidden;white-space:nowrap'>%s%s</span></button></td>";  // ?o is related to WebGetArg(PSTR("o"), tmp, sizeof(tmp))
+const char HTTP_DEVICE_CONTROL[] PROGMEM = "<td style='width:%d%%'><button id='o%d' onclick='la(\"&o=%d\");'>%s%s</button></td>";  // ?o is related to WebGetArg(PSTR("o"), tmp, sizeof(tmp))
 const char HTTP_DEVICE_STATE[] PROGMEM = "<td style='width:%d%%;text-align:center;font-weight:%s;font-size:%dpx'>%s</td>";
 
 const char HTTP_STATUS_STICKER[] PROGMEM =
@@ -1491,11 +1491,12 @@ void HandleRoot(void) {
         uint32_t button_ptr = 0;
         for (uint32_t button_idx = 1; button_idx <= TasmotaGlobal.devices_present; button_idx++) {
           if (bitRead(Web.light_shutter_button_mask, button_idx -1)) { continue; }  // Skip non-sequential light and/or shutter button
-          bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
+          const char* web_button = (button_idx <= MAX_BUTTON_TEXT) ? GetWebButton(button_idx -1) : "";
+          bool has_web_button = (web_button[0] != '\0');
           snprintf_P(stemp, sizeof(stemp), PSTR(" %d"), button_idx);
           WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / cols, button_idx, button_idx,
-            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : (cols < 5) ? PSTR(D_BUTTON_TOGGLE) : "",
-            (set_button) ? "" : (TasmotaGlobal.devices_present > 1) ? stemp : "");
+            (has_web_button) ? HtmlEscape(web_button).c_str() : (cols < 5) ? PSTR(D_BUTTON_TOGGLE) : "",
+            (has_web_button) ? "" : (TasmotaGlobal.devices_present > 1) ? stemp : "");
           button_ptr++;
           if (0 == button_ptr % cols) { WSContentSend_P(PSTR("</tr><tr>")); }
         }
@@ -1526,12 +1527,13 @@ void HandleRoot(void) {
           if (1 == j) { break; }           // Both buttons shown
 
           shutter_button_idx--;            // Right button is previous button (up)
-          bool set_button = ((shutter_button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(shutter_button_idx -1)));
+          const char* web_button = (shutter_button_idx <= MAX_BUTTON_TEXT) ? GetWebButton(shutter_button_idx -1) : "";
+          bool has_web_button = (web_button[0] != '\0');
           snprintf_P(stemp, sizeof(stemp), PSTR("Shutter %d"), shutter_idx +1);
           uint32_t shutter_real_to_percent_position = ShutterRealToPercentPosition(-9999, shutter_idx);
           Web.shutter_slider[shutter_idx] = (shutter_options & 1) ? (100 - shutter_real_to_percent_position) : shutter_real_to_percent_position;
           WSContentSend_P(HTTP_MSG_SLIDER_SHUTTER, 
-            (set_button) ? HtmlEscape(GetWebButton(shutter_button_idx -1)).c_str() : stemp,
+            (has_web_button) ? HtmlEscape(web_button).c_str() : stemp,
             shutter_idx +1,
             Web.shutter_slider[shutter_idx],
             shutter_idx +1);
@@ -1593,14 +1595,18 @@ void HandleRoot(void) {
             Web.slider[2],
             'n', 0);         // n0 - Value id
           WSContentSend_P(PSTR("</tr>"));
-        }
+        } 
 
-        bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
+        const char* web_button = (button_idx <= MAX_BUTTON_TEXT) ? GetWebButton(button_idx -1) : "";
+        bool has_web_button = (web_button[0] != '\0');
+        // web_button non-empty: truncate to max 4 chars or "visual width" of 4 (e.g. "Ligh", "💡💡", "台灯"). Latin char = 1 width, CJK/emoji char = 2 width
+        // web_button empty: take first char of D_BUTTON_TOGGLE + button index (e.g. "T1", "П1", "开1")
+        String butt_text = (has_web_button) ? HtmlEscape(Utf8Truncate(web_button, 4, 4)) : Utf8Truncate(D_BUTTON_TOGGLE, 1);
         char number[8];
         WSContentSend_P(PSTR("<tr>"));
         WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-          (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
-          (set_button) ? "" : itoa(button_idx, number, 10));
+          butt_text.c_str(),
+          (has_web_button) ? "" : itoa(button_idx, number, 10));
         button_idx++;
 
         Web.slider[3] = Settings->light_dimmer;
@@ -1623,11 +1629,15 @@ void HandleRoot(void) {
           WSContentSend_P(PSTR("<tr>"));
 
           if (button_idx < (light_device + light_devices)) {
-            bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
+            const char* web_button = (button_idx <= MAX_BUTTON_TEXT) ? GetWebButton(button_idx -1) : "";
+            bool has_web_button = (web_button[0] != '\0');
+            // web_button non-empty: truncate to max 4 chars or max "visual width" of 4 (e.g. "Ligh", "💡💡", "台灯"). Latin char = 1 width, CJK/emoji char = 2 width
+            // web_button empty: take first char of D_BUTTON_TOGGLE + button index (e.g. "T1", "П1", "开1")
+            String butt_text = (has_web_button) ? HtmlEscape(Utf8Truncate(web_button, 4, 4)) : Utf8Truncate(D_BUTTON_TOGGLE, 1);
             char number[8];
             WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-              (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
-              (set_button) ? "" : itoa(button_idx, number, 10));
+              butt_text.c_str(),
+              (has_web_button) ? "" : itoa(button_idx, number, 10));
             button_idx++;
             width = 85;
           }
@@ -1646,12 +1656,16 @@ void HandleRoot(void) {
       } else {  // Settings->flag3.pwm_multi_channels - SetOption68 1 - Enable multi-channels PWM instead of Color PWM
         stemp[0] = 'e'; stemp[1] = '0'; stemp[2] = '\0';  // e0
         for (uint32_t i = 0; i < light_devices; i++) {
-          bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
+          const char* web_button = (button_idx <= MAX_BUTTON_TEXT) ? GetWebButton(button_idx -1) : "";
+          bool has_web_button = (web_button[0] != '\0');
+          // web_button non-empty: truncate to max 4 chars or "visual width" of 4 (e.g. "Ligh", "💡💡", "台灯"). Latin char = 1 width, CJK/emoji char = 2 width
+          // web_button empty: take first char of D_BUTTON_TOGGLE + button index (e.g. "T1", "П1", "开1")
+          String butt_text = (has_web_button) ? HtmlEscape(Utf8Truncate(web_button, 4, 4)) : Utf8Truncate(D_BUTTON_TOGGLE, 1);
           char number[8];
           WSContentSend_P(PSTR("<tr>"));
           WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
-            (set_button) ? "" : itoa(button_idx, number, 10));
+            butt_text.c_str(),
+            (has_web_button) ? "" : itoa(button_idx, number, 10));
           button_idx++;
 
           stemp[1]++;        // e1 to e5 - Make unique ids

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1599,7 +1599,7 @@ void HandleRoot(void) {
         char number[8];
         WSContentSend_P(PSTR("<tr>"));
         WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-          (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
+          (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
           (set_button) ? "" : itoa(button_idx, number, 10));
         button_idx++;
 
@@ -1626,7 +1626,7 @@ void HandleRoot(void) {
             bool set_button = ((button_idx <= MAX_BUTTON_TEXT) && strlen(GetWebButton(button_idx -1)));
             char number[8];
             WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-              (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
+              (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
               (set_button) ? "" : itoa(button_idx, number, 10));
             button_idx++;
             width = 85;
@@ -1650,7 +1650,7 @@ void HandleRoot(void) {
           char number[8];
           WSContentSend_P(PSTR("<tr>"));
           WSContentSend_P(HTTP_DEVICE_CONTROL, 15, button_idx, button_idx,
-            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR("T"),
+            (set_button) ? HtmlEscape(GetWebButton(button_idx -1)).c_str() : PSTR(D_BUTTON_TOGGLE),
             (set_button) ? "" : itoa(button_idx, number, 10));
           button_idx++;
 


### PR DESCRIPTION
## Description:
Improve UTF-8 handling for light device toggle button labels (including emojis like 💡) by truncating safely before rendering.

- Add a UTF-8-aware truncation helper that avoids splitting multibyte characters and supports approximated visual-width limits for wider characters like CJK and emoji.
- When no WebButton string exists, fix non-English truncation by replacing the "fixed 1-byte truncation" with UTF-8-safe truncation to get the first, full codepoint from `D_BUTTON_TOGGLE`.
- When a WebButton string exists, replace the "fixed 3-byte truncation" with UTF-8-safe truncation based on a max of 4 codepoints and max visual width of 4.
- Cache WebButton text once per render block and reuse it (`has_web_button`) to avoid repeated lookups.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
