### PR TITLE
MDNS survive a Wifi restart

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -147,6 +147,9 @@ void WifiConfig(uint8_t type)
 #ifdef USE_EMULATION
     UdpDisconnect();
 #endif  // USE_EMULATION
+
+    WifiMDNSBeforeDisconnect();
+
     WiFi.disconnect();                       // Solve possible Wifi hangs
     delay(100);
     Wifi.config_type = type;
@@ -320,6 +323,9 @@ void WifiBegin(uint8_t flag, uint8_t channel) {
 #ifdef USE_WIFI_RANGE_EXTENDER
   if (WiFi.getMode() != WIFI_AP_STA || !RgxApUp()) {  // Preserve range extender connections (#17103)
 #endif  // USE_WIFI_RANGE_EXTENDER
+
+  WifiMDNSBeforeDisconnect();
+  
   WiFi.disconnect(true);  // Delete SDK wifi config
   delay(200);
   WifiSetMode(WIFI_STA);  // Disable AP mode
@@ -833,6 +839,62 @@ String WifiGetIPv6LinkLocalStr(void)
 {
   IPAddress ip;
   return WifiGetIPv6LinkLocal(&ip) ? ip.toString(true) : String();
+}
+
+// Do some cleaning before disconnecting Wifi
+//
+// // 1. BEFORE destroying the old WiFi netif (on user WiFi-off):
+// esp_netif_t *old_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+// if (old_sta) {
+//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP4);
+//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP6);
+// }
+// // Now destroy old_sta, deinit wifi, etc.
+
+// // 2. When WiFi is re-enabled, AFTER you have an IP (in your GOT_IP handler):
+// esp_netif_t *new_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+// if (new_sta) {
+//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP4);
+//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP6);
+// }
+void WifiMDNSBeforeDisconnect(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+  if (sta) {
+      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP4);
+      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP6);
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY)
+}
+
+void WifiMDNSAfterReconnectv4(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  // After WiFi is back up and you have IPs, get the new netif handle:
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+
+  // Tell mDNS to re-enable on this interface:
+  if (sta) {
+    char hostname[MDNS_NAME_BUF_LEN];
+    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP4);
+    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP4);
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY)
+}
+void WifiMDNSAfterReconnectv6(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  // After WiFi is back up and you have IPs, get the new netif handle:
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+
+  // Tell mDNS to re-enable on this interface:
+  if (sta) {
+    char hostname[MDNS_NAME_BUF_LEN];
+    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP6);
+    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP6);
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY)
 }
 
 
