### PR TITLE
Berry 'tasmota.urlbecload()' superseded by Extension Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Do not free BT memory when in use (#24480)
 
 ### Removed
+- Berry `tasmota.urlbecload()` superseded by Extension Manager
 
 
 ## [Released]

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -73,9 +73,6 @@ extern int tasm_apply_str_op(bvm *vm);
 extern int32_t be_Tasmota_version(void);
 BE_FUNC_CTYPE_DECLARE(be_Tasmota_version, "i", "-");
 
-extern bbool BerryBECLoader(const char * url);
-BE_FUNC_CTYPE_DECLARE(BerryBECLoader, "b", "s")
-
 #include "solidify/solidified_tasmota_class.h"
 #include "solidify/solidified_rule_matcher.h"
 #include "solidify/solidified_trigger_class.h"
@@ -201,7 +198,6 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     time_str, closure(class_Tasmota_time_str_closure)
     urlfetch, closure(class_Tasmota_urlfetch_closure)
     urlfetch_cmd, closure(class_Tasmota_urlfetch_cmd_closure)
-    urlbecload, static_ctype_func(BerryBECLoader)
 
     add_cron, closure(class_Tasmota_add_cron_closure)
     run_cron, closure(class_Tasmota_run_cron_closure)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1260,14 +1260,6 @@
                                                  // Note that only two ciphers are enabled: ECDHE_RSA_WITH_AES_128_GCM_SHA256, ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     #define USE_BERRY_WEBCLIENT_USERAGENT  "TasmotaClient" // default user-agent used, can be changed with `wc.set_useragent()`
     #define USE_BERRY_WEBCLIENT_TIMEOUT  2000    // Default timeout in milliseconds
-    // #define USE_BERRY_LEDS_PANEL                 // Add button to dynamically load the Leds Panel from a bec file online
-    #define USE_BERRY_LEDS_PANEL_URL             "http://ota.tasmota.com/tapp/leds_panel.bec"
-    // #define USE_BERRY_LVGL_PANEL                 // Add button to dynamically load the LVGL Panel from a bec file online
-    #define USE_BERRY_LVGL_PANEL_URL             "http://ota.tasmota.com/tapp/lvgl_panel.bec"
-    //#define USE_BERRY_PARTITION_WIZARD           // Add a button to dynamically load the Partion Wizard from a bec file online (+1.3KB Flash)
-    #define USE_BERRY_PARTITION_WIZARD_URL      "http://ota.tasmota.com/tapp/partition_wizard.bec"
-    //#define USE_BERRY_GPIOVIEWER                 // Add a button to dynamocally load the GPIO Viewer from a bec file online
-    #define USE_BERRY_GPIOVIEWER_URL            "http://ota.tasmota.com/tapp/gpioviewer.bec"
   #define USE_BERRY_TCPSERVER                    // Enable TCP socket server (+0.6k)
   // #define USE_BERRY_MQTTCLIENT                  // Enable standalone, independent Berry MQTT client (+5.1k)
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_0_berry_struct.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_0_berry_struct.ino
@@ -95,18 +95,6 @@ public:
   int32_t last_gc_heap_free = -1;       // Record the free heap size after the last garbage collection, -1 means not yet collected
   bool rules_busy = false;              // are we already processing rules, avoid infinite loop
   bool web_add_handler_done = false;    // did we already sent `web_add_handler` event
-#ifdef USE_BERRY_LEDS_PANEL
-  bool leds_panel_loaded = false; // did we already load Leds Panel
-#endif // USE_BERRY_LEDS_PANEL
-#ifdef USE_BERRY_LVGL_PANEL
-  bool lvgl_panel_loaded = true; // did we already load LVGL Panel, default true, changed to false when LVGL starts
-#endif // USE_BERRY_LVGL_PANEL
-#ifdef USE_BERRY_PARTITION_WIZARD
-  bool partition_wizard_loaded = false; // did we already load Parition_Wizard
-#endif // USE_BERRY_PARTITION_WIZARD
-#ifdef USE_BERRY_GPIOVIEWER
-  bool gpviewer_loaded = false;         // did we already load GPIOViewer
-#endif // USE_BERRY_GPIOVIEWER
   bool autoexec_done = false;           // do we still need to load 'autoexec.be'
   bool repl_active = false;             // is REPL running (activates log recording)
   // output log is stored as a LinkedList of buffers
@@ -117,62 +105,5 @@ BerrySupport berry;
 
 // multi-purpose serial logging
 extern "C" void serial_debug(const char * berry_buf, ...);
-
-
-/*********************************************************************************************\
- * Handle dynamic code from Berry bec files
- *
-\*********************************************************************************************/
-struct BeBECCode_t {
-  const char * display_name;      // display name in Web UI (must be URL encoded)
-  const char * id;                // id in requested URL, also don't load if the global name already exists in Berry
-  const char * url;               // absolute URL to download the bec file
-  const char * redirect;          // relative URI to redirect after loading
-  bool * loaded;
-};
-
-const BeBECCode_t BECCode[] = {
-#ifdef USE_BERRY_LEDS_PANEL
-  {
-    "Leds Panel",
-    "leds_panel",
-    USE_BERRY_LEDS_PANEL_URL,
-    "/?",
-    &berry.leds_panel_loaded
-  },
-#endif // USE_BERRY_LEDS_PANEL
-
-#if defined(USE_BERRY_LVGL_PANEL) && defined(USE_LVGL)
-  {
-    "LVGL Mirroring",
-    "lvgl_panel",
-    USE_BERRY_LVGL_PANEL_URL,
-    "/?",
-    &berry.lvgl_panel_loaded
-  },
-#endif // USE_BERRY_LEDS_PANEL
-
-#ifdef USE_BERRY_PARTITION_WIZARD
-  {
-    "Partition Wizard",
-    "partition_wizard",
-    USE_BERRY_PARTITION_WIZARD_URL,
-    "/part_wiz",
-    &berry.partition_wizard_loaded
-  },
-#endif // USE_BERRY_PARTITION_WIZARD
-
-#ifdef USE_BERRY_GPIOVIEWER
-  {
-    "GPIO Viewer",
-    "gpioviewer",
-    USE_BERRY_GPIOVIEWER_URL,
-    "/mn?",
-    &berry.gpviewer_loaded
-  },
-#endif // USE_BERRY_GPIOVIEWER
-
-};
-
 
 #endif  // USE_BERRY

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -801,113 +801,6 @@ void HandleBerryConsole(void)
   WSContentStop();
 }
 
