### PR TITLE
Don't send extraneous '0\r\n\r\n' with non-chunked HTTP/1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Do not free BT memory when in use (#24480)
 - Berry avoid `tasmota.wifi()` returning bad values when wifi is turned off
+- Don't send extraneous `0\r\n\r\n` with non-chunked HTTP/1.0
 
 ### Removed
 - Berry `tasmota.urlbecload()` superseded by Extension Manager (#24493)

--- a/lib/default/TasmotaWebServer/library.json
+++ b/lib/default/TasmotaWebServer/library.json
@@ -1,0 +1,17 @@
+{
+    "name": "TasmotaWebServer",
+    "version": "1.0.0",
+    "keywords": [
+      "webserver", "TasmotaWebServer"
+    ],
+    "description": "Customization of WebServer for both ESP8266 and ESP32",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/arendst/Tasmota/lib/TasmotaWebServer"
+    },
+    "frameworks": "arduino",
+    "platforms": [
+      "espressif8266", "espressif32"
+    ]
+}

--- a/lib/default/TasmotaWebServer/library.properties
+++ b/lib/default/TasmotaWebServer/library.properties
@@ -1,0 +1,9 @@
+name=TasmotaWebServer
+version=1.0.0
+author=Theo Arends
+maintainer=Theo Arends <theo@arends.com>
+sentence=Customization of WebServer for both ESP8266 and ESP32
+paragraph=
+category=
+url=
+architectures=esp8266,esp32

