### PR TITLE
Matter add USE_MATTER_VERBOSE

### DIFF
--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -260,6 +260,7 @@
   #define BE_USE_DEBUG_MODULE             1
   #define BE_USE_SOLIDIFY_MODULE          1
   #define BE_MAPPING_ENABLE_INPUT_VALIDATION   1    // input validation for lv_mapping
+  #define USE_MATTER_VERBOSE              1         // enable names for actions and attributes in logs
 #endif // USE_BERRY_DEBUG
 
 /* Macro: BE_EXPLICIT_XXX

--- a/lib/libesp32/berry_matter/generate/be_matter_clusters.h
+++ b/lib/libesp32/berry_matter/generate/be_matter_clusters.h
@@ -1238,6 +1238,7 @@ const matter_attribute_t matter_Attributes_Common[] = {
 };
 
 const matter_cluster_t matterAllClusters[] = {
+#ifdef USE_MATTER_VERBOSE
   { 0x0003, "Identify", matter_Attributes_0003, matter_Commands_0003 },
   { 0x0004, "Groups", matter_Attributes_0004, matter_Commands_0004 },
   { 0x0005, "Scenes", matter_Attributes_0005, matter_Commands_0005 },
@@ -1303,5 +1304,6 @@ const matter_cluster_t matterAllClusters[] = {
   // { 0x050D, "ApplicationBasic", matter_Attributes_050D, matter_Commands_050D },
   // { 0x050E, "AccountLogin", matter_Attributes_050E, matter_Commands_050E },
   // { 0x0B04, "ElectricalMeasurement", matter_Attributes_0B04, matter_Commands_0B04 },
+#endif // USE_MATTER_VERBOSE
   { 0xFFFF, NULL, NULL },
 };

--- a/lib/libesp32/berry_matter/generate/be_matter_events.h
+++ b/lib/libesp32/berry_matter/generate/be_matter_events.h
@@ -14,6 +14,7 @@ typedef struct {
 // Must be sorted, cluster first, then attribute
 
 const matter_event_t matter_Events[] = {
+#ifdef USE_MATTER_VERBOSE
   // 0x001F Access Control Cluster
   { 0x001F, 0x00, "AccessControlEntryChanged" },
   { 0x001F, 0x00, "AccessControlExtensionChanged" },
@@ -54,5 +55,6 @@ const matter_event_t matter_Events[] = {
   { 0x0039, 0x01, "ShutDown" },
   { 0x0039, 0x02, "Leave" },
   { 0x0039, 0x03, "ReachableChanged" },
+#endif // USE_MATTER_VERBOSE
   { 0xFFFF, 0xFF, NULL }
 };

--- a/lib/libesp32/berry_matter/generate/be_matter_vendors.h
+++ b/lib/libesp32/berry_matter/generate/be_matter_vendors.h
@@ -14,6 +14,7 @@ typedef struct {
 
 const matter_vendor_t matter_Vendors[] = {
 
+#ifdef USE_MATTER_VERBOSE
   { 0x100B, "Signify"},
   { 0x101D, "Assa Abloy"},
   { 0x1021, "Legrand Group"},
@@ -32,9 +33,13 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x1188, "TP-Link"},
   { 0x118C, "Midea Group"},
   { 0x120B, "HEIMAN"},
+#endif // USE_MATTER_VERBOSE
   { 0x1217, "Amazon Alexa"},
+#ifdef USE_MATTER_VERBOSE
   { 0x1219, "ORVIBO"},
+#endif // USE_MATTER_VERBOSE
   { 0x125D, "Tuya"},
+#ifdef USE_MATTER_VERBOSE
   { 0x127F, "Nordic Semiconductor ASA"},
   { 0x1280, "Siterwell"},
   { 0x1286, "CoolKit"},
@@ -53,7 +58,10 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x1344, "Eltako"},
   { 0x1345, "Meross"},
   { 0x1346, "Rafael"},
+#endif // USE_MATTER_VERBOSE
   { 0x1349, "Apple Home"},
+  { 0x134B, "Nabu Casa"},
+#ifdef USE_MATTER_VERBOSE
   { 0x134E, "tado"},
   { 0x134F, "mediola"},
   { 0x1351, "HooRii Technology"},
@@ -64,8 +72,10 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x1371, "Tridonic"},
   { 0x1372, "innovation matters"},
   { 0x137F, "NEO"},
+#endif // USE_MATTER_VERBOSE
   { 0x1381, "Amazon Prime Video"},
   { 0x1384, "Apple Keychain"},
+#ifdef USE_MATTER_VERBOSE
   { 0x1386, "Skylux"},
   { 0x1387, "Qianyan"},
   { 0x138A, "Nature"},
@@ -86,9 +96,8 @@ const matter_vendor_t matter_Vendors[] = {
   { 0x141F, "Ductech"},
   { 0x142D, "QH"},
   { 0x142F, "QIACHIP"},
+#endif // USE_MATTER_VERBOSE
   { 0x6006, "Google LLC"},
-  
-  { 0x134B, "Nabu Casa"},
 
   { 0xFFFF, NULL },
 };

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1349,6 +1349,7 @@
 // -- Matter protocol ---------------------------------
   // #define USE_MATTER_DEVICE                      // Enable Matter device support (+380KB)
                                                     // Enabled by default in standard ESP32 binary
+  // #define USE_MATTER_VERBOSE                     // Enable verbose mode in logs (+16KB), automatically enabled with USE_BERRY_DEBUG
 
 #endif  // ESP32
 


### PR DESCRIPTION
## Description:

Now that Matter has reached maturity and stability, we remove the verbose names for commands and attributes. They can be re-enabled with `#define USE_MATTER_VERBOSE` or with `#define USE_BERRY_DEBUG`. This changes only impacts loglevel 3.

Saves 16KB when not enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