-
-// const BeBECCode_t BECCode[] = {
-// struct BeBECCode_t {
-//   const char * display_name;      // display name in Web UI (must be URL encoded)
-//   const char * id;                // id in requested URL
-//   const char * url;               // absolute URL to download the bec file
-//   const char * redirect;          // relative URI to redirect after loading
-// };
-
-// Display Buttons to dynamically load bec files
-void HandleBerryBECLoaderButton(void) {
-  bvm * vm = berry.vm;
-  if (vm == NULL) { return; }       // Berry vm is not initialized
-
-  for (int32_t i = 0; i < ARRAY_SIZE(BECCode); i++) {
-    const BeBECCode_t &bec = BECCode[i];
-    if (!(*bec.loaded)) {
-      if (be_global_find(vm, be_newstr(vm, bec.id)) < 0) {    // the global name  doesn't exist
-        WSContentSend_P("<p></p><form id=but_part_mgr style='display:block;' action='tapp' method='get'><input type='hidden' name='n' value='%s'/><button>[Load %s]</button></form>", bec.id, bec.display_name);
-      } else {
-        *bec.loaded = true;
-      }
-    }
-  }
-}
-
-extern "C" bbool BerryBECLoader(const char * url);
-
-void HandleBerryBECLoader(void) {
-  String n = Webserver->arg("n");
-  for (int32_t i = 0; i < ARRAY_SIZE(BECCode); i++) {
-    const BeBECCode_t &bec = BECCode[i];
-    if (n.equals(bec.id)) {
-      if (BerryBECLoader(bec.url)) {
-        // All good, redirect
-        Webserver->sendHeader("Location", bec.redirect, true);
-        Webserver->send(302, "text/plain", "");
-        *bec.loaded  = true;
-      } else {
-        Webserver->sendHeader("Location", "/mn?", true);
-        Webserver->send(302, "text/plain", "");
-      }
-    }
-  }
-}
-
-// return true if successful
-extern "C" bbool BerryBECLoader(const char * url) {
-  bvm *vm = berry.vm;
-
-  HTTPClientLight cl;
-  cl.setUserAgent(USE_BERRY_WEBCLIENT_USERAGENT);
-  cl.setConnectTimeout(USE_BERRY_WEBCLIENT_TIMEOUT);   // set default timeout
-  cl.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-
-  if (!cl.begin(url)) {
-    AddLog(LOG_LEVEL_INFO, "BRY: unable to load URL '%s'", url);
-    // cl.end();
-    return false;
-  }
-  
-  uint32_t http_connect_time = millis();
-  int32_t httpCode = cl.GET();
-  if (httpCode != 200) {
-    AddLog(LOG_LEVEL_INFO, "BRY: unable to load URL '%s' code %i", url, httpCode);
-    // cl.end();
-    return false;
-  }
-
-  int32_t sz = cl.getSize();
-  AddLog(LOG_LEVEL_DEBUG, "BRY: Response http_code %i size %i bytes in %i ms", httpCode, sz, millis() - http_connect_time);
-  // abort if we exceed 32KB size, things will not go well otherwise
-  if (sz >= 32767 || sz <= 0) {
-    AddLog(LOG_LEVEL_DEBUG, "BRY: Response size too big %i bytes", sz);
-    return false;
-  }
-
-  // create a bytes object at top of stack.
-  // the streamwriter knows how to get it. 
-  uint8_t * buf = (uint8_t*) be_pushbytes(vm, nullptr, sz);
-  StreamBeBytesWriter memory_writer(vm);
-  int32_t written = cl.writeToStream(&memory_writer);
-  cl.end();  // free allocated memory ~16KB
-
-  size_t loaded_sz = 0;
-  const void * loaded_buf = be_tobytes(vm, -1, &loaded_sz);
-
-  FlashFileImplPtr fp = FlashFileImplPtr(new FlashFileImpl(loaded_buf, loaded_sz));
-  File * f_ptr = new File(fp);   // we need to allocate dynamically because be_close calls `delete` on it
-  bclosure* loaded_bec = be_bytecode_load_from_fs(vm, f_ptr);
-  be_pop(vm, 1);
-  if (loaded_bec != NULL) {
-    be_pushclosure(vm, loaded_bec);
-    be_call(vm, 0);
-    be_pop(vm, 1);
-  }
-   be_gc_collect(vm);   // force a GC to free the buffer now
-  return true;
-}
-
-#else   // No USE_WEBSERVER
-
-extern "C" bbool BerryBECLoader(const char * url) {
-  AddLog(LOG_LEVEL_INFO, "BRY: web server disabled");
-  return false;
-}
-
 #endif // USE_WEBSERVER
 
 /*********************************************************************************************\
@@ -1042,7 +935,6 @@ bool Xdrv52(uint32_t function)
         XdrvMailbox.index++;
       } else {
         WSContentSend_P(HTTP_FORM_BUTTON, PSTR("bc"), PSTR("Berry Scripting console"));
-        HandleBerryBECLoaderButton();               // display buttons to load BEC files
         callBerryEventDispatcher(PSTR("web_add_button"), nullptr, 0, nullptr);
         callBerryEventDispatcher(PSTR("web_add_console_button"), nullptr, 0, nullptr);
       }
@@ -1062,7 +954,6 @@ bool Xdrv52(uint32_t function)
         berry.web_add_handler_done = true;
       }
       WebServer_on("/bc", HandleBerryConsole);
-      WebServer_on("/tapp", HandleBerryBECLoader, HTTP_GET);
       break;
 #ifdef USE_WEB_STATUS_LINE
       case FUNC_WEB_STATUS_LEFT:


### PR DESCRIPTION
## Description:

Berry remove 'tasmota.urlbecload()' superseded by Extension Manager

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