--- a/lib/default/TasmotaWebServer/src/TasmotaWebServer.h
+++ b/lib/default/TasmotaWebServer/src/TasmotaWebServer.h
@@ -1,0 +1,51 @@
+/*
+  TasmotaWebServer.h - lib/default/TasmotaWebServer/library.json
+
+  Copyright (C) 2021  Theo Arends & Stephan Hadinger
+
+  This library is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __TASMOTA_WEBSERVER__
+#define __TASMOTA_WEBSERVER__
+
+#ifdef ESP8266
+#include <ESP8266WebServer.h>
+
+class TasmotaWebServer : public ESP8266WebServer
+{
+public:
+	TasmotaWebServer(int port) : ESP8266WebServer(port)
+	{
+	}
+
+  bool isChunked(void) const { return _chunked; }
+};
+#endif // ESP8266
+
+#ifdef ESP32
+#include <WebServer.h>
+
+class TasmotaWebServer : public WebServer
+{
+public:
+	TasmotaWebServer(int port) :WebServer(port)
+	{
+	}
+
+  bool isChunked(void) const { return _chunked; }
+};
+#endif // ESP32
+
+#endif // __TASMOTA_WEBSERVER__

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -60,7 +60,7 @@ const uint16_t HTTP_OTA_RESTART_RECONNECT_TIME = 24000;  // milliseconds - Allow
 const uint16_t HTTP_OTA_RESTART_RECONNECT_TIME = 10000;  // milliseconds - Allow time for restart and wifi reconnect
 #endif  // ESP32
 
-#include <ESP8266WebServer.h>
+#include "TasmotaWebServer.h"
 #include <DNSServer.h>
 
 #ifdef USE_UNISHOX_COMPRESSION
@@ -482,7 +482,7 @@ enum WebCmndStatus { WEBCMND_DONE, WEBCMND_WRONG_PARAMETERS, WEBCMND_CONNECT_FAI
                    };
 
 DNSServer *DnsServer;
-ESP8266WebServer *Webserver;
+TasmotaWebServer *Webserver;
 
 struct WEB {
   String chunk_buffer = "";                         // Could be max 2 * CHUNKED_BUFFER_SIZE
@@ -653,7 +653,7 @@ void StartWebserver(int type) {
     }
 
     if (!Webserver) {
-      Webserver = new ESP8266WebServer((HTTP_MANAGER == type || HTTP_MANAGER_RESET_ONLY == type) ? 80 : WEB_PORT);
+      Webserver = new TasmotaWebServer((HTTP_MANAGER == type || HTTP_MANAGER_RESET_ONLY == type) ? 80 : WEB_PORT);
 
       const char* headerkeys[] = { "Referer", "Host" };
       size_t headerkeyssize = sizeof(headerkeys) / sizeof(char*);
@@ -1186,9 +1186,11 @@ void WSContentEnd(void) {
 //  _WSContentSend("");                              // Signal end of chunked content using multiple writes
 
   // Fix UDP response #23613
-  const char *footer_empty = "0\r\n\r\n";
-  Webserver->client().write(footer_empty, 5);      // Signal end of chunked content in one write (doesn't clear core _chunked)
-  delay(5);
+  if (Webserver->isChunked()) {
+    const char *footer_empty = "0\r\n\r\n";
+    Webserver->client().write(footer_empty, 5);      // Signal end of chunked content in one write (doesn't clear core _chunked)
+    delay(5);
+  }
 
   Webserver->client().stop();
 #if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)

--- a/tasmota/tasmota_xdrv_driver/xdrv_21_wemo_multi.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_21_wemo_multi.ino
@@ -232,7 +232,7 @@ const char WEMO_SETUP_XML[] PROGMEM =
 class WemoSwitch {
 
 private:
-  ESP8266WebServer *_webServer = NULL;
+  TasmotaWebServer *_webServer = NULL;
   int _localPort = 80;
   int _deviceId;
 
@@ -255,7 +255,7 @@ private:
   }
 
 public:
-  WemoSwitch(int deviceId, ESP8266WebServer *webServer) {
+  WemoSwitch(int deviceId, TasmotaWebServer *webServer) {
     _deviceId = deviceId;
     _webServer = webServer;
 #ifdef USE_EMULATION_WEMO_DEBUG
@@ -269,7 +269,7 @@ public:
 #ifdef USE_EMULATION_WEMO_DEBUG
     AddLog(LOG_LEVEL_DEBUG, PSTR("WMO: Device #%d listening on port %d"), _deviceId, _localPort);
 #endif
-    _webServer = new ESP8266WebServer(_localPort);
+    _webServer = new TasmotaWebServer(_localPort);
 
     _webServer->begin();
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam_task.ino
@@ -288,7 +288,7 @@ extern FS *ffsp;
 #endif
 
 bool HttpCheckPriviledgedAccess(bool);
-extern ESP8266WebServer *Webserver;
+extern TasmotaWebServer *Webserver;
 
 SemaphoreHandle_t WebcamMutex = nullptr;
 
@@ -437,7 +437,7 @@ struct {
   volatile uint8_t  camPixelFormat; // 
 
   // our (separate) webserver on port 81
-  ESP8266WebServer *CamServer;
+  TasmotaWebServer *CamServer;
   // pointer to the first http streaming client in a list of multiple clients, or nullptr
   wc_client *client_p;
   struct PICSTORE picstore[MAX_PICSTORE];
@@ -1598,7 +1598,7 @@ uint32_t WcSetStreamserver(uint32_t flag) {
   if (flag) {
     if (!Wc.CamServer) {
       TasAutoMutex localmutex(&WebcamMutex, "HandleWebcamMjpeg", 20000);
-      Wc.CamServer = new ESP8266WebServer(81);
+      Wc.CamServer = new TasmotaWebServer(81);
       Wc.CamServer->on("/", HandleWebcamRoot);
       Wc.CamServer->on("/diff.mjpeg", HandleWebcamMjpegDiff);
       Wc.CamServer->on("/cam.mjpeg", HandleWebcamMjpeg);


### PR DESCRIPTION
## Description:

Create a new class `TasmotaWebServer` to unify and expand `ESP8266WebServer` (ESP8266) and `WebServer` (ESP32). This makes a cleaner abstraction than the current `ESP8266WebServer` wrapper.

Fixes the extraneous `0\r\n\r\n` with non-chunked HTTP/1.0

**Related issue (if applicable):** fixes #24508

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
