### PR TITLE
Berry avoid `tasmota.wifi()` returning bad values when wifi is turned off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Do not free BT memory when in use (#24480)
+- Berry avoid `tasmota.wifi()` returning bad values when wifi is turned off
 
 ### Removed
 - Berry `tasmota.urlbecload()` superseded by Extension Manager (#24493)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -258,7 +258,7 @@ extern "C" {
       // (-2) map instance, (-1) map
     }
     be_map_insert_str(vm, "mac", WiFiHelper::macAddress().c_str());
-    be_map_insert_bool(vm, "up", WifiHasIP());
+    be_map_insert_bool(vm, "up", WifiHasIP() && Settings->flag4.network_wifi);
     if (Settings->flag4.network_wifi) {
       int32_t rssi = WiFi.RSSI();
       bool show_rssi = false;


### PR DESCRIPTION
## Description:

When the wifi is turned off, there is a short time when `tasmota.wifi('up')` is true but wifi values are not available. This fix prevents it.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
