### PR TITLE
File upload improvements: "/ufsu" api mode, no interrupts disabling, cleaner confirmation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Do not free BT memory when in use (#24480)
 - Berry avoid `tasmota.wifi()` returning bad values when wifi is turned off (#24505)
 - Don't send extraneous `0\r\n\r\n` with non-chunked HTTP/1.0 (#24518)
+- File upload improvements: "/ufsu" api mode, no interrupts disanling, cleaner confirmation page
 
 ### Removed
 - Berry `tasmota.urlbecload()` superseded by Extension Manager (#24493)

--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -386,6 +386,17 @@ enum EmulationOptions {EMUL_NONE, EMUL_WEMO, EMUL_HUE, EMUL_MAX};
 
 enum TopicOptions { CMND, STAT, TELE, nu1, RESULT_OR_CMND, RESULT_OR_STAT, RESULT_OR_TELE };
 
+// Upload type used by HandleUploadLoop() to route incoming data.
+// Value 0 is invalid/unset. Each upload endpoint must set the appropriate
+// type before HandleUploadLoop() processes the first data block.
+// UPL_TASMOTA        - OTA firmware update (/u2)
+// UPL_SETTINGS       - Settings backup restore (/u2)
+// UPL_EFM8BB1        - Sonoff RF bridge EFM8BB1 firmware
+// UPL_TASMOTACLIENT  - Tasmota client (Arduino) hex file
+// UPL_EFR32          - Zigbee EZSP (EFR32) firmware
+// UPL_SHD            - Shelly dimmer firmware
+// UPL_CCL            - CC2530 Zigbee firmware via CCLoader
+// UPL_UFSFILE        - Filesystem file upload (/ufsu)
 enum UploadTypes { UPL_TASMOTA = 1, UPL_SETTINGS, UPL_EFM8BB1, UPL_TASMOTACLIENT, UPL_EFR32, UPL_SHD, UPL_CCL, UPL_UFSFILE };
 
 enum ExecuteCommandPowerOptions { POWER_OFF, POWER_ON, POWER_TOGGLE, POWER_BLINK, POWER_BLINK_STOP, POWER_OFF_FORCE,

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -3502,7 +3502,9 @@ void HandleUploadLoop(void) {
   if (Web.upload_error) {
     if (!upload_error_signalled) {
       if (UPL_TASMOTA == Web.upload_file_type) { Update.end(); }
-      UploadServices(1);
+      if (UPL_UFSFILE != Web.upload_file_type) {
+        UploadServices(1);
+      }
 
 //      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPLOAD "Upload error %d"), Web.upload_error);
 
@@ -3522,7 +3524,10 @@ void HandleUploadLoop(void) {
     WebGetArg("fsz", tmp, sizeof(tmp));                    // filesize
     upload_size = (!strlen(tmp)) ? 0 : atoi(tmp);
 
-    UploadServices(0);
+    // Filesystem uploads don't need to disable interrupts/services
+    if (UPL_UFSFILE != Web.upload_file_type) {
+      UploadServices(0);
+    }
 
     if (0 == upload.filename.c_str()[0]) {
       Web.upload_error = 1;  // No file selected
@@ -3667,7 +3672,9 @@ void HandleUploadLoop(void) {
 
   // ***** Step3: Finish upload file
   else if (UPLOAD_FILE_END == upload.status) {
-    UploadServices(1);
+    if (UPL_UFSFILE != Web.upload_file_type) {
+      UploadServices(1);
+    }
     if (UPL_SETTINGS == Web.upload_file_type) {
       if (!SettingsConfigRestore()) {
         Web.upload_error = 8;  // File invalid
@@ -3733,7 +3740,9 @@ void HandleUploadLoop(void) {
 
   // ***** Step4: Abort upload file
   else {
-    UploadServices(1);
+    if (UPL_UFSFILE != Web.upload_file_type) {
+      UploadServices(1);
+    }
     Web.upload_error = 7;  // Upload aborted
     if (UPL_TASMOTA == Web.upload_file_type) { Update.end(); }
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -1353,6 +1353,21 @@ const char HTTP_EDITOR_FORM_END[] PROGMEM =
 
 #endif  // #ifdef GUI_EDIT_FILE
 
+// Wrapper around HandleUploadLoop() for /ufsu file uploads.
+// HandleUploadLoop() is shared between OTA firmware updates (/u2) and filesystem
+// uploads (/ufsu), and uses Web.upload_file_type to distinguish them.
+// When uploading via the web UI, the browser first does a GET which calls
+// UfsDirectory() and sets upload_file_type = UPL_UFSFILE. But direct POST
+// requests (e.g. curl -F "file=@..." /ufsu) skip the GET, leaving
+// upload_file_type unset and causing HandleUploadLoop() to treat the file
+// as a firmware image, which fails.
+// This wrapper ensures upload_file_type is always set before entering the
+// shared upload handler.
+void HandleUploadUFSLoop(void) {
+  Web.upload_file_type = UPL_UFSFILE;
+  HandleUploadLoop();
+}
+
 void HandleUploadUFSDone(void) {
   if (!HttpCheckPriviledgedAccess()) { return; }
 
@@ -1382,7 +1397,7 @@ void HandleUploadUFSDone(void) {
   }
   WSContentSend_P(PSTR("</div><br>"));
 
-  XdrvCall(FUNC_WEB_ADD_MANAGEMENT_BUTTON);
+  WSContentSend_PD(UFS_WEB_DIR, "/", PSTR(D_MANAGE_FILE_SYSTEM));
 
   WSContentStop();
 }
@@ -1974,13 +1989,9 @@ bool Xdrv50(uint32_t function) {
       }
       break;
     case FUNC_WEB_ADD_HANDLER:
-//      Webserver->on(F("/ufsd"), UfsDirectory);
-//      Webserver->on(F("/ufsu"), HTTP_GET, UfsDirectory);
-//      Webserver->on(F("/ufsu"), HTTP_POST,[](){Webserver->sendHeader(F("Location"),F("/ufsu"));Webserver->send(303);}, HandleUploadLoop);
       Webserver->on("/ufsd", UfsDirectory);
       Webserver->on("/ufsu", HTTP_GET, UfsDirectory);
-      //Webserver->on("/ufsu", HTTP_POST,[](){Webserver->sendHeader(F("Location"),F("/ufsu"));Webserver->send(303);}, HandleUploadLoop);
-      Webserver->on("/ufsu", HTTP_POST, HandleUploadUFSDone, HandleUploadLoop);
+      Webserver->on("/ufsu", HTTP_POST, HandleUploadUFSDone, HandleUploadUFSLoop);
 #ifdef GUI_EDIT_FILE
       Webserver->on("/ufse", HTTP_GET, UfsEditor);
       Webserver->on("/ufse", HTTP_POST, UfsEditorUpload);


### PR DESCRIPTION
## Description:

File upload improvements:
- now you can use directly "/ufsu" API to upload a file without displaying the File Manager page first
- no interrupts disabling when file upload, to avoid Multicast reconnects
- GPIO Viewer button is not shown anymore when file upload is complete

Should I mention that it was all done by Claude Opus 4.6?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
