### PR TITLE
Fixing wrong data type in ULP.sleep()

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_ulp.ino
@@ -157,7 +157,7 @@ extern "C" {
 
     if (wake_up_s) {
       AddLog(LOG_LEVEL_INFO, PSTR("ULP: will wake up in %u seconds."), wake_up_s);
-      esp_sleep_enable_timer_wakeup(wake_up_s * 1000000);    
+      esp_sleep_enable_timer_wakeup(wake_up_s * 1000000ULL);    
     }
     esp_sleep_enable_ulp_wakeup();
     esp_deep_sleep_start();


### PR DESCRIPTION
Calculating microseconds in unsigned long long as expected by esp_sleep_enable_timer_wakeup

## Description:

**Related issue (if applicable):** fixes #24522

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