@@ -1527,6 +1589,7 @@ void WifiShutdown(bool option) {
   // option = true  - Disconnect with SDK wifi calibrate sector erase when WIFI_FORCE_RF_CAL_ERASE enabled
   delay(100);                 // Allow time for message xfer - disabled v6.1.0b
 
+  WifiMDNSBeforeDisconnect();
 #ifdef USE_EMULATION
   UdpDisconnect();
   delay(100);                 // Flush anything in the network buffers.
@@ -2058,6 +2121,9 @@ void WifiEvents(arduino_event_t *event) {
     case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
     {
 // Serial.printf(">>> event ARDUINO_EVENT_WIFI_STA_GOT_IP6 \n");
+      // Force republishing of MDNS entries from potential previous sessions
+      WifiMDNSAfterReconnectv6();
+
       IPAddress addr(IPv6, (const uint8_t*)event->event_info.got_ip6.ip6_info.ip.addr, event->event_info.got_ip6.ip6_info.ip.zone);
       AddLog(LOG_LEVEL_DEBUG, PSTR("%s: IPv6 %s %s"),
              event->event_id == ARDUINO_EVENT_ETH_GOT_IP6 ? "ETH" : "WIF",
@@ -2081,6 +2147,9 @@ void WifiEvents(arduino_event_t *event) {
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
     {
 // Serial.printf(">>> event ARDUINO_EVENT_WIFI_STA_GOT_IP \n");
+      // Force republishing of MDNS entries from potential previous sessions
+      WifiMDNSAfterReconnectv4();
+
       ip_addr_t ip_addr4;
       ip_addr_copy_from_ip4(ip_addr4, event->event_info.got_ip.ip_info.ip);
       AddLog(LOG_LEVEL_DEBUG, PSTR("WIF: IPv4 %_I, mask %_I, gateway %_I"),

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -46,6 +46,64 @@ const uint8_t WIFI_RETRY_OFFSET_SEC = WIFI_RETRY_SECONDS;  // seconds
   #include "esp_netif.h"
 #endif  // ESP32
 
+// Do some cleaning before disconnecting Wifi
+//
+// // 1. BEFORE destroying the old WiFi netif (on user WiFi-off):
+// esp_netif_t *old_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+// if (old_sta) {
+//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP4);
+//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP6);
+// }
+// // Now destroy old_sta, deinit wifi, etc.
+
+// // 2. When WiFi is re-enabled, AFTER you have an IP (in your GOT_IP handler):
+// esp_netif_t *new_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+// if (new_sta) {
+//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP4);
+//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP6);
+// }
+void WifiMDNSBeforeDisconnect(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+  if (sta) {
+      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP4);
+#ifdef USE_IPV6
+      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP6);
+#endif // USE_IPV6
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY)
+}
+
+void WifiMDNSAfterReconnectv4(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY)
+  // After WiFi is back up and you have IPs, get the new netif handle:
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+
+  // Tell mDNS to re-enable on this interface:
+  if (sta) {
+    char hostname[MDNS_NAME_BUF_LEN];
+    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP4);
+    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP4);
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY)
+}
+void WifiMDNSAfterReconnectv6(void)
+{
+#if defined(ESP32) && defined(USE_DISCOVERY) && defined(USE_IPV6)
+  // After WiFi is back up and you have IPs, get the new netif handle:
+  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+
+  // Tell mDNS to re-enable on this interface:
+  if (sta) {
+    char hostname[MDNS_NAME_BUF_LEN];
+    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP6);
+    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP6);
+  }
+#endif // defined(ESP32) && defined(USE_DISCOVERY) && defined(USE_IPV6)
+}
+
 /**
  * Converts WiFi RSSI (signal strength) to a quality percentage
  * 
@@ -839,62 +897,6 @@ String WifiGetIPv6LinkLocalStr(void)
 {
   IPAddress ip;
   return WifiGetIPv6LinkLocal(&ip) ? ip.toString(true) : String();
-}
-
-// Do some cleaning before disconnecting Wifi
-//
-// // 1. BEFORE destroying the old WiFi netif (on user WiFi-off):
-// esp_netif_t *old_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-// if (old_sta) {
-//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP4);
-//     mdns_netif_action(old_sta, MDNS_EVENT_DISABLE_IP6);
-// }
-// // Now destroy old_sta, deinit wifi, etc.
-
-// // 2. When WiFi is re-enabled, AFTER you have an IP (in your GOT_IP handler):
-// esp_netif_t *new_sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-// if (new_sta) {
-//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP4);
-//     mdns_netif_action(new_sta, MDNS_EVENT_ENABLE_IP6);
-// }
-void WifiMDNSBeforeDisconnect(void)
-{
-#if defined(ESP32) && defined(USE_DISCOVERY)
-  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-  if (sta) {
-      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP4);
-      mdns_netif_action(sta, MDNS_EVENT_DISABLE_IP6);
-  }
-#endif // defined(ESP32) && defined(USE_DISCOVERY)
-}
-
-void WifiMDNSAfterReconnectv4(void)
-{
-#if defined(ESP32) && defined(USE_DISCOVERY)
-  // After WiFi is back up and you have IPs, get the new netif handle:
-  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-
-  // Tell mDNS to re-enable on this interface:
-  if (sta) {
-    char hostname[MDNS_NAME_BUF_LEN];
-    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP4);
-    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP4);
-  }
-#endif // defined(ESP32) && defined(USE_DISCOVERY)
-}
-void WifiMDNSAfterReconnectv6(void)
-{
-#if defined(ESP32) && defined(USE_DISCOVERY)
-  // After WiFi is back up and you have IPs, get the new netif handle:
-  esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
-
-  // Tell mDNS to re-enable on this interface:
-  if (sta) {
-    char hostname[MDNS_NAME_BUF_LEN];
-    mdns_netif_action(sta, MDNS_EVENT_ENABLE_IP6);
-    mdns_netif_action(sta, MDNS_EVENT_ANNOUNCE_IP6);
-  }
-#endif // defined(ESP32) && defined(USE_DISCOVERY)
 }
 
 


### PR DESCRIPTION
## Description:

When wifi is restarted with `wifi 0` followed by `wifi 1`, all MDNS entries published by Matter are lost, which is abnormal. This patch forces a reattachment of MDNS entries to the newly created Wifi connection.

Btw, there is still a Wifi restart crash which looks unrelated to MDNS.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
