### PR TITLE
Crash when shutting down Wifi with 'Wifi 0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - ESP8266 redesigned I2C Wire driver to support second I2C bus
 
 ### Fixed
+- Crash when shutting down Wifi with `Wifi 0`
 
 ### Removed
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
@@ -109,10 +109,37 @@ class Matter_UDPServer
   # Stops the server and remove driver
   def stop()
     if self.listening
-      self.udp_socket.stop()
+      self.udp_socket.close()
       self.listening = false
       # tasmota.remove_driver(self)
       tasmota.remove_fast_loop(self.loop_cb)
+    end
+  end
+
+  #############################################################
+  # Flush the UDP socket by closing it.
+  # Called before WiFi teardown to discard any queued packets
+  # whose pbufs reference the WiFi netif (which is about to be
+  # destroyed).  The fast_loop stays registered so that the
+  # server can be reopened without re-registering.
+  def flush_socket()
+    if self.listening && self.udp_socket != nil
+      self.udp_socket.close()
+      self.udp_socket = nil
+      self.packets_sent = []        # clear all packets awaiting ack, the remote will retry
+    end
+  end
+
+  #############################################################
+  # Reopen the UDP socket after WiFi teardown is complete.
+  # Creates a fresh socket with an empty receive buffer.
+  def reopen_socket()
+    if self.listening && self.udp_socket == nil
+      self.udp_socket = udp()
+      var ok = self.udp_socket.begin(self.addr, self.port)
+      if !ok
+        log("MTR: error reopening UDP server", 2)
+      end
     end
   end
 
@@ -161,6 +188,7 @@ class Matter_UDPServer
   #
   # Returns `true` if packet was successfully sent.
   def send(packet)
+    if self.udp_socket == nil   return false end
     var ok = self.udp_socket.send(packet.addr ? packet.addr : self.udp_socket.remote_ip, packet.port ? packet.port : self.udp_socket.remote_port, packet.raw)
     
     if ok

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -248,6 +248,26 @@ class Matter_Device
   end
 
   #############################################################
+  # Called on 'network_down' event, before WiFi teardown.
+  # Flush the UDP socket to discard any queued packets whose
+  # pbufs reference the WiFi netif (about to be destroyed).
+  def network_down()
+    if self.udp_server
+      self.udp_server.flush_socket()
+    end
+  end
+
+  #############################################################
+  # Called on 'network_up' event, after WiFi teardown when
+  # Ethernet is still active (or when WiFi reconnects).
+  # Reopen the UDP socket with a clean receive buffer.
+  def network_up()
+    if self.udp_server
+      self.udp_server.reopen_socket()
+    end
+  end
+
+  #############################################################
   # Callback when message is received.
   # Send to `message_handler`
   def msg_received(raw, addr, port)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -110,78 +110,79 @@ be_local_class(Matter_UDPPacket_sent,
     be_str_weak(Matter_UDPPacket_sent)
 );
 extern const bclass be_class_Matter_UDPServer;
-// compact class 'Matter_UDPServer' ktab size: 61, total: 103 (saved 336 bytes)
-static const bvalue be_ktab_class_Matter_UDPServer[61] = {
-  /* K0   */  be_nested_str_weak(loop),
-  /* K1   */  be_nested_str_weak(matter),
-  /* K2   */  be_nested_str_weak(UDPPacket_sent),
-  /* K3   */  be_nested_str_weak(send),
-  /* K4   */  be_nested_str_weak(msg_id),
-  /* K5   */  be_nested_str_weak(packets_sent),
-  /* K6   */  be_nested_str_weak(push),
-  /* K7   */  be_nested_str_weak(ack_message_counter),
-  /* K8   */  be_nested_str_weak(exchange_id),
-  /* K9   */  be_const_int(0),
-  /* K10  */  be_nested_str_weak(remove),
-  /* K11  */  be_nested_str_weak(tasmota),
-  /* K12  */  be_nested_str_weak(loglevel),
-  /* K13  */  be_nested_str_weak(log),
-  /* K14  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
-  /* K15  */  be_const_int(1),
-  /* K16  */  be_nested_str_weak(listening),
-  /* K17  */  be_nested_str_weak(udp_socket),
-  /* K18  */  be_nested_str_weak(udp),
-  /* K19  */  be_nested_str_weak(begin),
-  /* K20  */  be_nested_str_weak(addr),
-  /* K21  */  be_nested_str_weak(port),
-  /* K22  */  be_nested_str_weak(network_error),
-  /* K23  */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
-  /* K24  */  be_nested_str_weak(dispatch_cb),
-  /* K25  */  be_nested_str_weak(add_fast_loop),
-  /* K26  */  be_nested_str_weak(loop_cb),
-  /* K27  */  be_nested_str_weak(remote_ip),
-  /* K28  */  be_nested_str_weak(remote_port),
-  /* K29  */  be_nested_str_weak(raw),
-  /* K30  */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-  /* K31  */  be_const_int(3),
-  /* K32  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-  /* K33  */  be_nested_str_weak(stop),
-  /* K34  */  be_nested_str_weak(remove_fast_loop),
-  /* K35  */  be_nested_str_weak(device),
-  /* K36  */  be_nested_str_weak(),
-  /* K37  */  be_nested_str_weak(time_reached),
-  /* K38  */  be_nested_str_weak(next_try),
-  /* K39  */  be_nested_str_weak(retries),
-  /* K40  */  be_nested_str_weak(RETRIES),
-  /* K41  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Resending_X20packet_X20id_X3D_X25s_X20packet_X2Eretries_X3D_X25s),
-  /* K42  */  be_nested_str_weak(millis),
-  /* K43  */  be_nested_str_weak(_backoff_time),
-  /* K44  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
-  /* K45  */  be_nested_str_weak(session_id),
-  /* K46  */  be_const_class(be_class_Matter_UDPServer),
-  /* K47  */  be_nested_str_weak(math),
-  /* K48  */  be_nested_str_weak(rand),
-  /* K49  */  be_const_real_hex(0x3FCCCCCD),
-  /* K50  */  be_const_real_hex(0x3F800000),
-  /* K51  */  be_const_real_hex(0x3E800000),
-  /* K52  */  be_nested_str_weak(profiler),
-  /* K53  */  be_nested_str_weak(read),
-  /* K54  */  be_nested_str_weak(packet),
-  /* K55  */  be_nested_str_weak(start),
-  /* K56  */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-  /* K57  */  be_nested_str_weak(dump),
-  /* K58  */  be_const_int(2),
-  /* K59  */  be_nested_str_weak(MAX_PACKETS_READ),
-  /* K60  */  be_nested_str_weak(_resend_packets),
+// compact class 'Matter_UDPServer' ktab size: 62, total: 116 (saved 432 bytes)
+static const bvalue be_ktab_class_Matter_UDPServer[62] = {
+  /* K0   */  be_nested_str_weak(listening),
+  /* K1   */  be_nested_str_weak(udp_socket),
+  /* K2   */  be_nested_str_weak(close),
+  /* K3   */  be_nested_str_weak(packets_sent),
+  /* K4   */  be_nested_str_weak(matter),
+  /* K5   */  be_nested_str_weak(profiler),
+  /* K6   */  be_const_int(0),
+  /* K7   */  be_nested_str_weak(read),
+  /* K8   */  be_nested_str_weak(packet),
+  /* K9   */  be_nested_str_weak(start),
+  /* K10  */  be_const_int(1),
+  /* K11  */  be_nested_str_weak(remote_ip),
+  /* K12  */  be_nested_str_weak(remote_port),
+  /* K13  */  be_nested_str_weak(tasmota),
+  /* K14  */  be_nested_str_weak(loglevel),
+  /* K15  */  be_nested_str_weak(log),
+  /* K16  */  be_nested_str_weak(MTR_X3A_X20UDP_X20received_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+  /* K17  */  be_nested_str_weak(dispatch_cb),
+  /* K18  */  be_nested_str_weak(dump),
+  /* K19  */  be_const_int(2),
+  /* K20  */  be_nested_str_weak(MAX_PACKETS_READ),
+  /* K21  */  be_nested_str_weak(_resend_packets),
+  /* K22  */  be_const_class(be_class_Matter_UDPServer),
+  /* K23  */  be_nested_str_weak(math),
+  /* K24  */  be_nested_str_weak(rand),
+  /* K25  */  be_const_real_hex(0x3FCCCCCD),
+  /* K26  */  be_const_real_hex(0x3F800000),
+  /* K27  */  be_const_real_hex(0x3E800000),
+  /* K28  */  be_nested_str_weak(time_reached),
+  /* K29  */  be_nested_str_weak(next_try),
+  /* K30  */  be_nested_str_weak(retries),
+  /* K31  */  be_nested_str_weak(RETRIES),
+  /* K32  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Resending_X20packet_X20id_X3D_X25s_X20packet_X2Eretries_X3D_X25s),
+  /* K33  */  be_nested_str_weak(msg_id),
+  /* K34  */  be_const_int(3),
+  /* K35  */  be_nested_str_weak(send),
+  /* K36  */  be_nested_str_weak(millis),
+  /* K37  */  be_nested_str_weak(_backoff_time),
+  /* K38  */  be_nested_str_weak(remove),
+  /* K39  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
+  /* K40  */  be_nested_str_weak(session_id),
+  /* K41  */  be_nested_str_weak(addr),
+  /* K42  */  be_nested_str_weak(port),
+  /* K43  */  be_nested_str_weak(loop),
+  /* K44  */  be_nested_str_weak(device),
+  /* K45  */  be_nested_str_weak(),
+  /* K46  */  be_nested_str_weak(loop_cb),
+  /* K47  */  be_nested_str_weak(raw),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+  /* K49  */  be_nested_str_weak(MTR_X3A_X20error_X20sending_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+  /* K50  */  be_nested_str_weak(ack_message_counter),
+  /* K51  */  be_nested_str_weak(exchange_id),
+  /* K52  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
+  /* K53  */  be_nested_str_weak(UDPPacket_sent),
+  /* K54  */  be_nested_str_weak(push),
+  /* K55  */  be_nested_str_weak(udp),
+  /* K56  */  be_nested_str_weak(begin),
+  /* K57  */  be_nested_str_weak(MTR_X3A_X20error_X20reopening_X20UDP_X20server),
+  /* K58  */  be_nested_str_weak(remove_fast_loop),
+  /* K59  */  be_nested_str_weak(network_error),
+  /* K60  */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
+  /* K61  */  be_nested_str_weak(add_fast_loop),
 };
 
 
 extern const bclass be_class_Matter_UDPServer;
 
 /********************************************************************
-** Solidified function: every_50ms
+** Solidified function: flush_socket
 ********************************************************************/
-be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
+be_local_closure(class_Matter_UDPServer_flush_socket,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -192,12 +193,24 @@ be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(every_50ms),
+    be_str_weak(flush_socket),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[15]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x7806000B,  //  0001  JMPF	R1	#000E
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x20040202,  //  0004  NE	R1	R1	R2
+      0x78060007,  //  0005  JMPF	R1	#000E
+      0x88040101,  //  0006  GETMBR	R1	R0	K1
+      0x8C040302,  //  0007  GETMET	R1	R1	K2
+      0x7C040200,  //  0008  CALL	R1	1
+      0x4C040000,  //  0009  LDNIL	R1
+      0x90020201,  //  000A  SETMBR	R0	K1	R1
+      0x60040012,  //  000B  GETGBL	R1	G18
+      0x7C040000,  //  000C  CALL	R1	0
+      0x90020601,  //  000D  SETMBR	R0	K3	R1
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -205,12 +218,12 @@ be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_UDP
+** Solidified function: loop
 ********************************************************************/
-be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
+be_local_closure(class_Matter_UDPServer_loop,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    11,                          /* nstack */
+    1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -218,385 +231,68 @@ be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(send_UDP),
+    be_str_weak(loop),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0xB80A0200,  //  0000  GETNGBL	R2	K1
-      0x8C080502,  //  0001  GETMET	R2	R2	K2
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x8C0C0103,  //  0004  GETMET	R3	R0	K3
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x880C0504,  //  0007  GETMBR	R3	R2	K4
-      0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C0105,  //  0009  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  000A  GETMET	R3	R3	K6
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x88080307,  //  0000  GETMBR	R2	R1	K7
-      0x880C0308,  //  0001  GETMBR	R3	R1	K8
-      0x4C100000,  //  0002  LDNIL	R4
-      0x1C100404,  //  0003  EQ	R4	R2	R4
-      0x78120000,  //  0004  JMPF	R4	#0006
-      0x80000800,  //  0005  RET	0
-      0x58100009,  //  0006  LDCONST	R4	K9
-      0x6014000C,  //  0007  GETGBL	R5	G12
-      0x88180105,  //  0008  GETMBR	R6	R0	K5
-      0x7C140200,  //  0009  CALL	R5	1
-      0x14140805,  //  000A  LT	R5	R4	R5
-      0x7816001A,  //  000B  JMPF	R5	#0027
-      0x88140105,  //  000C  GETMBR	R5	R0	K5
-      0x94140A04,  //  000D  GETIDX	R5	R5	R4
-      0x88180B04,  //  000E  GETMBR	R6	R5	K4
-      0x1C180C02,  //  000F  EQ	R6	R6	R2
-      0x781A0013,  //  0010  JMPF	R6	#0025
-      0x88180B08,  //  0011  GETMBR	R6	R5	K8
-      0x1C180C03,  //  0012  EQ	R6	R6	R3
-      0x781A0010,  //  0013  JMPF	R6	#0025
-      0x88180105,  //  0014  GETMBR	R6	R0	K5
-      0x8C180D0A,  //  0015  GETMET	R6	R6	K10
-      0x5C200800,  //  0016  MOVE	R8	R4
-      0x7C180400,  //  0017  CALL	R6	2
-      0xB81A1600,  //  0018  GETNGBL	R6	K11
-      0x8C180D0C,  //  0019  GETMET	R6	R6	K12
-      0x54220003,  //  001A  LDINT	R8	4
-      0x7C180400,  //  001B  CALL	R6	2
-      0x781A0006,  //  001C  JMPF	R6	#0024
-      0xB81A1A00,  //  001D  GETNGBL	R6	K13
-      0x601C0008,  //  001E  GETGBL	R7	G8
-      0x5C200400,  //  001F  MOVE	R8	R2
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1C07,  //  0021  ADD	R7	K14	R7
+    ( &(const binstruction[59]) {  /* code */
+      0xB8060800,  //  0000  GETNGBL	R1	K4
+      0x88040305,  //  0001  GETMBR	R1	R1	K5
+      0x58080006,  //  0002  LDCONST	R2	K6
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C0C0604,  //  0005  EQ	R3	R3	R4
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x880C0101,  //  0008  GETMBR	R3	R0	K1
+      0x8C0C0707,  //  0009  GETMET	R3	R3	K7
+      0x88140108,  //  000A  GETMBR	R5	R0	K8
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x4C100000,  //  000C  LDNIL	R4
+      0x20100604,  //  000D  NE	R4	R3	R4
+      0x78120028,  //  000E  JMPF	R4	#0038
+      0x8C100309,  //  000F  GETMET	R4	R1	K9
+      0x7C100200,  //  0010  CALL	R4	1
+      0x90021003,  //  0011  SETMBR	R0	K8	R3
+      0x0008050A,  //  0012  ADD	R2	R2	K10
+      0x88100101,  //  0013  GETMBR	R4	R0	K1
+      0x8810090B,  //  0014  GETMBR	R4	R4	K11
+      0x88140101,  //  0015  GETMBR	R5	R0	K1
+      0x88140B0C,  //  0016  GETMBR	R5	R5	K12
+      0xB81A1A00,  //  0017  GETNGBL	R6	K13
+      0x8C180D0E,  //  0018  GETMET	R6	R6	K14
+      0x54220003,  //  0019  LDINT	R8	4
+      0x7C180400,  //  001A  CALL	R6	2
+      0x781A0007,  //  001B  JMPF	R6	#0024
+      0xB81A1E00,  //  001C  GETNGBL	R6	K15
+      0x601C0018,  //  001D  GETGBL	R7	G24
+      0x58200010,  //  001E  LDCONST	R8	K16
+      0x5C240800,  //  001F  MOVE	R9	R4
+      0x5C280A00,  //  0020  MOVE	R10	R5
+      0x7C1C0600,  //  0021  CALL	R7	3
       0x54220003,  //  0022  LDINT	R8	4
       0x7C180400,  //  0023  CALL	R6	2
-      0x70020000,  //  0024  JMP		#0026
-      0x0010090F,  //  0025  ADD	R4	R4	K15
-      0x7001FFDF,  //  0026  JMP		#0007
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(class_Matter_UDPServer_start,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88080110,  //  0000  GETMBR	R2	R0	K16
-      0x740A0011,  //  0001  JMPT	R2	#0014
-      0xB80A2400,  //  0002  GETNGBL	R2	K18
-      0x7C080000,  //  0003  CALL	R2	0
-      0x90022202,  //  0004  SETMBR	R0	K17	R2
-      0x88080111,  //  0005  GETMBR	R2	R0	K17
-      0x8C080513,  //  0006  GETMET	R2	R2	K19
-      0x88100114,  //  0007  GETMBR	R4	R0	K20
-      0x88140115,  //  0008  GETMBR	R5	R0	K21
-      0x7C080600,  //  0009  CALL	R2	3
-      0x5C0C0400,  //  000A  MOVE	R3	R2
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0xB0062D17,  //  000C  RAISE	1	K22	K23
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x90022003,  //  000E  SETMBR	R0	K16	R3
-      0x90023001,  //  000F  SETMBR	R0	K24	R1
-      0xB80E1600,  //  0010  GETNGBL	R3	K11
-      0x8C0C0719,  //  0011  GETMET	R3	R3	K25
-      0x8814011A,  //  0012  GETMBR	R5	R0	K26
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send
-********************************************************************/
-be_local_closure(class_Matter_UDPServer_send,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(send),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0x88080111,  //  0000  GETMBR	R2	R0	K17
-      0x8C080503,  //  0001  GETMET	R2	R2	K3
-      0x88100314,  //  0002  GETMBR	R4	R1	K20
-      0x78120001,  //  0003  JMPF	R4	#0006
-      0x88100314,  //  0004  GETMBR	R4	R1	K20
-      0x70020001,  //  0005  JMP		#0008
-      0x88100111,  //  0006  GETMBR	R4	R0	K17
-      0x8810091B,  //  0007  GETMBR	R4	R4	K27
-      0x88140315,  //  0008  GETMBR	R5	R1	K21
-      0x78160001,  //  0009  JMPF	R5	#000C
-      0x88140315,  //  000A  GETMBR	R5	R1	K21
-      0x70020001,  //  000B  JMP		#000E
-      0x88140111,  //  000C  GETMBR	R5	R0	K17
-      0x88140B1C,  //  000D  GETMBR	R5	R5	K28
-      0x8818031D,  //  000E  GETMBR	R6	R1	K29
-      0x7C080800,  //  000F  CALL	R2	4
-      0x780A000D,  //  0010  JMPF	R2	#001F
-      0xB80E1600,  //  0011  GETNGBL	R3	K11
-      0x8C0C070C,  //  0012  GETMET	R3	R3	K12
-      0x54160003,  //  0013  LDINT	R5	4
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x780E0007,  //  0015  JMPF	R3	#001E
-      0xB80E1A00,  //  0016  GETNGBL	R3	K13
-      0x60100018,  //  0017  GETGBL	R4	G24
-      0x5814001E,  //  0018  LDCONST	R5	K30
-      0x88180314,  //  0019  GETMBR	R6	R1	K20
-      0x881C0315,  //  001A  GETMBR	R7	R1	K21
-      0x7C100600,  //  001B  CALL	R4	3
-      0x54160003,  //  001C  LDINT	R5	4
-      0x7C0C0400,  //  001D  CALL	R3	2
-      0x7002000C,  //  001E  JMP		#002C
-      0xB80E1600,  //  001F  GETNGBL	R3	K11
-      0x8C0C070C,  //  0020  GETMET	R3	R3	K12
-      0x5814001F,  //  0021  LDCONST	R5	K31
-      0x7C0C0400,  //  0022  CALL	R3	2
-      0x780E0007,  //  0023  JMPF	R3	#002C
-      0xB80E1A00,  //  0024  GETNGBL	R3	K13
-      0x60100018,  //  0025  GETGBL	R4	G24
-      0x58140020,  //  0026  LDCONST	R5	K32
-      0x88180314,  //  0027  GETMBR	R6	R1	K20
-      0x881C0315,  //  0028  GETMBR	R7	R1	K21
-      0x7C100600,  //  0029  CALL	R4	3
-      0x5814001F,  //  002A  LDCONST	R5	K31
-      0x7C0C0400,  //  002B  CALL	R3	2
-      0x80040400,  //  002C  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_Matter_UDPServer_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040110,  //  0000  GETMBR	R1	R0	K16
-      0x78060008,  //  0001  JMPF	R1	#000B
-      0x88040111,  //  0002  GETMBR	R1	R0	K17
-      0x8C040321,  //  0003  GETMET	R1	R1	K33
-      0x7C040200,  //  0004  CALL	R1	1
-      0x50040000,  //  0005  LDBOOL	R1	0	0
-      0x90022001,  //  0006  SETMBR	R0	K16	R1
-      0xB8061600,  //  0007  GETNGBL	R1	K11
-      0x8C040322,  //  0008  GETMET	R1	R1	K34
-      0x880C011A,  //  0009  GETMBR	R3	R0	K26
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(class_Matter_UDPServer_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(loop),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0x90024601,  //  0000  SETMBR	R0	K35	R1
-      0x780A0001,  //  0001  JMPF	R2	#0004
-      0x5C100400,  //  0002  MOVE	R4	R2
-      0x70020000,  //  0003  JMP		#0005
-      0x58100024,  //  0004  LDCONST	R4	K36
-      0x90022804,  //  0005  SETMBR	R0	K20	R4
-      0x780E0001,  //  0006  JMPF	R3	#0009
-      0x5C100600,  //  0007  MOVE	R4	R3
-      0x70020000,  //  0008  JMP		#000A
-      0x541215A3,  //  0009  LDINT	R4	5540
-      0x90022A04,  //  000A  SETMBR	R0	K21	R4
-      0x50100000,  //  000B  LDBOOL	R4	0	0
-      0x90022004,  //  000C  SETMBR	R0	K16	R4
-      0x60100012,  //  000D  GETGBL	R4	G18
-      0x7C100000,  //  000E  CALL	R4	0
-      0x90020A04,  //  000F  SETMBR	R0	K5	R4
-      0x84100000,  //  0010  CLOSURE	R4	P0
-      0x90023404,  //  0011  SETMBR	R0	K26	R4
-      0xA0000000,  //  0012  CLOSE	R0
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _resend_packets
-********************************************************************/
-be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(_resend_packets),
-    &be_const_str_solidified,
-    ( &(const binstruction[62]) {  /* code */
-      0x58040009,  //  0000  LDCONST	R1	K9
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0105,  //  0002  GETMBR	R3	R0	K5
-      0x7C080200,  //  0003  CALL	R2	1
-      0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A0036,  //  0005  JMPF	R2	#003D
-      0x540A0003,  //  0006  LDINT	R2	4
-      0x14080202,  //  0007  LT	R2	R1	R2
-      0x780A0033,  //  0008  JMPF	R2	#003D
-      0x88080105,  //  0009  GETMBR	R2	R0	K5
-      0x94080401,  //  000A  GETIDX	R2	R2	R1
-      0xB80E1600,  //  000B  GETNGBL	R3	K11
-      0x8C0C0725,  //  000C  GETMET	R3	R3	K37
-      0x88140526,  //  000D  GETMBR	R5	R2	K38
-      0x7C0C0400,  //  000E  CALL	R3	2
-      0x780E002A,  //  000F  JMPF	R3	#003B
-      0x880C0527,  //  0010  GETMBR	R3	R2	K39
-      0x88100128,  //  0011  GETMBR	R4	R0	K40
-      0x180C0604,  //  0012  LE	R3	R3	R4
-      0x780E0017,  //  0013  JMPF	R3	#002C
-      0xB80E1A00,  //  0014  GETNGBL	R3	K13
-      0x60100018,  //  0015  GETGBL	R4	G24
-      0x58140029,  //  0016  LDCONST	R5	K41
-      0x88180504,  //  0017  GETMBR	R6	R2	K4
-      0x881C0527,  //  0018  GETMBR	R7	R2	K39
-      0x7C100600,  //  0019  CALL	R4	3
-      0x5814001F,  //  001A  LDCONST	R5	K31
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x8C0C0103,  //  001C  GETMET	R3	R0	K3
-      0x5C140400,  //  001D  MOVE	R5	R2
-      0x7C0C0400,  //  001E  CALL	R3	2
-      0xB80E1600,  //  001F  GETNGBL	R3	K11
-      0x8C0C072A,  //  0020  GETMET	R3	R3	K42
-      0x7C0C0200,  //  0021  CALL	R3	1
-      0x8C10012B,  //  0022  GETMET	R4	R0	K43
-      0x88180527,  //  0023  GETMBR	R6	R2	K39
-      0x7C100400,  //  0024  CALL	R4	2
-      0x000C0604,  //  0025  ADD	R3	R3	R4
-      0x900A4C03,  //  0026  SETMBR	R2	K38	R3
-      0x880C0527,  //  0027  GETMBR	R3	R2	K39
-      0x000C070F,  //  0028  ADD	R3	R3	K15
-      0x900A4E03,  //  0029  SETMBR	R2	K39	R3
-      0x0004030F,  //  002A  ADD	R1	R1	K15
-      0x7002000D,  //  002B  JMP		#003A
-      0x880C0105,  //  002C  GETMBR	R3	R0	K5
-      0x8C0C070A,  //  002D  GETMET	R3	R3	K10
-      0x5C140200,  //  002E  MOVE	R5	R1
-      0x7C0C0400,  //  002F  CALL	R3	2
-      0xB80E1A00,  //  0030  GETNGBL	R3	K13
-      0x60100018,  //  0031  GETGBL	R4	G24
-      0x5814002C,  //  0032  LDCONST	R5	K44
-      0x8818052D,  //  0033  GETMBR	R6	R2	K45
-      0x881C0514,  //  0034  GETMBR	R7	R2	K20
-      0x88200515,  //  0035  GETMBR	R8	R2	K21
-      0x88240504,  //  0036  GETMBR	R9	R2	K4
-      0x7C100A00,  //  0037  CALL	R4	5
-      0x5814001F,  //  0038  LDCONST	R5	K31
-      0x7C0C0400,  //  0039  CALL	R3	2
-      0x70020000,  //  003A  JMP		#003C
-      0x0004030F,  //  003B  ADD	R1	R1	K15
-      0x7001FFC3,  //  003C  JMP		#0001
-      0x80000000,  //  003D  RET	0
+      0x88180111,  //  0024  GETMBR	R6	R0	K17
+      0x781A0004,  //  0025  JMPF	R6	#002B
+      0x8C180111,  //  0026  GETMET	R6	R0	K17
+      0x5C200600,  //  0027  MOVE	R8	R3
+      0x5C240800,  //  0028  MOVE	R9	R4
+      0x5C280A00,  //  0029  MOVE	R10	R5
+      0x7C180800,  //  002A  CALL	R6	4
+      0x8C180312,  //  002B  GETMET	R6	R1	K18
+      0x58200013,  //  002C  LDCONST	R8	K19
+      0x7C180400,  //  002D  CALL	R6	2
+      0x88180114,  //  002E  GETMBR	R6	R0	K20
+      0x14180406,  //  002F  LT	R6	R2	R6
+      0x781A0004,  //  0030  JMPF	R6	#0036
+      0x88180101,  //  0031  GETMBR	R6	R0	K1
+      0x8C180D07,  //  0032  GETMET	R6	R6	K7
+      0x7C180200,  //  0033  CALL	R6	1
+      0x5C0C0C00,  //  0034  MOVE	R3	R6
+      0x70020000,  //  0035  JMP		#0037
+      0x4C0C0000,  //  0036  LDNIL	R3
+      0x7001FFD3,  //  0037  JMP		#000C
+      0x8C100115,  //  0038  GETMET	R4	R0	K21
+      0x7C100200,  //  0039  CALL	R4	1
+      0x80000000,  //  003A  RET	0
     })
   )
 );
@@ -646,30 +342,30 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
     be_str_weak(_backoff_time),
     &be_const_str_solidified,
     ( &(const binstruction[29]) {  /* code */
-      0x5804002E,  //  0000  LDCONST	R1	K46
+      0x58040016,  //  0000  LDCONST	R1	K22
       0x84080000,  //  0001  CLOSURE	R2	P0
-      0xA40E5E00,  //  0002  IMPORT	R3	K47
+      0xA40E2E00,  //  0002  IMPORT	R3	K23
       0x5412012B,  //  0003  LDINT	R4	300
       0x6014000A,  //  0004  GETGBL	R5	G10
-      0x8C180730,  //  0005  GETMET	R6	R3	K48
+      0x8C180718,  //  0005  GETMET	R6	R3	K24
       0x7C180200,  //  0006  CALL	R6	1
       0x541E00FE,  //  0007  LDINT	R7	255
       0x2C180C07,  //  0008  AND	R6	R6	R7
       0x7C140200,  //  0009  CALL	R5	1
       0x541A00FE,  //  000A  LDINT	R6	255
       0x0C140A06,  //  000B  DIV	R5	R5	R6
-      0x24180109,  //  000C  GT	R6	R0	K9
+      0x24180106,  //  000C  GT	R6	R0	K6
       0x781A0001,  //  000D  JMPF	R6	#0010
-      0x0418010F,  //  000E  SUB	R6	R0	K15
+      0x0418010A,  //  000E  SUB	R6	R0	K10
       0x70020000,  //  000F  JMP		#0011
-      0x58180009,  //  0010  LDCONST	R6	K9
+      0x58180006,  //  0010  LDCONST	R6	K6
       0x5C1C0400,  //  0011  MOVE	R7	R2
-      0x58200031,  //  0012  LDCONST	R8	K49
+      0x58200019,  //  0012  LDCONST	R8	K25
       0x5C240C00,  //  0013  MOVE	R9	R6
       0x7C1C0400,  //  0014  CALL	R7	2
       0x081C0807,  //  0015  MUL	R7	R4	R7
-      0x08200B33,  //  0016  MUL	R8	R5	K51
-      0x00226408,  //  0017  ADD	R8	K50	R8
+      0x08200B1B,  //  0016  MUL	R8	R5	K27
+      0x00223408,  //  0017  ADD	R8	K26	R8
       0x081C0E08,  //  0018  MUL	R7	R7	R8
       0x60200009,  //  0019  GETGBL	R8	G9
       0x5C240E00,  //  001A  MOVE	R9	R7
@@ -682,11 +378,11 @@ be_local_closure(class_Matter_UDPServer__backoff_time,   /* name */
 
 
 /********************************************************************
-** Solidified function: loop
+** Solidified function: _resend_packets
 ********************************************************************/
-be_local_closure(class_Matter_UDPServer_loop,   /* name */
+be_local_closure(class_Matter_UDPServer__resend_packets,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -695,68 +391,97 @@ be_local_closure(class_Matter_UDPServer_loop,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_UDPServer,     /* shared constants */
-    be_str_weak(loop),
+    be_str_weak(_resend_packets),
     &be_const_str_solidified,
-    ( &(const binstruction[59]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x88040334,  //  0001  GETMBR	R1	R1	K52
-      0x58080009,  //  0002  LDCONST	R2	K9
-      0x880C0111,  //  0003  GETMBR	R3	R0	K17
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C0C0604,  //  0005  EQ	R3	R3	R4
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x880C0111,  //  0008  GETMBR	R3	R0	K17
-      0x8C0C0735,  //  0009  GETMET	R3	R3	K53
-      0x88140136,  //  000A  GETMBR	R5	R0	K54
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x4C100000,  //  000C  LDNIL	R4
-      0x20100604,  //  000D  NE	R4	R3	R4
-      0x78120028,  //  000E  JMPF	R4	#0038
-      0x8C100337,  //  000F  GETMET	R4	R1	K55
-      0x7C100200,  //  0010  CALL	R4	1
-      0x90026C03,  //  0011  SETMBR	R0	K54	R3
-      0x0008050F,  //  0012  ADD	R2	R2	K15
-      0x88100111,  //  0013  GETMBR	R4	R0	K17
-      0x8810091B,  //  0014  GETMBR	R4	R4	K27
-      0x88140111,  //  0015  GETMBR	R5	R0	K17
-      0x88140B1C,  //  0016  GETMBR	R5	R5	K28
-      0xB81A1600,  //  0017  GETNGBL	R6	K11
-      0x8C180D0C,  //  0018  GETMET	R6	R6	K12
-      0x54220003,  //  0019  LDINT	R8	4
-      0x7C180400,  //  001A  CALL	R6	2
-      0x781A0007,  //  001B  JMPF	R6	#0024
-      0xB81A1A00,  //  001C  GETNGBL	R6	K13
-      0x601C0018,  //  001D  GETGBL	R7	G24
-      0x58200038,  //  001E  LDCONST	R8	K56
-      0x5C240800,  //  001F  MOVE	R9	R4
-      0x5C280A00,  //  0020  MOVE	R10	R5
-      0x7C1C0600,  //  0021  CALL	R7	3
-      0x54220003,  //  0022  LDINT	R8	4
-      0x7C180400,  //  0023  CALL	R6	2
-      0x88180118,  //  0024  GETMBR	R6	R0	K24
-      0x781A0004,  //  0025  JMPF	R6	#002B
-      0x8C180118,  //  0026  GETMET	R6	R0	K24
-      0x5C200600,  //  0027  MOVE	R8	R3
-      0x5C240800,  //  0028  MOVE	R9	R4
-      0x5C280A00,  //  0029  MOVE	R10	R5
-      0x7C180800,  //  002A  CALL	R6	4
-      0x8C180339,  //  002B  GETMET	R6	R1	K57
-      0x5820003A,  //  002C  LDCONST	R8	K58
-      0x7C180400,  //  002D  CALL	R6	2
-      0x8818013B,  //  002E  GETMBR	R6	R0	K59
-      0x14180406,  //  002F  LT	R6	R2	R6
-      0x781A0004,  //  0030  JMPF	R6	#0036
-      0x88180111,  //  0031  GETMBR	R6	R0	K17
-      0x8C180D35,  //  0032  GETMET	R6	R6	K53
-      0x7C180200,  //  0033  CALL	R6	1
-      0x5C0C0C00,  //  0034  MOVE	R3	R6
-      0x70020000,  //  0035  JMP		#0037
-      0x4C0C0000,  //  0036  LDNIL	R3
-      0x7001FFD3,  //  0037  JMP		#000C
-      0x8C10013C,  //  0038  GETMET	R4	R0	K60
-      0x7C100200,  //  0039  CALL	R4	1
-      0x80000000,  //  003A  RET	0
+    ( &(const binstruction[62]) {  /* code */
+      0x58040006,  //  0000  LDCONST	R1	K6
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0103,  //  0002  GETMBR	R3	R0	K3
+      0x7C080200,  //  0003  CALL	R2	1
+      0x14080202,  //  0004  LT	R2	R1	R2
+      0x780A0036,  //  0005  JMPF	R2	#003D
+      0x540A0003,  //  0006  LDINT	R2	4
+      0x14080202,  //  0007  LT	R2	R1	R2
+      0x780A0033,  //  0008  JMPF	R2	#003D
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x94080401,  //  000A  GETIDX	R2	R2	R1
+      0xB80E1A00,  //  000B  GETNGBL	R3	K13
+      0x8C0C071C,  //  000C  GETMET	R3	R3	K28
+      0x8814051D,  //  000D  GETMBR	R5	R2	K29
+      0x7C0C0400,  //  000E  CALL	R3	2
+      0x780E002A,  //  000F  JMPF	R3	#003B
+      0x880C051E,  //  0010  GETMBR	R3	R2	K30
+      0x8810011F,  //  0011  GETMBR	R4	R0	K31
+      0x180C0604,  //  0012  LE	R3	R3	R4
+      0x780E0017,  //  0013  JMPF	R3	#002C
+      0xB80E1E00,  //  0014  GETNGBL	R3	K15
+      0x60100018,  //  0015  GETGBL	R4	G24
+      0x58140020,  //  0016  LDCONST	R5	K32
+      0x88180521,  //  0017  GETMBR	R6	R2	K33
+      0x881C051E,  //  0018  GETMBR	R7	R2	K30
+      0x7C100600,  //  0019  CALL	R4	3
+      0x58140022,  //  001A  LDCONST	R5	K34
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x8C0C0123,  //  001C  GETMET	R3	R0	K35
+      0x5C140400,  //  001D  MOVE	R5	R2
+      0x7C0C0400,  //  001E  CALL	R3	2
+      0xB80E1A00,  //  001F  GETNGBL	R3	K13
+      0x8C0C0724,  //  0020  GETMET	R3	R3	K36
+      0x7C0C0200,  //  0021  CALL	R3	1
+      0x8C100125,  //  0022  GETMET	R4	R0	K37
+      0x8818051E,  //  0023  GETMBR	R6	R2	K30
+      0x7C100400,  //  0024  CALL	R4	2
+      0x000C0604,  //  0025  ADD	R3	R3	R4
+      0x900A3A03,  //  0026  SETMBR	R2	K29	R3
+      0x880C051E,  //  0027  GETMBR	R3	R2	K30
+      0x000C070A,  //  0028  ADD	R3	R3	K10
+      0x900A3C03,  //  0029  SETMBR	R2	K30	R3
+      0x0004030A,  //  002A  ADD	R1	R1	K10
+      0x7002000D,  //  002B  JMP		#003A
+      0x880C0103,  //  002C  GETMBR	R3	R0	K3
+      0x8C0C0726,  //  002D  GETMET	R3	R3	K38
+      0x5C140200,  //  002E  MOVE	R5	R1
+      0x7C0C0400,  //  002F  CALL	R3	2
+      0xB80E1E00,  //  0030  GETNGBL	R3	K15
+      0x60100018,  //  0031  GETGBL	R4	G24
+      0x58140027,  //  0032  LDCONST	R5	K39
+      0x88180528,  //  0033  GETMBR	R6	R2	K40
+      0x881C0529,  //  0034  GETMBR	R7	R2	K41
+      0x8820052A,  //  0035  GETMBR	R8	R2	K42
+      0x88240521,  //  0036  GETMBR	R9	R2	K33
+      0x7C100A00,  //  0037  CALL	R4	5
+      0x58140022,  //  0038  LDCONST	R5	K34
+      0x7C0C0400,  //  0039  CALL	R3	2
+      0x70020000,  //  003A  JMP		#003C
+      0x0004030A,  //  003B  ADD	R1	R1	K10
+      0x7001FFC3,  //  003C  JMP		#0001
+      0x80000000,  //  003D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C04012B,  //  0000  GETMET	R1	R0	K43
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -788,35 +513,401 @@ be_local_closure(class_Matter_UDPServer_every_second,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(loop),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x90025801,  //  0000  SETMBR	R0	K44	R1
+      0x780A0001,  //  0001  JMPF	R2	#0004
+      0x5C100400,  //  0002  MOVE	R4	R2
+      0x70020000,  //  0003  JMP		#0005
+      0x5810002D,  //  0004  LDCONST	R4	K45
+      0x90025204,  //  0005  SETMBR	R0	K41	R4
+      0x780E0001,  //  0006  JMPF	R3	#0009
+      0x5C100600,  //  0007  MOVE	R4	R3
+      0x70020000,  //  0008  JMP		#000A
+      0x541215A3,  //  0009  LDINT	R4	5540
+      0x90025404,  //  000A  SETMBR	R0	K42	R4
+      0x50100000,  //  000B  LDBOOL	R4	0	0
+      0x90020004,  //  000C  SETMBR	R0	K0	R4
+      0x60100012,  //  000D  GETGBL	R4	G18
+      0x7C100000,  //  000E  CALL	R4	0
+      0x90020604,  //  000F  SETMBR	R0	K3	R4
+      0x84100000,  //  0010  CLOSURE	R4	P0
+      0x90025C04,  //  0011  SETMBR	R0	K46	R4
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_send,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(send),
+    &be_const_str_solidified,
+    ( &(const binstruction[51]) {  /* code */
+      0x88080101,  //  0000  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x780A0001,  //  0003  JMPF	R2	#0006
+      0x50080000,  //  0004  LDBOOL	R2	0	0
+      0x80040400,  //  0005  RET	1	R2
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x8C080523,  //  0007  GETMET	R2	R2	K35
+      0x88100329,  //  0008  GETMBR	R4	R1	K41
+      0x78120001,  //  0009  JMPF	R4	#000C
+      0x88100329,  //  000A  GETMBR	R4	R1	K41
+      0x70020001,  //  000B  JMP		#000E
+      0x88100101,  //  000C  GETMBR	R4	R0	K1
+      0x8810090B,  //  000D  GETMBR	R4	R4	K11
+      0x8814032A,  //  000E  GETMBR	R5	R1	K42
+      0x78160001,  //  000F  JMPF	R5	#0012
+      0x8814032A,  //  0010  GETMBR	R5	R1	K42
+      0x70020001,  //  0011  JMP		#0014
+      0x88140101,  //  0012  GETMBR	R5	R0	K1
+      0x88140B0C,  //  0013  GETMBR	R5	R5	K12
+      0x8818032F,  //  0014  GETMBR	R6	R1	K47
+      0x7C080800,  //  0015  CALL	R2	4
+      0x780A000D,  //  0016  JMPF	R2	#0025
+      0xB80E1A00,  //  0017  GETNGBL	R3	K13
+      0x8C0C070E,  //  0018  GETMET	R3	R3	K14
+      0x54160003,  //  0019  LDINT	R5	4
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x780E0007,  //  001B  JMPF	R3	#0024
+      0xB80E1E00,  //  001C  GETNGBL	R3	K15
+      0x60100018,  //  001D  GETGBL	R4	G24
+      0x58140030,  //  001E  LDCONST	R5	K48
+      0x88180329,  //  001F  GETMBR	R6	R1	K41
+      0x881C032A,  //  0020  GETMBR	R7	R1	K42
+      0x7C100600,  //  0021  CALL	R4	3
+      0x54160003,  //  0022  LDINT	R5	4
+      0x7C0C0400,  //  0023  CALL	R3	2
+      0x7002000C,  //  0024  JMP		#0032
+      0xB80E1A00,  //  0025  GETNGBL	R3	K13
+      0x8C0C070E,  //  0026  GETMET	R3	R3	K14
+      0x58140022,  //  0027  LDCONST	R5	K34
+      0x7C0C0400,  //  0028  CALL	R3	2
+      0x780E0007,  //  0029  JMPF	R3	#0032
+      0xB80E1E00,  //  002A  GETNGBL	R3	K15
+      0x60100018,  //  002B  GETGBL	R4	G24
+      0x58140031,  //  002C  LDCONST	R5	K49
+      0x88180329,  //  002D  GETMBR	R6	R1	K41
+      0x881C032A,  //  002E  GETMBR	R7	R1	K42
+      0x7C100600,  //  002F  CALL	R4	3
+      0x58140022,  //  0030  LDCONST	R5	K34
+      0x7C0C0400,  //  0031  CALL	R3	2
+      0x80040400,  //  0032  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_received_ack,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x88080332,  //  0000  GETMBR	R2	R1	K50
+      0x880C0333,  //  0001  GETMBR	R3	R1	K51
+      0x4C100000,  //  0002  LDNIL	R4
+      0x1C100404,  //  0003  EQ	R4	R2	R4
+      0x78120000,  //  0004  JMPF	R4	#0006
+      0x80000800,  //  0005  RET	0
+      0x58100006,  //  0006  LDCONST	R4	K6
+      0x6014000C,  //  0007  GETGBL	R5	G12
+      0x88180103,  //  0008  GETMBR	R6	R0	K3
+      0x7C140200,  //  0009  CALL	R5	1
+      0x14140805,  //  000A  LT	R5	R4	R5
+      0x7816001A,  //  000B  JMPF	R5	#0027
+      0x88140103,  //  000C  GETMBR	R5	R0	K3
+      0x94140A04,  //  000D  GETIDX	R5	R5	R4
+      0x88180B21,  //  000E  GETMBR	R6	R5	K33
+      0x1C180C02,  //  000F  EQ	R6	R6	R2
+      0x781A0013,  //  0010  JMPF	R6	#0025
+      0x88180B33,  //  0011  GETMBR	R6	R5	K51
+      0x1C180C03,  //  0012  EQ	R6	R6	R3
+      0x781A0010,  //  0013  JMPF	R6	#0025
+      0x88180103,  //  0014  GETMBR	R6	R0	K3
+      0x8C180D26,  //  0015  GETMET	R6	R6	K38
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x7C180400,  //  0017  CALL	R6	2
+      0xB81A1A00,  //  0018  GETNGBL	R6	K13
+      0x8C180D0E,  //  0019  GETMET	R6	R6	K14
+      0x54220003,  //  001A  LDINT	R8	4
+      0x7C180400,  //  001B  CALL	R6	2
+      0x781A0006,  //  001C  JMPF	R6	#0024
+      0xB81A1E00,  //  001D  GETNGBL	R6	K15
+      0x601C0008,  //  001E  GETGBL	R7	G8
+      0x5C200400,  //  001F  MOVE	R8	R2
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x001E6807,  //  0021  ADD	R7	K52	R7
+      0x54220003,  //  0022  LDINT	R8	4
+      0x7C180400,  //  0023  CALL	R6	2
+      0x70020000,  //  0024  JMP		#0026
+      0x0010090A,  //  0025  ADD	R4	R4	K10
+      0x7001FFDF,  //  0026  JMP		#0007
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_UDP
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_send_UDP,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(send_UDP),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0xB80A0800,  //  0000  GETNGBL	R2	K4
+      0x8C080535,  //  0001  GETMET	R2	R2	K53
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x8C0C0123,  //  0004  GETMET	R3	R0	K35
+      0x5C140400,  //  0005  MOVE	R5	R2
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x880C0521,  //  0007  GETMBR	R3	R2	K33
+      0x780E0003,  //  0008  JMPF	R3	#000D
+      0x880C0103,  //  0009  GETMBR	R3	R0	K3
+      0x8C0C0736,  //  000A  GETMET	R3	R3	K54
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reopen_socket
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_reopen_socket,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(reopen_socket),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060011,  //  0001  JMPF	R1	#0014
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C040202,  //  0004  EQ	R1	R1	R2
+      0x7806000D,  //  0005  JMPF	R1	#0014
+      0xB8066E00,  //  0006  GETNGBL	R1	K55
+      0x7C040000,  //  0007  CALL	R1	0
+      0x90020201,  //  0008  SETMBR	R0	K1	R1
+      0x88040101,  //  0009  GETMBR	R1	R0	K1
+      0x8C040338,  //  000A  GETMET	R1	R1	K56
+      0x880C0129,  //  000B  GETMBR	R3	R0	K41
+      0x8810012A,  //  000C  GETMBR	R4	R0	K42
+      0x7C040600,  //  000D  CALL	R1	3
+      0x5C080200,  //  000E  MOVE	R2	R1
+      0x740A0003,  //  000F  JMPT	R2	#0014
+      0xB80A1E00,  //  0010  GETNGBL	R2	K15
+      0x580C0039,  //  0011  LDCONST	R3	K57
+      0x58100013,  //  0012  LDCONST	R4	K19
+      0x7C080400,  //  0013  CALL	R2	2
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060008,  //  0001  JMPF	R1	#000B
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x50040000,  //  0005  LDBOOL	R1	0	0
+      0x90020001,  //  0006  SETMBR	R0	K0	R1
+      0xB8061A00,  //  0007  GETNGBL	R1	K13
+      0x8C04033A,  //  0008  GETMET	R1	R1	K58
+      0x880C012E,  //  0009  GETMBR	R3	R0	K46
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(class_Matter_UDPServer_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_UDPServer,     /* shared constants */
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0011,  //  0001  JMPT	R2	#0014
+      0xB80A6E00,  //  0002  GETNGBL	R2	K55
+      0x7C080000,  //  0003  CALL	R2	0
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x8C080538,  //  0006  GETMET	R2	R2	K56
+      0x88100129,  //  0007  GETMBR	R4	R0	K41
+      0x8814012A,  //  0008  GETMBR	R5	R0	K42
+      0x7C080600,  //  0009  CALL	R2	3
+      0x5C0C0400,  //  000A  MOVE	R3	R2
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0xB006773C,  //  000C  RAISE	1	K59	K60
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x90020003,  //  000E  SETMBR	R0	K0	R3
+      0x90022201,  //  000F  SETMBR	R0	K17	R1
+      0xB80E1A00,  //  0010  GETNGBL	R3	K13
+      0x8C0C073D,  //  0011  GETMET	R3	R3	K61
+      0x8814012E,  //  0012  GETMBR	R5	R0	K46
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_UDPServer
 ********************************************************************/
 be_local_class(Matter_UDPServer,
     9,
     NULL,
-    be_nested_map(22,
+    be_nested_map(24,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(every_50ms, -1), be_const_closure(class_Matter_UDPServer_every_50ms_closure) },
-        { be_const_key_weak(send_UDP, -1), be_const_closure(class_Matter_UDPServer_send_UDP_closure) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_UDPServer_received_ack_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_UDPServer_every_second_closure) },
-        { be_const_key_weak(stop, 18), be_const_closure(class_Matter_UDPServer_stop_closure) },
-        { be_const_key_weak(start, 4), be_const_closure(class_Matter_UDPServer_start_closure) },
-        { be_const_key_weak(listening, -1), be_const_var(3) },
-        { be_const_key_weak(send, -1), be_const_closure(class_Matter_UDPServer_send_closure) },
-        { be_const_key_weak(loop, -1), be_const_closure(class_Matter_UDPServer_loop_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_UDPServer_init_closure) },
-        { be_const_key_weak(udp_socket, 6), be_const_var(4) },
-        { be_const_key_weak(packet, -1), be_const_var(8) },
-        { be_const_key_weak(_backoff_time, -1), be_const_static_closure(class_Matter_UDPServer__backoff_time_closure) },
-        { be_const_key_weak(_resend_packets, -1), be_const_closure(class_Matter_UDPServer__resend_packets_closure) },
+        { be_const_key_weak(udp_socket, 16), be_const_var(4) },
+        { be_const_key_weak(start, -1), be_const_closure(class_Matter_UDPServer_start_closure) },
         { be_const_key_weak(addr, -1), be_const_var(0) },
-        { be_const_key_weak(dispatch_cb, 8), be_const_var(5) },
-        { be_const_key_weak(port, 12), be_const_var(1) },
+        { be_const_key_weak(device, 14), be_const_var(2) },
+        { be_const_key_weak(loop, -1), be_const_closure(class_Matter_UDPServer_loop_closure) },
+        { be_const_key_weak(dispatch_cb, 10), be_const_var(5) },
+        { be_const_key_weak(_backoff_time, -1), be_const_static_closure(class_Matter_UDPServer__backoff_time_closure) },
+        { be_const_key_weak(_resend_packets, 15), be_const_closure(class_Matter_UDPServer__resend_packets_closure) },
+        { be_const_key_weak(every_50ms, 21), be_const_closure(class_Matter_UDPServer_every_50ms_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_UDPServer_every_second_closure) },
+        { be_const_key_weak(stop, 11), be_const_closure(class_Matter_UDPServer_stop_closure) },
         { be_const_key_weak(packets_sent, -1), be_const_var(6) },
-        { be_const_key_weak(device, -1), be_const_var(2) },
         { be_const_key_weak(loop_cb, -1), be_const_var(7) },
+        { be_const_key_weak(RETRIES, 12), be_const_int(5) },
+        { be_const_key_weak(init, 4), be_const_closure(class_Matter_UDPServer_init_closure) },
+        { be_const_key_weak(send, -1), be_const_closure(class_Matter_UDPServer_send_closure) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_UDPServer_received_ack_closure) },
+        { be_const_key_weak(packet, -1), be_const_var(8) },
+        { be_const_key_weak(listening, -1), be_const_var(3) },
+        { be_const_key_weak(send_UDP, -1), be_const_closure(class_Matter_UDPServer_send_UDP_closure) },
+        { be_const_key_weak(reopen_socket, -1), be_const_closure(class_Matter_UDPServer_reopen_socket_closure) },
         { be_const_key_weak(MAX_PACKETS_READ, -1), be_const_int(4) },
-        { be_const_key_weak(RETRIES, 3), be_const_int(5) },
+        { be_const_key_weak(port, -1), be_const_var(1) },
+        { be_const_key_weak(flush_socket, 1), be_const_closure(class_Matter_UDPServer_flush_socket_closure) },
     })),
     be_str_weak(Matter_UDPServer)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_zz_Device.h
@@ -4,374 +4,224 @@
 \********************************************************************/
 #include "be_constobj.h"
 extern const bclass be_class_Matter_Device;
-// compact class 'Matter_Device' ktab size: 205, total: 439 (saved 1872 bytes)
-static const bvalue be_ktab_class_Matter_Device[205] = {
-  /* K0   */  be_nested_str_weak(sessions),
-  /* K1   */  be_nested_str_weak(count_active_fabrics),
-  /* K2   */  be_const_int(0),
-  /* K3   */  be_nested_str_weak(plugins_persist),
-  /* K4   */  be_nested_str_weak(save_param),
-  /* K5   */  be_nested_str_weak(json),
-  /* K6   */  be_nested_str_weak(tasmota),
-  /* K7   */  be_nested_str_weak(read_sensors),
-  /* K8   */  be_nested_str_weak(loglevel),
-  /* K9   */  be_const_int(3),
-  /* K10  */  be_nested_str_weak(log),
-  /* K11  */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
-  /* K12  */  be_nested_str_weak(load),
+// compact class 'Matter_Device' ktab size: 207, total: 443 (saved 1888 bytes)
+static const bvalue be_ktab_class_Matter_Device[207] = {
+  /* K0   */  be_nested_str_weak(udp_server),
+  /* K1   */  be_nested_str_weak(send_UDP),
+  /* K2   */  be_nested_str_weak(is_zigbee_present),
+  /* K3   */  be_nested_str_weak(matter_zigbee),
+  /* K4   */  be_const_class(be_class_Matter_Device),
+  /* K5   */  be_nested_str_weak(keys),
+  /* K6   */  be_nested_str_weak(push),
+  /* K7   */  be_nested_str_weak(stop_iteration),
+  /* K8   */  be_const_int(1),
+  /* K9   */  be_const_int(0),
+  /* K10  */  be_nested_str_weak(message_handler),
+  /* K11  */  be_nested_str_weak(msg_received),
+  /* K12  */  be_nested_str_weak(),
   /* K13  */  be_nested_str_weak(plugins),
-  /* K14  */  be_nested_str_weak(parse_sensors),
-  /* K15  */  be_const_int(1),
-  /* K16  */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-  /* K17  */  be_nested_str_weak(endpoint),
-  /* K18  */  be_nested_str_weak(invoke_request),
-  /* K19  */  be_nested_str_weak(status),
-  /* K20  */  be_nested_str_weak(probe_sensor_time),
-  /* K21  */  be_nested_str_weak(probe_sensor_timestamp),
-  /* K22  */  be_nested_str_weak(matter),
-  /* K23  */  be_nested_str_weak(jitter),
-  /* K24  */  be_nested_str_weak(attribute_updated),
-  /* K25  */  be_nested_str_weak(get_name),
-  /* K26  */  be_nested_str_weak(plugins_config_remotes),
-  /* K27  */  be_nested_str_weak(find),
-  /* K28  */  be_const_class(be_class_Matter_Device),
-  /* K29  */  be_nested_str_weak(keys),
-  /* K30  */  be_nested_str_weak(push),
-  /* K31  */  be_nested_str_weak(stop_iteration),
-  /* K32  */  be_nested_str_weak(tick),
-  /* K33  */  be_nested_str_weak(message_handler),
-  /* K34  */  be_nested_str_weak(every_50ms),
-  /* K35  */  be_nested_str_weak(),
-  /* K36  */  be_nested_str_weak(k2l),
-  /* K37  */  be_nested_str_weak(type),
-  /* K38  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
-  /* K39  */  be_nested_str_weak(button_handler),
-  /* K40  */  be_const_int(2),
-  /* K41  */  be_nested_str_weak(crypto),
-  /* K42  */  be_nested_str_weak(get_option),
-  /* K43  */  be_nested_str_weak(ui),
-  /* K44  */  be_nested_str_weak(UI),
-  /* K45  */  be_nested_str_weak(profiler),
-  /* K46  */  be_nested_str_weak(Profiler),
-  /* K47  */  be_nested_str_weak(next_ep),
-  /* K48  */  be_nested_str_weak(EP),
-  /* K49  */  be_nested_str_weak(ipv4only),
-  /* K50  */  be_nested_str_weak(disable_bridge_mode),
-  /* K51  */  be_nested_str_weak(commissioning),
-  /* K52  */  be_nested_str_weak(Commissioning),
-  /* K53  */  be_nested_str_weak(load_param),
-  /* K54  */  be_nested_str_weak(Session_Store),
-  /* K55  */  be_nested_str_weak(load_fabrics),
-  /* K56  */  be_nested_str_weak(MessageHandler),
-  /* K57  */  be_nested_str_weak(events),
-  /* K58  */  be_nested_str_weak(EventHandler),
-  /* K59  */  be_nested_str_weak(zigbee),
-  /* K60  */  be_nested_str_weak(init_zigbee),
-  /* K61  */  be_nested_str_weak(when_network_up),
-  /* K62  */  be_nested_str_weak(init_basic_commissioning),
-  /* K63  */  be_nested_str_weak(add_driver),
-  /* K64  */  be_nested_str_weak(register_commands),
-  /* K65  */  be_nested_str_weak(remove),
-  /* K66  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-  /* K67  */  be_nested_str_weak(get_fabric_id),
-  /* K68  */  be_nested_str_weak(copy),
-  /* K69  */  be_nested_str_weak(reverse),
-  /* K70  */  be_nested_str_weak(tohex),
-  /* K71  */  be_nested_str_weak(im),
-  /* K72  */  be_nested_str_weak(subs_shop),
-  /* K73  */  be_nested_str_weak(remove_by_fabric),
-  /* K74  */  be_nested_str_weak(mdns_remove_op_discovery),
-  /* K75  */  be_nested_str_weak(remove_fabric),
-  /* K76  */  be_nested_str_weak(save_fabrics),
-  /* K77  */  be_nested_str_weak(plugins_config),
-  /* K78  */  be_nested_str_weak(contains),
-  /* K79  */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
-  /* K80  */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
-  /* K81  */  be_nested_str_weak(get_endpoint),
-  /* K82  */  be_nested_str_weak(clean_remotes),
-  /* K83  */  be_nested_str_weak(signal_endpoints_changed),
-  /* K84  */  be_nested_str_weak(read_sensors_scheduler),
-  /* K85  */  be_nested_str_weak(every_250ms),
-  /* K86  */  be_nested_str_weak(autoconf_device),
-  /* K87  */  be_nested_str_weak(_start_udp),
-  /* K88  */  be_nested_str_weak(UDP_PORT),
-  /* K89  */  be_nested_str_weak(start_mdns_announce_hostnames),
-  /* K90  */  be_nested_str_weak(add_cmd),
-  /* K91  */  be_nested_str_weak(MtrJoin),
-  /* K92  */  be_nested_str_weak(MtrUpdate),
-  /* K93  */  be_nested_str_weak(MtrInfo),
-  /* K94  */  be_nested_str_weak(MtrInfo_one),
-  /* K95  */  be_nested_str_weak(int),
-  /* K96  */  be_nested_str_weak(find_plugin_by_friendly_name),
-  /* K97  */  be_nested_str_weak(resp_cmnd_done),
-  /* K98  */  be_nested_str_weak(msg_received),
-  /* K99  */  be_nested_str_weak(FILENAME),
-  /* K100 */  be_nested_str_weak(read),
-  /* K101 */  be_nested_str_weak(close),
-  /* K102 */  be_nested_str_weak(root_discriminator),
-  /* K103 */  be_nested_str_weak(distinguish),
-  /* K104 */  be_nested_str_weak(root_passcode),
-  /* K105 */  be_nested_str_weak(passcode),
-  /* K106 */  be_nested_str_weak(nextep),
-  /* K107 */  be_nested_str_weak(config),
-  /* K108 */  be_nested_str_weak(debug),
-  /* K109 */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
-  /* K110 */  be_nested_str_weak(adjust_next_ep),
-  /* K111 */  be_nested_str_weak(check_config_ep),
-  /* K112 */  be_nested_str_weak(remotes),
-  /* K113 */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
-  /* K114 */  be_nested_str_weak(io_error),
-  /* K115 */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
-  /* K116 */  be_nested_str_weak(_X7C),
-  /* K117 */  be_nested_str_weak(random),
-  /* K118 */  be_nested_str_weak(get),
-  /* K119 */  be_nested_str_weak(generate_random_passcode),
-  /* K120 */  be_nested_str_weak(http_remotes),
-  /* K121 */  be_nested_str_weak(get_timeout),
-  /* K122 */  be_nested_str_weak(set_timeout),
-  /* K123 */  be_nested_str_weak(HTTP_remote),
-  /* K124 */  be_nested_str_weak(set_info),
-  /* K125 */  be_nested_str_weak(start_root_basic_commissioning),
-  /* K126 */  be_nested_str_weak(stop_basic_commissioning),
-  /* K127 */  be_nested_str_weak(autoconf),
-  /* K128 */  be_nested_str_weak(Autoconf),
-  /* K129 */  be_nested_str_weak(autoconf_device_map),
-  /* K130 */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
-  /* K131 */  be_nested_str_weak(instantiate_plugins_from_config),
-  /* K132 */  be_nested_str_weak(introspect),
-  /* K133 */  be_nested_str_weak(module),
-  /* K134 */  be_nested_str_weak(matter_zigbee),
-  /* K135 */  be_nested_str_weak(udp_server),
-  /* K136 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-  /* K137 */  be_nested_str_weak(UDPServer),
-  /* K138 */  be_nested_str_weak(start),
-  /* K139 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-  /* K140 */  be_nested_str_weak(Path),
-  /* K141 */  be_nested_str_weak(cluster),
-  /* K142 */  be_nested_str_weak(attribute),
-  /* K143 */  be_nested_str_weak(attribute_updated_ctx),
-  /* K144 */  be_nested_str_weak(received_ack),
-  /* K145 */  be_nested_str_weak(update_remotes_info),
-  /* K146 */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
-  /* K147 */  be_nested_str_weak(true),
-  /* K148 */  be_nested_str_weak(false),
-  /* K149 */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
-  /* K150 */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
-  /* K151 */  be_nested_str_weak(dump),
-  /* K152 */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
-  /* K153 */  be_nested_str_weak(_X7D),
-  /* K154 */  be_nested_str_weak(w),
-  /* K155 */  be_nested_str_weak(write),
-  /* K156 */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
-  /* K157 */  be_nested_str_weak(_X20and_X20configuration),
-  /* K158 */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-  /* K159 */  be_nested_str_weak(get_info),
-  /* K160 */  be_nested_str_weak(every_second),
-  /* K161 */  be_nested_str_weak(remove_driver),
-  /* K162 */  be_nested_str_weak(stop),
-  /* K163 */  be_nested_str_weak(plugins_classes),
-  /* K164 */  be_nested_str_weak(DISPLAY_NAME),
-  /* K165 */  be_nested_str_weak(find_plugin_by_endpoint),
-  /* K166 */  be_nested_str_weak(state_json),
-  /* K167 */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
-  /* K168 */  be_nested_str_weak(publish_result),
-  /* K169 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
-  /* K170 */  be_nested_str_weak(_X27_X20skipping),
-  /* K171 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
-  /* K172 */  be_nested_str_weak(conf_to_log),
-  /* K173 */  be_nested_str_weak(contains_cluster),
-  /* K174 */  be_nested_str_weak(contains_attribute),
-  /* K175 */  be_nested_str_weak(send_UDP),
-  /* K176 */  be_nested_str_weak(http_remote),
-  /* K177 */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
-  /* K178 */  be_nested_str_weak(addr),
-  /* K179 */  be_nested_str_weak(resp_cmnd_str),
-  /* K180 */  be_nested_str_weak(Invalid_X20JSON),
-  /* K181 */  be_nested_str_weak(find_key_i),
-  /* K182 */  be_nested_str_weak(Ep),
-  /* K183 */  be_nested_str_weak(Name),
-  /* K184 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
-  /* K185 */  be_nested_str_weak(Invalid_X20Device),
-  /* K186 */  be_nested_str_weak(VIRTUAL),
-  /* K187 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
-  /* K188 */  be_nested_str_weak(consolidate_update_commands),
-  /* K189 */  be_nested_str_weak(find_list_i),
-  /* K190 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
-  /* K191 */  be_nested_str_weak(update_virtual),
-  /* K192 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
-  /* K193 */  be_nested_str_weak(resp_cmnd),
-  /* K194 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
-  /* K195 */  be_nested_str_weak(time_reached),
-  /* K196 */  be_nested_str_weak(_trigger_read_sensors),
-  /* K197 */  be_nested_str_weak(millis),
-  /* K198 */  be_nested_str_weak(Matter_Zigbee_Mapper),
-  /* K199 */  be_nested_str_weak(PathGenerator),
-  /* K200 */  be_nested_str_weak(is_direct),
-  /* K201 */  be_nested_str_weak(next_attribute),
-  /* K202 */  be_nested_str_weak(get_pi),
-  /* K203 */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
-  /* K204 */  be_nested_str_weak(is_zigbee_present),
+  /* K14  */  be_nested_str_weak(MtrInfo_one),
+  /* K15  */  be_nested_str_weak(endpoint),
+  /* K16  */  be_nested_str_weak(int),
+  /* K17  */  be_nested_str_weak(find_plugin_by_friendly_name),
+  /* K18  */  be_nested_str_weak(tasmota),
+  /* K19  */  be_nested_str_weak(resp_cmnd_done),
+  /* K20  */  be_nested_str_weak(read_sensors_scheduler),
+  /* K21  */  be_nested_str_weak(every_250ms),
+  /* K22  */  be_nested_str_weak(get_endpoint),
+  /* K23  */  be_nested_str_weak(find),
+  /* K24  */  be_nested_str_weak(plugins_config_remotes),
+  /* K25  */  be_nested_str_weak(json),
+  /* K26  */  be_nested_str_weak(update_remotes_info),
+  /* K27  */  be_nested_str_weak(_X7B_X22distinguish_X22_X3A_X25i_X2C_X22passcode_X22_X3A_X25i_X2C_X22ipv4only_X22_X3A_X25s_X2C_X22disable_bridge_mode_X22_X3A_X25s_X2C_X22nextep_X22_X3A_X25i),
+  /* K28  */  be_nested_str_weak(root_discriminator),
+  /* K29  */  be_nested_str_weak(root_passcode),
+  /* K30  */  be_nested_str_weak(ipv4only),
+  /* K31  */  be_nested_str_weak(true),
+  /* K32  */  be_nested_str_weak(false),
+  /* K33  */  be_nested_str_weak(disable_bridge_mode),
+  /* K34  */  be_nested_str_weak(next_ep),
+  /* K35  */  be_nested_str_weak(debug),
+  /* K36  */  be_nested_str_weak(_X2C_X22debug_X22_X3Atrue),
+  /* K37  */  be_nested_str_weak(plugins_persist),
+  /* K38  */  be_nested_str_weak(_X2C_X0A_X22config_X22_X3A),
+  /* K39  */  be_nested_str_weak(dump),
+  /* K40  */  be_nested_str_weak(plugins_config),
+  /* K41  */  be_nested_str_weak(_X2C_X0A_X22remotes_X22_X3A),
+  /* K42  */  be_nested_str_weak(_X7D),
+  /* K43  */  be_nested_str_weak(FILENAME),
+  /* K44  */  be_nested_str_weak(w),
+  /* K45  */  be_nested_str_weak(write),
+  /* K46  */  be_nested_str_weak(close),
+  /* K47  */  be_nested_str_weak(log),
+  /* K48  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20parameters_X25s),
+  /* K49  */  be_nested_str_weak(_X20and_X20configuration),
+  /* K50  */  be_const_int(2),
+  /* K51  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+  /* K52  */  be_nested_str_weak(_X7C),
+  /* K53  */  be_nested_str_weak(remove_driver),
+  /* K54  */  be_nested_str_weak(stop),
+  /* K55  */  be_nested_str_weak(k2l),
+  /* K56  */  be_nested_str_weak(type),
+  /* K57  */  be_nested_str_weak(_X20_X25s_X3A_X25s),
+  /* K58  */  be_nested_str_weak(remove),
+  /* K59  */  be_nested_str_weak(sessions),
+  /* K60  */  be_nested_str_weak(count_active_fabrics),
+  /* K61  */  be_nested_str_weak(save_param),
+  /* K62  */  be_nested_str_weak(autoconf),
+  /* K63  */  be_nested_str_weak(matter),
+  /* K64  */  be_nested_str_weak(Autoconf),
+  /* K65  */  be_nested_str_weak(autoconf_device_map),
+  /* K66  */  be_nested_str_weak(adjust_next_ep),
+  /* K67  */  be_nested_str_weak(MTR_X3A_X20autoconfig_X20_X3D_X20),
+  /* K68  */  be_const_int(3),
+  /* K69  */  be_nested_str_weak(instantiate_plugins_from_config),
+  /* K70  */  be_nested_str_weak(button_handler),
+  /* K71  */  be_nested_str_weak(cluster),
+  /* K72  */  be_nested_str_weak(attribute),
+  /* K73  */  be_nested_str_weak(find_plugin_by_endpoint),
+  /* K74  */  be_nested_str_weak(status),
+  /* K75  */  be_nested_str_weak(contains_cluster),
+  /* K76  */  be_nested_str_weak(contains_attribute),
+  /* K77  */  be_nested_str_weak(introspect),
+  /* K78  */  be_nested_str_weak(http_remotes),
+  /* K79  */  be_nested_str_weak(get),
+  /* K80  */  be_nested_str_weak(http_remote),
+  /* K81  */  be_nested_str_weak(MTR_X3A_X20remove_X20unused_X20remote_X3A_X20),
+  /* K82  */  be_nested_str_weak(addr),
+  /* K83  */  be_nested_str_weak(invoke_request),
+  /* K84  */  be_nested_str_weak(crypto),
+  /* K85  */  be_nested_str_weak(get_option),
+  /* K86  */  be_nested_str_weak(ui),
+  /* K87  */  be_nested_str_weak(UI),
+  /* K88  */  be_nested_str_weak(profiler),
+  /* K89  */  be_nested_str_weak(Profiler),
+  /* K90  */  be_nested_str_weak(tick),
+  /* K91  */  be_nested_str_weak(EP),
+  /* K92  */  be_nested_str_weak(commissioning),
+  /* K93  */  be_nested_str_weak(Commissioning),
+  /* K94  */  be_nested_str_weak(load_param),
+  /* K95  */  be_nested_str_weak(Session_Store),
+  /* K96  */  be_nested_str_weak(load_fabrics),
+  /* K97  */  be_nested_str_weak(MessageHandler),
+  /* K98  */  be_nested_str_weak(events),
+  /* K99  */  be_nested_str_weak(EventHandler),
+  /* K100 */  be_nested_str_weak(zigbee),
+  /* K101 */  be_nested_str_weak(init_zigbee),
+  /* K102 */  be_nested_str_weak(when_network_up),
+  /* K103 */  be_nested_str_weak(init_basic_commissioning),
+  /* K104 */  be_nested_str_weak(add_driver),
+  /* K105 */  be_nested_str_weak(register_commands),
+  /* K106 */  be_nested_str_weak(get_name),
+  /* K107 */  be_nested_str_weak(Path),
+  /* K108 */  be_nested_str_weak(im),
+  /* K109 */  be_nested_str_weak(subs_shop),
+  /* K110 */  be_nested_str_weak(attribute_updated_ctx),
+  /* K111 */  be_nested_str_weak(resp_cmnd_str),
+  /* K112 */  be_nested_str_weak(Invalid_X20JSON),
+  /* K113 */  be_nested_str_weak(find_key_i),
+  /* K114 */  be_nested_str_weak(Ep),
+  /* K115 */  be_nested_str_weak(Name),
+  /* K116 */  be_nested_str_weak(Invalid_X20_X27Ep_X27_X20attribute),
+  /* K117 */  be_nested_str_weak(Invalid_X20Device),
+  /* K118 */  be_nested_str_weak(VIRTUAL),
+  /* K119 */  be_nested_str_weak(Device_X20is_X20not_X20virtual),
+  /* K120 */  be_nested_str_weak(consolidate_update_commands),
+  /* K121 */  be_nested_str_weak(find_list_i),
+  /* K122 */  be_nested_str_weak(Invalid_X20attribute_X20_X27_X25s_X27),
+  /* K123 */  be_nested_str_weak(update_virtual),
+  /* K124 */  be_nested_str_weak(state_json),
+  /* K125 */  be_nested_str_weak(_X7B_X22_X25s_X22_X3A_X25s_X7D),
+  /* K126 */  be_nested_str_weak(resp_cmnd),
+  /* K127 */  be_nested_str_weak(Missing_X20_X27Device_X27_X20attribute),
+  /* K128 */  be_nested_str_weak(every_50ms),
+  /* K129 */  be_nested_str_weak(every_second),
+  /* K130 */  be_nested_str_weak(probe_sensor_time),
+  /* K131 */  be_nested_str_weak(probe_sensor_timestamp),
+  /* K132 */  be_nested_str_weak(jitter),
+  /* K133 */  be_nested_str_weak(read),
+  /* K134 */  be_nested_str_weak(load),
+  /* K135 */  be_nested_str_weak(distinguish),
+  /* K136 */  be_nested_str_weak(passcode),
+  /* K137 */  be_nested_str_weak(nextep),
+  /* K138 */  be_nested_str_weak(config),
+  /* K139 */  be_nested_str_weak(MTR_X3A_X20Load_config_X20_X3D_X20_X25s),
+  /* K140 */  be_nested_str_weak(check_config_ep),
+  /* K141 */  be_nested_str_weak(remotes),
+  /* K142 */  be_nested_str_weak(MTR_X3A_X20load_remotes_X20_X3D_X20),
+  /* K143 */  be_nested_str_weak(io_error),
+  /* K144 */  be_nested_str_weak(MTR_X3A_X20load_param_X20Exception_X3A),
+  /* K145 */  be_nested_str_weak(random),
+  /* K146 */  be_nested_str_weak(generate_random_passcode),
+  /* K147 */  be_nested_str_weak(MTR_X3A_X20Starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+  /* K148 */  be_nested_str_weak(UDPServer),
+  /* K149 */  be_nested_str_weak(start),
+  /* K150 */  be_nested_str_weak(reopen_socket),
+  /* K151 */  be_nested_str_weak(module),
+  /* K152 */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+  /* K153 */  be_nested_str_weak(get_fabric_id),
+  /* K154 */  be_nested_str_weak(copy),
+  /* K155 */  be_nested_str_weak(reverse),
+  /* K156 */  be_nested_str_weak(tohex),
+  /* K157 */  be_nested_str_weak(remove_by_fabric),
+  /* K158 */  be_nested_str_weak(mdns_remove_op_discovery),
+  /* K159 */  be_nested_str_weak(remove_fabric),
+  /* K160 */  be_nested_str_weak(save_fabrics),
+  /* K161 */  be_nested_str_weak(get_info),
+  /* K162 */  be_nested_str_weak(plugins_classes),
+  /* K163 */  be_nested_str_weak(DISPLAY_NAME),
+  /* K164 */  be_nested_str_weak(MTR_X3A_X20unknown_X20class_X20name_X20_X27),
+  /* K165 */  be_nested_str_weak(_X27_X20skipping),
+  /* K166 */  be_nested_str_weak(MTR_X3A_X20adding_X20endpoint_X20_X3D_X20_X25i_X20type_X3A_X25s_X25s),
+  /* K167 */  be_nested_str_weak(conf_to_log),
+  /* K168 */  be_nested_str_weak(signal_endpoints_changed),
+  /* K169 */  be_nested_str_weak(time_reached),
+  /* K170 */  be_nested_str_weak(_trigger_read_sensors),
+  /* K171 */  be_nested_str_weak(millis),
+  /* K172 */  be_nested_str_weak(MTR_X3A_X20endpoint_X20_X25s_X20collides_X20wit_X20aggregator_X2C_X20relocating_X20to_X20_X25s),
+  /* K173 */  be_nested_str_weak(attribute_updated),
+  /* K174 */  be_nested_str_weak(PathGenerator),
+  /* K175 */  be_nested_str_weak(is_direct),
+  /* K176 */  be_nested_str_weak(next_attribute),
+  /* K177 */  be_nested_str_weak(get_pi),
+  /* K178 */  be_nested_str_weak(contains),
+  /* K179 */  be_nested_str_weak(get_timeout),
+  /* K180 */  be_nested_str_weak(set_timeout),
+  /* K181 */  be_nested_str_weak(HTTP_remote),
+  /* K182 */  be_nested_str_weak(set_info),
+  /* K183 */  be_nested_str_weak(read_sensors),
+  /* K184 */  be_nested_str_weak(loglevel),
+  /* K185 */  be_nested_str_weak(MTR_X3A_X20read_sensors_X3A_X20),
+  /* K186 */  be_nested_str_weak(parse_sensors),
+  /* K187 */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+  /* K188 */  be_nested_str_weak(received_ack),
+  /* K189 */  be_nested_str_weak(flush_socket),
+  /* K190 */  be_nested_str_weak(MTR_X3A_X20Cannot_X20remove_X20an_X20enpoint_X20not_X20configured_X3A_X20),
+  /* K191 */  be_nested_str_weak(MTR_X3A_X20deleting_X20endpoint_X20_X3D_X20_X25i),
+  /* K192 */  be_nested_str_weak(clean_remotes),
+  /* K193 */  be_nested_str_weak(start_root_basic_commissioning),
+  /* K194 */  be_nested_str_weak(stop_basic_commissioning),
+  /* K195 */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+  /* K196 */  be_nested_str_weak(add_cmd),
+  /* K197 */  be_nested_str_weak(MtrJoin),
+  /* K198 */  be_nested_str_weak(MtrUpdate),
+  /* K199 */  be_nested_str_weak(MtrInfo),
+  /* K200 */  be_nested_str_weak(_X7B_X22MtrInfo_X22_X3A_X25s_X7D),
+  /* K201 */  be_nested_str_weak(publish_result),
+  /* K202 */  be_nested_str_weak(Matter_Zigbee_Mapper),
+  /* K203 */  be_nested_str_weak(autoconf_device),
+  /* K204 */  be_nested_str_weak(_start_udp),
+  /* K205 */  be_nested_str_weak(UDP_PORT),
+  /* K206 */  be_nested_str_weak(start_mdns_announce_hostnames),
 };
 
 
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: event_fabrics_saved
+** Solidified function: msg_send
 ********************************************************************/
-be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(event_fabrics_saved),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x24040302,  //  0003  GT	R1	R1	K2
-      0x78060005,  //  0004  JMPF	R1	#000B
-      0x88040103,  //  0005  GETMBR	R1	R0	K3
-      0x74060003,  //  0006  JMPT	R1	#000B
-      0x50040200,  //  0007  LDBOOL	R1	1	0
-      0x90020601,  //  0008  SETMBR	R0	K3	R1
-      0x8C040104,  //  0009  GETMET	R1	R0	K4
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _trigger_read_sensors
-********************************************************************/
-be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
-      0xA4060A00,  //  0000  IMPORT	R1	K5
-      0xB80A0C00,  //  0001  GETNGBL	R2	K6
-      0x8C080507,  //  0002  GETMET	R2	R2	K7
-      0x7C080200,  //  0003  CALL	R2	1
-      0xB80E0C00,  //  0004  GETNGBL	R3	K6
-      0x8C0C0708,  //  0005  GETMET	R3	R3	K8
-      0x58140009,  //  0006  LDCONST	R5	K9
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x780E0006,  //  0008  JMPF	R3	#0010
-      0xB80E1400,  //  0009  GETNGBL	R3	K10
-      0x60100008,  //  000A  GETGBL	R4	G8
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C100200,  //  000C  CALL	R4	1
-      0x00121604,  //  000D  ADD	R4	K11	R4
-      0x58140009,  //  000E  LDCONST	R5	K9
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x4C0C0000,  //  0010  LDNIL	R3
-      0x1C0C0403,  //  0011  EQ	R3	R2	R3
-      0x780E0000,  //  0012  JMPF	R3	#0014
-      0x80000600,  //  0013  RET	0
-      0x8C0C030C,  //  0014  GETMET	R3	R1	K12
-      0x5C140400,  //  0015  MOVE	R5	R2
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x4C100000,  //  0017  LDNIL	R4
-      0x20100604,  //  0018  NE	R4	R3	R4
-      0x7812000D,  //  0019  JMPF	R4	#0028
-      0x58100002,  //  001A  LDCONST	R4	K2
-      0x6014000C,  //  001B  GETGBL	R5	G12
-      0x8818010D,  //  001C  GETMBR	R6	R0	K13
-      0x7C140200,  //  001D  CALL	R5	1
-      0x14140805,  //  001E  LT	R5	R4	R5
-      0x78160006,  //  001F  JMPF	R5	#0027
-      0x8814010D,  //  0020  GETMBR	R5	R0	K13
-      0x94140A04,  //  0021  GETIDX	R5	R5	R4
-      0x8C140B0E,  //  0022  GETMET	R5	R5	K14
-      0x5C1C0600,  //  0023  MOVE	R7	R3
-      0x7C140400,  //  0024  CALL	R5	2
-      0x0010090F,  //  0025  ADD	R4	R4	K15
-      0x7001FFF3,  //  0026  JMP		#001B
-      0x70020006,  //  0027  JMP		#002F
-      0xB8121400,  //  0028  GETNGBL	R4	K10
-      0x60140008,  //  0029  GETGBL	R5	G8
-      0x5C180400,  //  002A  MOVE	R6	R2
-      0x7C140200,  //  002B  CALL	R5	1
-      0x00162005,  //  002C  ADD	R5	K16	R5
-      0x58180009,  //  002D  LDCONST	R6	K9
-      0x7C100400,  //  002E  CALL	R4	2
-      0x80000000,  //  002F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(class_Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0x58100002,  //  0000  LDCONST	R4	K2
-      0x88140711,  //  0001  GETMBR	R5	R3	K17
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C010D,  //  0003  GETMBR	R7	R0	K13
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x8818010D,  //  0007  GETMBR	R6	R0	K13
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D11,  //  0009  GETMBR	R7	R6	K17
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D12,  //  000C  GETMET	R7	R6	K18
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x0010090F,  //  0012  ADD	R4	R4	K15
-      0x7001FFED,  //  0013  JMP		#0002
-      0x541A007E,  //  0014  LDINT	R6	127
-      0x900E2606,  //  0015  SETMBR	R3	K19	R6
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_read_sensors_schedule
-********************************************************************/
-be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
+be_local_closure(class_Matter_Device_msg_send,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -382,23 +232,14 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(add_read_sensors_schedule),
+    be_str_weak(msg_send),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080114,  //  0000  GETMBR	R2	R0	K20
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C080403,  //  0002  EQ	R2	R2	R3
-      0x740A0002,  //  0003  JMPT	R2	#0007
-      0x88080114,  //  0004  GETMBR	R2	R0	K20
-      0x24080401,  //  0005  GT	R2	R2	R1
-      0x780A0005,  //  0006  JMPF	R2	#000D
-      0x90022801,  //  0007  SETMBR	R0	K20	R1
-      0xB80A2C00,  //  0008  GETNGBL	R2	K22
-      0x8C080517,  //  0009  GETMET	R2	R2	K23
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x90022A02,  //  000C  SETMBR	R0	K21	R2
-      0x80000000,  //  000D  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
     })
   )
 );
@@ -406,11 +247,11 @@ be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
 
 
 /********************************************************************
-** Solidified function: signal_endpoints_changed
+** Solidified function: init_zigbee
 ********************************************************************/
-be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
+be_local_closure(class_Matter_Device_init_zigbee,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -419,110 +260,18 @@ be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(signal_endpoints_changed),
+    be_str_weak(init_zigbee),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x8C040118,  //  0000  GETMET	R1	R0	K24
-      0x580C0002,  //  0001  LDCONST	R3	K2
-      0x5412001C,  //  0002  LDINT	R4	29
-      0x58140009,  //  0003  LDCONST	R5	K9
-      0x50180000,  //  0004  LDBOOL	R6	0	0
-      0x7C040A00,  //  0005  CALL	R1	5
-      0x8C040118,  //  0006  GETMET	R1	R0	K24
-      0x580C000F,  //  0007  LDCONST	R3	K15
-      0x5412001C,  //  0008  LDINT	R4	29
-      0x58140009,  //  0009  LDCONST	R5	K9
-      0x50180000,  //  000A  LDBOOL	R6	0	0
-      0x7C040A00,  //  000B  CALL	R1	5
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_friendly_name
-********************************************************************/
-be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(find_plugin_by_friendly_name),
-    &be_const_str_solidified,
-    ( &(const binstruction[35]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x740A0004,  //  0002  JMPT	R2	#0008
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x5C0C0200,  //  0004  MOVE	R3	R1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x1C080502,  //  0006  EQ	R2	R2	K2
-      0x780A0001,  //  0007  JMPF	R2	#000A
-      0x4C080000,  //  0008  LDNIL	R2
-      0x80040400,  //  0009  RET	1	R2
-      0x58080002,  //  000A  LDCONST	R2	K2
-      0x600C000C,  //  000B  GETGBL	R3	G12
-      0x8810010D,  //  000C  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x140C0403,  //  000E  LT	R3	R2	R3
-      0x780E0010,  //  000F  JMPF	R3	#0021
-      0x880C010D,  //  0010  GETMBR	R3	R0	K13
-      0x940C0602,  //  0011  GETIDX	R3	R3	R2
-      0x8C100719,  //  0012  GETMET	R4	R3	K25
-      0x7C100200,  //  0013  CALL	R4	1
-      0x4C140000,  //  0014  LDNIL	R5
-      0x20140805,  //  0015  NE	R5	R4	R5
-      0x78160007,  //  0016  JMPF	R5	#001F
-      0x6014000C,  //  0017  GETGBL	R5	G12
-      0x5C180800,  //  0018  MOVE	R6	R4
-      0x7C140200,  //  0019  CALL	R5	1
-      0x24140B02,  //  001A  GT	R5	R5	K2
-      0x78160002,  //  001B  JMPF	R5	#001F
-      0x1C140801,  //  001C  EQ	R5	R4	R1
-      0x78160000,  //  001D  JMPF	R5	#001F
-      0x80040600,  //  001E  RET	1	R3
-      0x0008050F,  //  001F  ADD	R2	R2	K15
-      0x7001FFE9,  //  0020  JMP		#000B
-      0x4C0C0000,  //  0021  LDNIL	R3
-      0x80040600,  //  0022  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_remote_info
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_remote_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x8808011A,  //  0000  GETMBR	R2	R0	K26
-      0x8C08051B,  //  0001  GETMET	R2	R2	K27
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x60140013,  //  0003  GETGBL	R5	G19
-      0x7C140000,  //  0004  CALL	R5	0
-      0x7C080600,  //  0005  CALL	R2	3
-      0x80040400,  //  0006  RET	1	R2
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C040102,  //  0000  GETMET	R1	R0	K2
+      0x7C040200,  //  0001  CALL	R1	1
+      0x78060004,  //  0002  JMPF	R1	#0008
+      0xA4060600,  //  0003  IMPORT	R1	K3
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x5C0C0000,  //  0005  MOVE	R3	R0
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80040400,  //  0007  RET	1	R2
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -546,7 +295,7 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
     be_str_weak(k2l_num),
     &be_const_str_solidified,
     ( &(const binstruction[52]) {  /* code */
-      0x5804001C,  //  0000  LDCONST	R1	K28
+      0x58040004,  //  0000  LDCONST	R1	K4
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -554,47 +303,47 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x80040400,  //  0006  RET	1	R2
       0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C10011D,  //  0008  GETMET	R4	R0	K29
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
       0x7C100200,  //  0009  CALL	R4	1
       0x7C0C0200,  //  000A  CALL	R3	1
       0xA8020007,  //  000B  EXBLK	0	#0014
       0x5C100600,  //  000C  MOVE	R4	R3
       0x7C100000,  //  000D  CALL	R4	0
-      0x8C14051E,  //  000E  GETMET	R5	R2	K30
+      0x8C140506,  //  000E  GETMET	R5	R2	K6
       0x601C0009,  //  000F  GETGBL	R7	G9
       0x5C200800,  //  0010  MOVE	R8	R4
       0x7C1C0200,  //  0011  CALL	R7	1
       0x7C140400,  //  0012  CALL	R5	2
       0x7001FFF7,  //  0013  JMP		#000C
-      0x580C001F,  //  0014  LDCONST	R3	K31
+      0x580C0007,  //  0014  LDCONST	R3	K7
       0xAC0C0200,  //  0015  CATCH	R3	1	0
       0xB0080000,  //  0016  RAISE	2	R0	R0
       0x600C0010,  //  0017  GETGBL	R3	G16
       0x6010000C,  //  0018  GETGBL	R4	G12
       0x5C140400,  //  0019  MOVE	R5	R2
       0x7C100200,  //  001A  CALL	R4	1
-      0x0410090F,  //  001B  SUB	R4	R4	K15
-      0x40121E04,  //  001C  CONNECT	R4	K15	R4
+      0x04100908,  //  001B  SUB	R4	R4	K8
+      0x40121004,  //  001C  CONNECT	R4	K8	R4
       0x7C0C0200,  //  001D  CALL	R3	1
       0xA8020010,  //  001E  EXBLK	0	#0030
       0x5C100600,  //  001F  MOVE	R4	R3
       0x7C100000,  //  0020  CALL	R4	0
       0x94140404,  //  0021  GETIDX	R5	R2	R4
       0x5C180800,  //  0022  MOVE	R6	R4
-      0x241C0D02,  //  0023  GT	R7	R6	K2
+      0x241C0D09,  //  0023  GT	R7	R6	K9
       0x781E0008,  //  0024  JMPF	R7	#002E
-      0x041C0D0F,  //  0025  SUB	R7	R6	K15
+      0x041C0D08,  //  0025  SUB	R7	R6	K8
       0x941C0407,  //  0026  GETIDX	R7	R2	R7
       0x241C0E05,  //  0027  GT	R7	R7	R5
       0x781E0004,  //  0028  JMPF	R7	#002E
-      0x041C0D0F,  //  0029  SUB	R7	R6	K15
+      0x041C0D08,  //  0029  SUB	R7	R6	K8
       0x941C0407,  //  002A  GETIDX	R7	R2	R7
       0x98080C07,  //  002B  SETIDX	R2	R6	R7
-      0x04180D0F,  //  002C  SUB	R6	R6	K15
+      0x04180D08,  //  002C  SUB	R6	R6	K8
       0x7001FFF4,  //  002D  JMP		#0023
       0x98080C05,  //  002E  SETIDX	R2	R6	R5
       0x7001FFEE,  //  002F  JMP		#001F
-      0x580C001F,  //  0030  LDCONST	R3	K31
+      0x580C0007,  //  0030  LDCONST	R3	K7
       0xAC0C0200,  //  0031  CATCH	R3	1	0
       0xB0080000,  //  0032  RAISE	2	R0	R0
       0x80040400,  //  0033  RET	1	R2
@@ -605,11 +354,104 @@ be_local_closure(class_Matter_Device_k2l_num,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_50ms
+** Solidified function: msg_received
 ********************************************************************/
-be_local_closure(class_Matter_Device_every_50ms,   /* name */
+be_local_closure(class_Matter_Device_msg_received,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    9,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(msg_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8810010A,  //  0000  GETMBR	R4	R0	K10
+      0x8C10090B,  //  0001  GETMET	R4	R4	K11
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrInfo
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrInfo,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrInfo),
+    &be_const_str_solidified,
+    ( &(const binstruction[40]) {  /* code */
+      0x1C14070C,  //  0000  EQ	R5	R3	K12
+      0x7815FFFF,  //  0001  JMPF	R5	#0002
+      0x1C14070C,  //  0002  EQ	R5	R3	K12
+      0x7816000D,  //  0003  JMPF	R5	#0012
+      0x60140010,  //  0004  GETGBL	R5	G16
+      0x8818010D,  //  0005  GETMBR	R6	R0	K13
+      0x7C140200,  //  0006  CALL	R5	1
+      0xA8020005,  //  0007  EXBLK	0	#000E
+      0x5C180A00,  //  0008  MOVE	R6	R5
+      0x7C180000,  //  0009  CALL	R6	0
+      0x8C1C010E,  //  000A  GETMET	R7	R0	K14
+      0x88240D0F,  //  000B  GETMBR	R9	R6	K15
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x7001FFF9,  //  000D  JMP		#0008
+      0x58140007,  //  000E  LDCONST	R5	K7
+      0xAC140200,  //  000F  CATCH	R5	1	0
+      0xB0080000,  //  0010  RAISE	2	R0	R0
+      0x70020011,  //  0011  JMP		#0024
+      0x60140004,  //  0012  GETGBL	R5	G4
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x1C140B10,  //  0015  EQ	R5	R5	K16
+      0x78160003,  //  0016  JMPF	R5	#001B
+      0x8C14010E,  //  0017  GETMET	R5	R0	K14
+      0x5C1C0800,  //  0018  MOVE	R7	R4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x70020008,  //  001A  JMP		#0024
+      0x8C140111,  //  001B  GETMET	R5	R0	K17
+      0x5C1C0600,  //  001C  MOVE	R7	R3
+      0x7C140400,  //  001D  CALL	R5	2
+      0x4C180000,  //  001E  LDNIL	R6
+      0x20180A06,  //  001F  NE	R6	R5	R6
+      0x781A0002,  //  0020  JMPF	R6	#0024
+      0x8C18010E,  //  0021  GETMET	R6	R0	K14
+      0x88200B0F,  //  0022  GETMBR	R8	R5	K15
+      0x7C180400,  //  0023  CALL	R6	2
+      0xB8162400,  //  0024  GETNGBL	R5	K18
+      0x8C140B13,  //  0025  GETMET	R5	R5	K19
+      0x7C140200,  //  0026  CALL	R5	1
+      0x80000000,  //  0027  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(class_Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -618,16 +460,244 @@ be_local_closure(class_Matter_Device_every_50ms,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_50ms),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8C040114,  //  0000  GETMET	R1	R0	K20
+      0x7C040200,  //  0001  CALL	R1	1
+      0x58040009,  //  0002  LDCONST	R1	K9
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C010D,  //  0004  GETMBR	R3	R0	K13
+      0x7C080200,  //  0005  CALL	R2	1
+      0x14080202,  //  0006  LT	R2	R1	R2
+      0x780A0005,  //  0007  JMPF	R2	#000E
+      0x8808010D,  //  0008  GETMBR	R2	R0	K13
+      0x94080401,  //  0009  GETIDX	R2	R2	R1
+      0x8C080515,  //  000A  GETMET	R2	R2	K21
+      0x7C080200,  //  000B  CALL	R2	1
+      0x00040308,  //  000C  ADD	R1	R1	K8
+      0x7001FFF4,  //  000D  JMP		#0003
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_active_endpoints
+********************************************************************/
+be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_active_endpoints),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x8810010D,  //  0003  GETMBR	R4	R0	K13
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA8020011,  //  0005  EXBLK	0	#0018
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140916,  //  0008  GETMET	R5	R4	K22
+      0x7C140200,  //  0009  CALL	R5	1
+      0x78060002,  //  000A  JMPF	R1	#000E
+      0x1C180B09,  //  000B  EQ	R6	R5	K9
+      0x781A0000,  //  000C  JMPF	R6	#000E
+      0x7001FFF7,  //  000D  JMP		#0006
+      0x8C180517,  //  000E  GETMET	R6	R2	K23
+      0x5C200A00,  //  000F  MOVE	R8	R5
+      0x7C180400,  //  0010  CALL	R6	2
+      0x4C1C0000,  //  0011  LDNIL	R7
+      0x1C180C07,  //  0012  EQ	R6	R6	R7
+      0x781A0002,  //  0013  JMPF	R6	#0017
+      0x8C180506,  //  0014  GETMET	R6	R2	K6
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x7C180400,  //  0016  CALL	R6	2
+      0x7001FFED,  //  0017  JMP		#0006
+      0x580C0007,  //  0018  LDCONST	R3	K7
+      0xAC0C0200,  //  0019  CATCH	R3	1	0
+      0xB0080000,  //  001A  RAISE	2	R0	R0
+      0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_remote_info
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_remote_info,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_plugin_remote_info),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
-      0x88040120,  //  0000  GETMBR	R1	R0	K32
-      0x0004030F,  //  0001  ADD	R1	R1	K15
-      0x90024001,  //  0002  SETMBR	R0	K32	R1
-      0x88040121,  //  0003  GETMBR	R1	R0	K33
-      0x8C040322,  //  0004  GETMET	R1	R1	K34
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
+      0x88080118,  //  0000  GETMBR	R2	R0	K24
+      0x8C080517,  //  0001  GETMET	R2	R2	K23
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x60140013,  //  0003  GETGBL	R5	G19
+      0x7C140000,  //  0004  CALL	R5	0
+      0x7C080600,  //  0005  CALL	R2	3
+      0x80040400,  //  0006  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(class_Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4063200,  //  0000  IMPORT	R1	K25
+      0x8C08011A,  //  0001  GETMET	R2	R0	K26
+      0x7C080200,  //  0002  CALL	R2	1
+      0x60080018,  //  0003  GETGBL	R2	G24
+      0x580C001B,  //  0004  LDCONST	R3	K27
+      0x8810011C,  //  0005  GETMBR	R4	R0	K28
+      0x8814011D,  //  0006  GETMBR	R5	R0	K29
+      0x8818011E,  //  0007  GETMBR	R6	R0	K30
+      0x781A0001,  //  0008  JMPF	R6	#000B
+      0x5818001F,  //  0009  LDCONST	R6	K31
+      0x70020000,  //  000A  JMP		#000C
+      0x58180020,  //  000B  LDCONST	R6	K32
+      0x881C0121,  //  000C  GETMBR	R7	R0	K33
+      0x781E0001,  //  000D  JMPF	R7	#0010
+      0x581C001F,  //  000E  LDCONST	R7	K31
+      0x70020000,  //  000F  JMP		#0011
+      0x581C0020,  //  0010  LDCONST	R7	K32
+      0x88200122,  //  0011  GETMBR	R8	R0	K34
+      0x7C080C00,  //  0012  CALL	R2	6
+      0x880C0123,  //  0013  GETMBR	R3	R0	K35
+      0x780E0000,  //  0014  JMPF	R3	#0016
+      0x00080524,  //  0015  ADD	R2	R2	K36
+      0x880C0125,  //  0016  GETMBR	R3	R0	K37
+      0x780E000E,  //  0017  JMPF	R3	#0027
+      0x00080526,  //  0018  ADD	R2	R2	K38
+      0x8C0C0327,  //  0019  GETMET	R3	R1	K39
+      0x88140128,  //  001A  GETMBR	R5	R0	K40
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x00080403,  //  001C  ADD	R2	R2	R3
+      0x600C000C,  //  001D  GETGBL	R3	G12
+      0x88100118,  //  001E  GETMBR	R4	R0	K24
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x240C0709,  //  0020  GT	R3	R3	K9
+      0x780E0004,  //  0021  JMPF	R3	#0027
+      0x00080529,  //  0022  ADD	R2	R2	K41
+      0x8C0C0327,  //  0023  GETMET	R3	R1	K39
+      0x88140118,  //  0024  GETMBR	R5	R0	K24
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x00080403,  //  0026  ADD	R2	R2	R3
+      0x0008052A,  //  0027  ADD	R2	R2	K42
+      0xA8020017,  //  0028  EXBLK	0	#0041
+      0x600C0011,  //  0029  GETGBL	R3	G17
+      0x8810012B,  //  002A  GETMBR	R4	R0	K43
+      0x5814002C,  //  002B  LDCONST	R5	K44
+      0x7C0C0400,  //  002C  CALL	R3	2
+      0x8C10072D,  //  002D  GETMET	R4	R3	K45
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x8C10072E,  //  0030  GETMET	R4	R3	K46
+      0x7C100200,  //  0031  CALL	R4	1
+      0xB8125E00,  //  0032  GETNGBL	R4	K47
+      0x60140018,  //  0033  GETGBL	R5	G24
+      0x58180030,  //  0034  LDCONST	R6	K48
+      0x881C0125,  //  0035  GETMBR	R7	R0	K37
+      0x781E0001,  //  0036  JMPF	R7	#0039
+      0x581C0031,  //  0037  LDCONST	R7	K49
+      0x70020000,  //  0038  JMP		#003A
+      0x581C000C,  //  0039  LDCONST	R7	K12
+      0x7C140400,  //  003A  CALL	R5	2
+      0x58180032,  //  003B  LDCONST	R6	K50
+      0x7C100400,  //  003C  CALL	R4	2
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x80040400,  //  003E  RET	1	R2
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8165E00,  //  0043  GETNGBL	R5	K47
+      0x60180008,  //  0044  GETGBL	R6	G8
+      0x5C1C0600,  //  0045  MOVE	R7	R3
+      0x7C180200,  //  0046  CALL	R6	1
+      0x001A6606,  //  0047  ADD	R6	K51	R6
+      0x00180D34,  //  0048  ADD	R6	R6	K52
+      0x601C0008,  //  0049  GETGBL	R7	G8
+      0x5C200800,  //  004A  MOVE	R8	R4
+      0x7C1C0200,  //  004B  CALL	R7	1
+      0x00180C07,  //  004C  ADD	R6	R6	R7
+      0x581C0032,  //  004D  LDCONST	R7	K50
+      0x7C140400,  //  004E  CALL	R5	2
+      0x80040400,  //  004F  RET	1	R2
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(class_Matter_Device_stop,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xB8062400,  //  0000  GETNGBL	R1	K18
+      0x8C040335,  //  0001  GETMET	R1	R1	K53
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040100,  //  0006  GETMBR	R1	R0	K0
+      0x8C040336,  //  0007  GETMET	R1	R1	K54
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -651,30 +721,214 @@ be_local_closure(class_Matter_Device_conf_to_log,   /* name */
     be_str_weak(conf_to_log),
     &be_const_str_solidified,
     ( &(const binstruction[24]) {  /* code */
-      0x5804001C,  //  0000  LDCONST	R1	K28
-      0x58080023,  //  0001  LDCONST	R2	K35
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x5808000C,  //  0001  LDCONST	R2	K12
       0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8C100324,  //  0003  GETMET	R4	R1	K36
+      0x8C100337,  //  0003  GETMET	R4	R1	K55
       0x5C180000,  //  0004  MOVE	R6	R0
       0x7C100400,  //  0005  CALL	R4	2
       0x7C0C0200,  //  0006  CALL	R3	1
       0xA802000B,  //  0007  EXBLK	0	#0014
       0x5C100600,  //  0008  MOVE	R4	R3
       0x7C100000,  //  0009  CALL	R4	0
-      0x1C140925,  //  000A  EQ	R5	R4	K37
+      0x1C140938,  //  000A  EQ	R5	R4	K56
       0x78160000,  //  000B  JMPF	R5	#000D
       0x7001FFFA,  //  000C  JMP		#0008
       0x60140018,  //  000D  GETGBL	R5	G24
-      0x58180026,  //  000E  LDCONST	R6	K38
+      0x58180039,  //  000E  LDCONST	R6	K57
       0x5C1C0800,  //  000F  MOVE	R7	R4
       0x94200004,  //  0010  GETIDX	R8	R0	R4
       0x7C140600,  //  0011  CALL	R5	3
       0x00080405,  //  0012  ADD	R2	R2	R5
       0x7001FFF3,  //  0013  JMP		#0008
-      0x580C001F,  //  0014  LDCONST	R3	K31
+      0x580C0007,  //  0014  LDCONST	R3	K7
       0xAC0C0200,  //  0015  CATCH	R3	1	0
       0xB0080000,  //  0016  RAISE	2	R0	R0
       0x80040400,  //  0017  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort_distinct
+********************************************************************/
+be_local_closure(class_Matter_Device_sort_distinct,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    12,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(sort_distinct),
+    &be_const_str_solidified,
+    ( &(const binstruction[53]) {  /* code */
+      0x58040004,  //  0000  LDCONST	R1	K4
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0708,  //  0005  SUB	R3	R3	K8
+      0x400E1003,  //  0006  CONNECT	R3	K8	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B09,  //  000D  GT	R6	R5	K9
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B08,  //  000F  SUB	R6	R5	K8
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B08,  //  0013  SUB	R6	R5	K8
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B08,  //  0016  SUB	R5	R5	K8
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080007,  //  001A  LDCONST	R2	K7
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080008,  //  001D  LDCONST	R2	K8
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0708,  //  0021  LE	R3	R3	K8
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0109,  //  0024  GETIDX	R3	R0	K9
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C10013A,  //  002D  GETMET	R4	R0	K58
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080508,  //  0032  ADD	R2	R2	K8
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: event_fabrics_saved
+********************************************************************/
+be_local_closure(class_Matter_Device_event_fabrics_saved,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(event_fabrics_saved),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x8804013B,  //  0000  GETMBR	R1	R0	K59
+      0x8C04033C,  //  0001  GETMET	R1	R1	K60
+      0x7C040200,  //  0002  CALL	R1	1
+      0x24040309,  //  0003  GT	R1	R1	K9
+      0x78060005,  //  0004  JMPF	R1	#000B
+      0x88040125,  //  0005  GETMBR	R1	R0	K37
+      0x74060003,  //  0006  JMPT	R1	#000B
+      0x50040200,  //  0007  LDBOOL	R1	1	0
+      0x90024A01,  //  0008  SETMBR	R0	K37	R1
+      0x8C04013D,  //  0009  GETMET	R1	R0	K61
+      0x7C040200,  //  000A  CALL	R1	1
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: autoconf_device
+********************************************************************/
+be_local_closure(class_Matter_Device_autoconf_device,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(autoconf_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[50]) {  /* code */
+      0xA4063200,  //  0000  IMPORT	R1	K25
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C010D,  //  0002  GETMBR	R3	R0	K13
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080509,  //  0004  GT	R2	R2	K9
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x80000400,  //  0006  RET	0
+      0x8808013E,  //  0007  GETMBR	R2	R0	K62
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x1C080403,  //  0009  EQ	R2	R2	R3
+      0x780A0004,  //  000A  JMPF	R2	#0010
+      0xB80A7E00,  //  000B  GETNGBL	R2	K63
+      0x8C080540,  //  000C  GETMET	R2	R2	K64
+      0x5C100000,  //  000D  MOVE	R4	R0
+      0x7C080400,  //  000E  CALL	R2	2
+      0x90027C02,  //  000F  SETMBR	R0	K62	R2
+      0x88080125,  //  0010  GETMBR	R2	R0	K37
+      0x740A000F,  //  0011  JMPT	R2	#0022
+      0x8808013E,  //  0012  GETMBR	R2	R0	K62
+      0x8C080541,  //  0013  GETMET	R2	R2	K65
+      0x7C080200,  //  0014  CALL	R2	1
+      0x90025002,  //  0015  SETMBR	R0	K40	R2
+      0x60080013,  //  0016  GETGBL	R2	G19
+      0x7C080000,  //  0017  CALL	R2	0
+      0x90023002,  //  0018  SETMBR	R0	K24	R2
+      0x8C080142,  //  0019  GETMET	R2	R0	K66
+      0x7C080200,  //  001A  CALL	R2	1
+      0xB80A5E00,  //  001B  GETNGBL	R2	K47
+      0x600C0008,  //  001C  GETGBL	R3	G8
+      0x88100128,  //  001D  GETMBR	R4	R0	K40
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x000E8603,  //  001F  ADD	R3	K67	R3
+      0x58100044,  //  0020  LDCONST	R4	K68
+      0x7C080400,  //  0021  CALL	R2	2
+      0x8808013E,  //  0022  GETMBR	R2	R0	K62
+      0x8C080545,  //  0023  GETMET	R2	R2	K69
+      0x88100128,  //  0024  GETMBR	R4	R0	K40
+      0x7C080400,  //  0025  CALL	R2	2
+      0x88080125,  //  0026  GETMBR	R2	R0	K37
+      0x740A0008,  //  0027  JMPT	R2	#0031
+      0x8808013B,  //  0028  GETMBR	R2	R0	K59
+      0x8C08053C,  //  0029  GETMET	R2	R2	K60
+      0x7C080200,  //  002A  CALL	R2	1
+      0x24080509,  //  002B  GT	R2	R2	K9
+      0x780A0003,  //  002C  JMPF	R2	#0031
+      0x50080200,  //  002D  LDBOOL	R2	1	0
+      0x90024A02,  //  002E  SETMBR	R0	K37	R2
+      0x8C08013D,  //  002F  GETMET	R2	R0	K61
+      0x7C080200,  //  0030  CALL	R2	1
+      0x80000000,  //  0031  RET	0
     })
   )
 );
@@ -704,13 +958,229 @@ be_local_closure(class_Matter_Device_button_multi_pressed,   /* name */
       0x2C0C0604,  //  0003  AND	R3	R3	R4
       0x541200FE,  //  0004  LDINT	R4	255
       0x2C100404,  //  0005  AND	R4	R2	R4
-      0x8C140127,  //  0006  GETMET	R5	R0	K39
-      0x001C090F,  //  0007  ADD	R7	R4	K15
-      0x58200028,  //  0008  LDCONST	R8	K40
-      0x58240002,  //  0009  LDCONST	R9	K2
+      0x8C140146,  //  0006  GETMET	R5	R0	K70
+      0x001C0908,  //  0007  ADD	R7	R4	K8
+      0x58200032,  //  0008  LDCONST	R8	K50
+      0x58240009,  //  0009  LDCONST	R9	K9
       0x5C280600,  //  000A  MOVE	R10	R3
       0x7C140A00,  //  000B  CALL	R5	5
       0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: resolve_attribute_read_solo
+********************************************************************/
+be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(resolve_attribute_read_solo),
+    &be_const_str_solidified,
+    ( &(const binstruction[44]) {  /* code */
+      0x8808030F,  //  0000  GETMBR	R2	R1	K15
+      0x880C0347,  //  0001  GETMBR	R3	R1	K71
+      0x88100348,  //  0002  GETMBR	R4	R1	K72
+      0x4C140000,  //  0003  LDNIL	R5
+      0x1C140405,  //  0004  EQ	R5	R2	R5
+      0x74160005,  //  0005  JMPT	R5	#000C
+      0x4C140000,  //  0006  LDNIL	R5
+      0x1C140605,  //  0007  EQ	R5	R3	R5
+      0x74160002,  //  0008  JMPT	R5	#000C
+      0x4C140000,  //  0009  LDNIL	R5
+      0x1C140805,  //  000A  EQ	R5	R4	R5
+      0x78160001,  //  000B  JMPF	R5	#000E
+      0x4C140000,  //  000C  LDNIL	R5
+      0x80040A00,  //  000D  RET	1	R5
+      0x8C140149,  //  000E  GETMET	R5	R0	K73
+      0x5C1C0400,  //  000F  MOVE	R7	R2
+      0x7C140400,  //  0010  CALL	R5	2
+      0x4C180000,  //  0011  LDNIL	R6
+      0x1C180A06,  //  0012  EQ	R6	R5	R6
+      0x781A0004,  //  0013  JMPF	R6	#0019
+      0x541A007E,  //  0014  LDINT	R6	127
+      0x90069406,  //  0015  SETMBR	R1	K74	R6
+      0x4C180000,  //  0016  LDNIL	R6
+      0x80040C00,  //  0017  RET	1	R6
+      0x70020011,  //  0018  JMP		#002B
+      0x8C180B4B,  //  0019  GETMET	R6	R5	K75
+      0x5C200600,  //  001A  MOVE	R8	R3
+      0x7C180400,  //  001B  CALL	R6	2
+      0x741A0004,  //  001C  JMPT	R6	#0022
+      0x541A00C2,  //  001D  LDINT	R6	195
+      0x90069406,  //  001E  SETMBR	R1	K74	R6
+      0x4C180000,  //  001F  LDNIL	R6
+      0x80040C00,  //  0020  RET	1	R6
+      0x70020008,  //  0021  JMP		#002B
+      0x8C180B4C,  //  0022  GETMET	R6	R5	K76
+      0x5C200600,  //  0023  MOVE	R8	R3
+      0x5C240800,  //  0024  MOVE	R9	R4
+      0x7C180600,  //  0025  CALL	R6	3
+      0x741A0003,  //  0026  JMPT	R6	#002B
+      0x541A0085,  //  0027  LDINT	R6	134
+      0x90069406,  //  0028  SETMBR	R1	K74	R6
+      0x4C180000,  //  0029  LDNIL	R6
+      0x80040C00,  //  002A  RET	1	R6
+      0x80040A00,  //  002B  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clean_remotes
+********************************************************************/
+be_local_closure(class_Matter_Device_clean_remotes,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(clean_remotes),
+    &be_const_str_solidified,
+    ( &(const binstruction[80]) {  /* code */
+      0xA4069A00,  //  0000  IMPORT	R1	K77
+      0x8808014E,  //  0001  GETMBR	R2	R0	K78
+      0x780A004B,  //  0002  JMPF	R2	#004F
+      0x60080013,  //  0003  GETGBL	R2	G19
+      0x7C080000,  //  0004  CALL	R2	0
+      0x600C0010,  //  0005  GETGBL	R3	G16
+      0x8810014E,  //  0006  GETMBR	R4	R0	K78
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020003,  //  0008  EXBLK	0	#000D
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x98080909,  //  000B  SETIDX	R2	R4	K9
+      0x7001FFFB,  //  000C  JMP		#0009
+      0x580C0007,  //  000D  LDCONST	R3	K7
+      0xAC0C0200,  //  000E  CATCH	R3	1	0
+      0xB0080000,  //  000F  RAISE	2	R0	R0
+      0x600C0010,  //  0010  GETGBL	R3	G16
+      0x8810010D,  //  0011  GETMBR	R4	R0	K13
+      0x7C0C0200,  //  0012  CALL	R3	1
+      0xA802000F,  //  0013  EXBLK	0	#0024
+      0x5C100600,  //  0014  MOVE	R4	R3
+      0x7C100000,  //  0015  CALL	R4	0
+      0x8C14034F,  //  0016  GETMET	R5	R1	K79
+      0x5C1C0800,  //  0017  MOVE	R7	R4
+      0x58200050,  //  0018  LDCONST	R8	K80
+      0x7C140600,  //  0019  CALL	R5	3
+      0x4C180000,  //  001A  LDNIL	R6
+      0x20180A06,  //  001B  NE	R6	R5	R6
+      0x781A0005,  //  001C  JMPF	R6	#0023
+      0x8C180517,  //  001D  GETMET	R6	R2	K23
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x58240009,  //  001F  LDCONST	R9	K9
+      0x7C180600,  //  0020  CALL	R6	3
+      0x00180D08,  //  0021  ADD	R6	R6	K8
+      0x98080A06,  //  0022  SETIDX	R2	R5	R6
+      0x7001FFEF,  //  0023  JMP		#0014
+      0x580C0007,  //  0024  LDCONST	R3	K7
+      0xAC0C0200,  //  0025  CATCH	R3	1	0
+      0xB0080000,  //  0026  RAISE	2	R0	R0
+      0x600C0012,  //  0027  GETGBL	R3	G18
+      0x7C0C0000,  //  0028  CALL	R3	0
+      0x60100010,  //  0029  GETGBL	R4	G16
+      0x8C140505,  //  002A  GETMET	R5	R2	K5
+      0x7C140200,  //  002B  CALL	R5	1
+      0x7C100200,  //  002C  CALL	R4	1
+      0xA8020008,  //  002D  EXBLK	0	#0037
+      0x5C140800,  //  002E  MOVE	R5	R4
+      0x7C140000,  //  002F  CALL	R5	0
+      0x94180405,  //  0030  GETIDX	R6	R2	R5
+      0x1C180D09,  //  0031  EQ	R6	R6	K9
+      0x781A0002,  //  0032  JMPF	R6	#0036
+      0x8C180706,  //  0033  GETMET	R6	R3	K6
+      0x5C200A00,  //  0034  MOVE	R8	R5
+      0x7C180400,  //  0035  CALL	R6	2
+      0x7001FFF6,  //  0036  JMP		#002E
+      0x58100007,  //  0037  LDCONST	R4	K7
+      0xAC100200,  //  0038  CATCH	R4	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x60100010,  //  003A  GETGBL	R4	G16
+      0x5C140600,  //  003B  MOVE	R5	R3
+      0x7C100200,  //  003C  CALL	R4	1
+      0xA802000D,  //  003D  EXBLK	0	#004C
+      0x5C140800,  //  003E  MOVE	R5	R4
+      0x7C140000,  //  003F  CALL	R5	0
+      0xB81A5E00,  //  0040  GETNGBL	R6	K47
+      0x881C0B52,  //  0041  GETMBR	R7	R5	K82
+      0x001EA207,  //  0042  ADD	R7	K81	R7
+      0x58200044,  //  0043  LDCONST	R8	K68
+      0x7C180400,  //  0044  CALL	R6	2
+      0x8C180B2E,  //  0045  GETMET	R6	R5	K46
+      0x7C180200,  //  0046  CALL	R6	1
+      0x8818014E,  //  0047  GETMBR	R6	R0	K78
+      0x8C180D3A,  //  0048  GETMET	R6	R6	K58
+      0x88200B52,  //  0049  GETMBR	R8	R5	K82
+      0x7C180400,  //  004A  CALL	R6	2
+      0x7001FFF1,  //  004B  JMP		#003E
+      0x58100007,  //  004C  LDCONST	R4	K7
+      0xAC100200,  //  004D  CATCH	R4	1	0
+      0xB0080000,  //  004E  RAISE	2	R0	R0
+      0x80000000,  //  004F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(class_Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0x58100009,  //  0000  LDCONST	R4	K9
+      0x8814070F,  //  0001  GETMBR	R5	R3	K15
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C010D,  //  0003  GETMBR	R7	R0	K13
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x8818010D,  //  0007  GETMBR	R6	R0	K13
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D0F,  //  0009  GETMBR	R7	R6	K15
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D53,  //  000C  GETMET	R7	R6	K83
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100908,  //  0012  ADD	R4	R4	K8
+      0x7001FFED,  //  0013  JMP		#0002
+      0x541A007E,  //  0014  LDINT	R6	127
+      0x900E9406,  //  0015  SETMBR	R3	K74	R6
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -758,85 +1228,85 @@ be_local_closure(class_Matter_Device_init,   /* name */
     be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[82]) {  /* code */
-      0xA4065200,  //  0000  IMPORT	R1	K41
-      0xB80A0C00,  //  0001  GETNGBL	R2	K6
-      0x8C08052A,  //  0002  GETMET	R2	R2	K42
+      0xA406A800,  //  0000  IMPORT	R1	K84
+      0xB80A2400,  //  0001  GETNGBL	R2	K18
+      0x8C080555,  //  0002  GETMET	R2	R2	K85
       0x54120096,  //  0003  LDINT	R4	151
       0x7C080400,  //  0004  CALL	R2	2
       0x740A0006,  //  0005  JMPT	R2	#000D
-      0xB80A2C00,  //  0006  GETNGBL	R2	K22
-      0x8C08052C,  //  0007  GETMET	R2	R2	K44
+      0xB80A7E00,  //  0006  GETNGBL	R2	K63
+      0x8C080557,  //  0007  GETMET	R2	R2	K87
       0x5C100000,  //  0008  MOVE	R4	R0
       0x50140000,  //  0009  LDBOOL	R5	0	0
       0x7C080600,  //  000A  CALL	R2	3
-      0x90025602,  //  000B  SETMBR	R0	K43	R2
+      0x9002AC02,  //  000B  SETMBR	R0	K86	R2
       0x80000400,  //  000C  RET	0
-      0xB80A2C00,  //  000D  GETNGBL	R2	K22
-      0xB80E2C00,  //  000E  GETNGBL	R3	K22
-      0x8C0C072E,  //  000F  GETMET	R3	R3	K46
+      0xB80A7E00,  //  000D  GETNGBL	R2	K63
+      0xB80E7E00,  //  000E  GETNGBL	R3	K63
+      0x8C0C0759,  //  000F  GETMET	R3	R3	K89
       0x7C0C0200,  //  0010  CALL	R3	1
-      0x900A5A03,  //  0011  SETMBR	R2	K45	R3
-      0x90024102,  //  0012  SETMBR	R0	K32	K2
+      0x900AB003,  //  0011  SETMBR	R2	K88	R3
+      0x9002B509,  //  0012  SETMBR	R0	K90	K9
       0x60080012,  //  0013  GETGBL	R2	G18
       0x7C080000,  //  0014  CALL	R2	0
       0x90021A02,  //  0015  SETMBR	R0	K13	R2
       0x50080000,  //  0016  LDBOOL	R2	0	0
-      0x90020602,  //  0017  SETMBR	R0	K3	R2
+      0x90024A02,  //  0017  SETMBR	R0	K37	R2
       0x60080013,  //  0018  GETGBL	R2	G19
       0x7C080000,  //  0019  CALL	R2	0
-      0x90023402,  //  001A  SETMBR	R0	K26	R2
-      0x88080130,  //  001B  GETMBR	R2	R0	K48
-      0x90025E02,  //  001C  SETMBR	R0	K47	R2
+      0x90023002,  //  001A  SETMBR	R0	K24	R2
+      0x8808015B,  //  001B  GETMBR	R2	R0	K91
+      0x90024402,  //  001C  SETMBR	R0	K34	R2
       0x50080000,  //  001D  LDBOOL	R2	0	0
-      0x90026202,  //  001E  SETMBR	R0	K49	R2
+      0x90023C02,  //  001E  SETMBR	R0	K30	R2
       0x50080000,  //  001F  LDBOOL	R2	0	0
-      0x90026402,  //  0020  SETMBR	R0	K50	R2
-      0xB80A2C00,  //  0021  GETNGBL	R2	K22
-      0x8C080534,  //  0022  GETMET	R2	R2	K52
+      0x90024202,  //  0020  SETMBR	R0	K33	R2
+      0xB80A7E00,  //  0021  GETNGBL	R2	K63
+      0x8C08055D,  //  0022  GETMET	R2	R2	K93
       0x5C100000,  //  0023  MOVE	R4	R0
       0x7C080400,  //  0024  CALL	R2	2
-      0x90026602,  //  0025  SETMBR	R0	K51	R2
-      0x8C080135,  //  0026  GETMET	R2	R0	K53
+      0x9002B802,  //  0025  SETMBR	R0	K92	R2
+      0x8C08015E,  //  0026  GETMET	R2	R0	K94
       0x7C080200,  //  0027  CALL	R2	1
-      0xB80A2C00,  //  0028  GETNGBL	R2	K22
-      0x8C080536,  //  0029  GETMET	R2	R2	K54
+      0xB80A7E00,  //  0028  GETNGBL	R2	K63
+      0x8C08055F,  //  0029  GETMET	R2	R2	K95
       0x5C100000,  //  002A  MOVE	R4	R0
       0x7C080400,  //  002B  CALL	R2	2
-      0x90020002,  //  002C  SETMBR	R0	K0	R2
-      0x88080100,  //  002D  GETMBR	R2	R0	K0
-      0x8C080537,  //  002E  GETMET	R2	R2	K55
+      0x90027602,  //  002C  SETMBR	R0	K59	R2
+      0x8808013B,  //  002D  GETMBR	R2	R0	K59
+      0x8C080560,  //  002E  GETMET	R2	R2	K96
       0x7C080200,  //  002F  CALL	R2	1
-      0xB80A2C00,  //  0030  GETNGBL	R2	K22
-      0x8C080538,  //  0031  GETMET	R2	R2	K56
+      0xB80A7E00,  //  0030  GETNGBL	R2	K63
+      0x8C080561,  //  0031  GETMET	R2	R2	K97
       0x5C100000,  //  0032  MOVE	R4	R0
       0x7C080400,  //  0033  CALL	R2	2
-      0x90024202,  //  0034  SETMBR	R0	K33	R2
-      0xB80A2C00,  //  0035  GETNGBL	R2	K22
-      0x8C08053A,  //  0036  GETMET	R2	R2	K58
+      0x90021402,  //  0034  SETMBR	R0	K10	R2
+      0xB80A7E00,  //  0035  GETNGBL	R2	K63
+      0x8C080563,  //  0036  GETMET	R2	R2	K99
       0x5C100000,  //  0037  MOVE	R4	R0
       0x7C080400,  //  0038  CALL	R2	2
-      0x90027202,  //  0039  SETMBR	R0	K57	R2
-      0x8C08013C,  //  003A  GETMET	R2	R0	K60
+      0x9002C402,  //  0039  SETMBR	R0	K98	R2
+      0x8C080165,  //  003A  GETMET	R2	R0	K101
       0x7C080200,  //  003B  CALL	R2	1
-      0x90027602,  //  003C  SETMBR	R0	K59	R2
-      0xB80A2C00,  //  003D  GETNGBL	R2	K22
-      0x8C08052C,  //  003E  GETMET	R2	R2	K44
+      0x9002C802,  //  003C  SETMBR	R0	K100	R2
+      0xB80A7E00,  //  003D  GETNGBL	R2	K63
+      0x8C080557,  //  003E  GETMET	R2	R2	K87
       0x5C100000,  //  003F  MOVE	R4	R0
       0x50140200,  //  0040  LDBOOL	R5	1	0
       0x7C080600,  //  0041  CALL	R2	3
-      0x90025602,  //  0042  SETMBR	R0	K43	R2
-      0xB80A0C00,  //  0043  GETNGBL	R2	K6
-      0x8C08053D,  //  0044  GETMET	R2	R2	K61
+      0x9002AC02,  //  0042  SETMBR	R0	K86	R2
+      0xB80A2400,  //  0043  GETNGBL	R2	K18
+      0x8C080566,  //  0044  GETMET	R2	R2	K102
       0x84100000,  //  0045  CLOSURE	R4	P0
       0x7C080400,  //  0046  CALL	R2	2
-      0x88080133,  //  0047  GETMBR	R2	R0	K51
-      0x8C08053E,  //  0048  GETMET	R2	R2	K62
+      0x8808015C,  //  0047  GETMBR	R2	R0	K92
+      0x8C080567,  //  0048  GETMET	R2	R2	K103
       0x7C080200,  //  0049  CALL	R2	1
-      0xB80A0C00,  //  004A  GETNGBL	R2	K6
-      0x8C08053F,  //  004B  GETMET	R2	R2	K63
+      0xB80A2400,  //  004A  GETNGBL	R2	K18
+      0x8C080568,  //  004B  GETMET	R2	R2	K104
       0x5C100000,  //  004C  MOVE	R4	R0
       0x7C080400,  //  004D  CALL	R2	2
-      0x8C080140,  //  004E  GETMET	R2	R0	K64
+      0x8C080169,  //  004E  GETMET	R2	R0	K105
       0x7C080200,  //  004F  CALL	R2	1
       0xA0000000,  //  0050  CLOSE	R0
       0x80000000,  //  0051  RET	0
@@ -847,75 +1317,696 @@ be_local_closure(class_Matter_Device_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort_distinct
+** Solidified function: button_pressed
 ********************************************************************/
-be_local_closure(class_Matter_Device_sort_distinct,   /* name */
+be_local_closure(class_Matter_Device_button_pressed,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    12,                          /* varg */
+    13,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(sort_distinct),
+    be_str_weak(button_pressed),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x5804001C,  //  0000  LDCONST	R1	K28
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C070F,  //  0005  SUB	R3	R3	K15
-      0x400E1E03,  //  0006  CONNECT	R3	K15	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B0F,  //  000F  SUB	R6	R5	K15
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B0F,  //  0013  SUB	R6	R5	K15
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B0F,  //  0016  SUB	R5	R5	K15
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x5808001F,  //  001A  LDCONST	R2	K31
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x5808000F,  //  001D  LDCONST	R2	K15
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C070F,  //  0021  LE	R3	R3	K15
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100141,  //  002D  GETMET	R4	R0	K65
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x0008050F,  //  0032  ADD	R2	R2	K15
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
+    ( &(const binstruction[28]) {  /* code */
+      0x540E000F,  //  0000  LDINT	R3	16
+      0x3C0C0403,  //  0001  SHR	R3	R2	R3
+      0x541200FE,  //  0002  LDINT	R4	255
+      0x2C0C0604,  //  0003  AND	R3	R3	R4
+      0x54120007,  //  0004  LDINT	R4	8
+      0x3C100404,  //  0005  SHR	R4	R2	R4
+      0x541600FE,  //  0006  LDINT	R5	255
+      0x2C100805,  //  0007  AND	R4	R4	R5
+      0x541600FE,  //  0008  LDINT	R5	255
+      0x2C140405,  //  0009  AND	R5	R2	R5
+      0x541A0017,  //  000A  LDINT	R6	24
+      0x3C180406,  //  000B  SHR	R6	R2	R6
+      0x541E00FE,  //  000C  LDINT	R7	255
+      0x2C180C07,  //  000D  AND	R6	R6	R7
+      0x8C1C0146,  //  000E  GETMET	R7	R0	K70
+      0x00240B08,  //  000F  ADD	R9	R5	K8
+      0x20280604,  //  0010  NE	R10	R3	R4
+      0x782A0001,  //  0011  JMPF	R10	#0014
+      0x58280008,  //  0012  LDCONST	R10	K8
+      0x70020000,  //  0013  JMP		#0015
+      0x58280009,  //  0014  LDCONST	R10	K9
+      0x780E0001,  //  0015  JMPF	R3	#0018
+      0x582C0009,  //  0016  LDCONST	R11	K9
+      0x70020000,  //  0017  JMP		#0019
+      0x582C0008,  //  0018  LDCONST	R11	K8
+      0x5C300C00,  //  0019  MOVE	R12	R6
+      0x7C1C0A00,  //  001A  CALL	R7	5
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_plugin_by_friendly_name
+********************************************************************/
+be_local_closure(class_Matter_Device_find_plugin_by_friendly_name,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(find_plugin_by_friendly_name),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x740A0004,  //  0002  JMPT	R2	#0008
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x5C0C0200,  //  0004  MOVE	R3	R1
+      0x7C080200,  //  0005  CALL	R2	1
+      0x1C080509,  //  0006  EQ	R2	R2	K9
+      0x780A0001,  //  0007  JMPF	R2	#000A
+      0x4C080000,  //  0008  LDNIL	R2
+      0x80040400,  //  0009  RET	1	R2
+      0x58080009,  //  000A  LDCONST	R2	K9
+      0x600C000C,  //  000B  GETGBL	R3	G12
+      0x8810010D,  //  000C  GETMBR	R4	R0	K13
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x140C0403,  //  000E  LT	R3	R2	R3
+      0x780E0010,  //  000F  JMPF	R3	#0021
+      0x880C010D,  //  0010  GETMBR	R3	R0	K13
+      0x940C0602,  //  0011  GETIDX	R3	R3	R2
+      0x8C10076A,  //  0012  GETMET	R4	R3	K106
+      0x7C100200,  //  0013  CALL	R4	1
+      0x4C140000,  //  0014  LDNIL	R5
+      0x20140805,  //  0015  NE	R5	R4	R5
+      0x78160007,  //  0016  JMPF	R5	#001F
+      0x6014000C,  //  0017  GETGBL	R5	G12
+      0x5C180800,  //  0018  MOVE	R6	R4
+      0x7C140200,  //  0019  CALL	R5	1
+      0x24140B09,  //  001A  GT	R5	R5	K9
+      0x78160002,  //  001B  JMPF	R5	#001F
+      0x1C140801,  //  001C  EQ	R5	R4	R1
+      0x78160000,  //  001D  JMPF	R5	#001F
+      0x80040600,  //  001E  RET	1	R3
+      0x00080508,  //  001F  ADD	R2	R2	K8
+      0x7001FFE9,  //  0020  JMP		#000B
+      0x4C0C0000,  //  0021  LDNIL	R3
+      0x80040600,  //  0022  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(class_Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8167E00,  //  0004  GETNGBL	R5	K63
+      0x8C140B6B,  //  0005  GETMET	R5	R5	K107
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90161E01,  //  0007  SETMBR	R5	K15	R1
+      0x90168E02,  //  0008  SETMBR	R5	K71	R2
+      0x90169003,  //  0009  SETMBR	R5	K72	R3
+      0x8818010A,  //  000A  GETMBR	R6	R0	K10
+      0x88180D6C,  //  000B  GETMBR	R6	R6	K108
+      0x88180D6D,  //  000C  GETMBR	R6	R6	K109
+      0x8C180D6E,  //  000D  GETMET	R6	R6	K110
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrUpdate
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrUpdate),
+    &be_const_str_solidified,
+    ( &(const binstruction[126]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160004,  //  0002  JMPF	R5	#0008
+      0xB8162400,  //  0003  GETNGBL	R5	K18
+      0x8C140B6F,  //  0004  GETMET	R5	R5	K111
+      0x581C0070,  //  0005  LDCONST	R7	K112
+      0x7C140400,  //  0006  CALL	R5	2
+      0x80040A00,  //  0007  RET	1	R5
+      0xB8162400,  //  0008  GETNGBL	R5	K18
+      0x8C140B71,  //  0009  GETMET	R5	R5	K113
+      0x5C1C0800,  //  000A  MOVE	R7	R4
+      0x58200072,  //  000B  LDCONST	R8	K114
+      0x7C140600,  //  000C  CALL	R5	3
+      0xB81A2400,  //  000D  GETNGBL	R6	K18
+      0x8C180D71,  //  000E  GETMET	R6	R6	K113
+      0x5C200800,  //  000F  MOVE	R8	R4
+      0x58240073,  //  0010  LDCONST	R9	K115
+      0x7C180600,  //  0011  CALL	R6	3
+      0x74160000,  //  0012  JMPT	R5	#0014
+      0x781A0064,  //  0013  JMPF	R6	#0079
+      0x4C1C0000,  //  0014  LDNIL	R7
+      0x78160010,  //  0015  JMPF	R5	#0027
+      0x60200009,  //  0016  GETGBL	R8	G9
+      0x94240805,  //  0017  GETIDX	R9	R4	R5
+      0x7C200200,  //  0018  CALL	R8	1
+      0x18241109,  //  0019  LE	R9	R8	K9
+      0x78260004,  //  001A  JMPF	R9	#0020
+      0xB8262400,  //  001B  GETNGBL	R9	K18
+      0x8C24136F,  //  001C  GETMET	R9	R9	K111
+      0x582C0074,  //  001D  LDCONST	R11	K116
+      0x7C240400,  //  001E  CALL	R9	2
+      0x80041200,  //  001F  RET	1	R9
+      0x8C240149,  //  0020  GETMET	R9	R0	K73
+      0x5C2C1000,  //  0021  MOVE	R11	R8
+      0x7C240400,  //  0022  CALL	R9	2
+      0x5C1C1200,  //  0023  MOVE	R7	R9
+      0x8C24093A,  //  0024  GETMET	R9	R4	K58
+      0x5C2C0A00,  //  0025  MOVE	R11	R5
+      0x7C240400,  //  0026  CALL	R9	2
+      0x781A0009,  //  0027  JMPF	R6	#0032
+      0x4C200000,  //  0028  LDNIL	R8
+      0x1C200E08,  //  0029  EQ	R8	R7	R8
+      0x78220003,  //  002A  JMPF	R8	#002F
+      0x8C200111,  //  002B  GETMET	R8	R0	K17
+      0x94280806,  //  002C  GETIDX	R10	R4	R6
+      0x7C200400,  //  002D  CALL	R8	2
+      0x5C1C1000,  //  002E  MOVE	R7	R8
+      0x8C20093A,  //  002F  GETMET	R8	R4	K58
+      0x5C280C00,  //  0030  MOVE	R10	R6
+      0x7C200400,  //  0031  CALL	R8	2
+      0x4C200000,  //  0032  LDNIL	R8
+      0x1C200E08,  //  0033  EQ	R8	R7	R8
+      0x78220004,  //  0034  JMPF	R8	#003A
+      0xB8222400,  //  0035  GETNGBL	R8	K18
+      0x8C20116F,  //  0036  GETMET	R8	R8	K111
+      0x58280075,  //  0037  LDCONST	R10	K117
+      0x7C200400,  //  0038  CALL	R8	2
+      0x80041000,  //  0039  RET	1	R8
+      0x88200F76,  //  003A  GETMBR	R8	R7	K118
+      0x74220004,  //  003B  JMPT	R8	#0041
+      0xB8222400,  //  003C  GETNGBL	R8	K18
+      0x8C20116F,  //  003D  GETMET	R8	R8	K111
+      0x58280077,  //  003E  LDCONST	R10	K119
+      0x7C200400,  //  003F  CALL	R8	2
+      0x80041000,  //  0040  RET	1	R8
+      0x8C200F78,  //  0041  GETMET	R8	R7	K120
+      0x7C200200,  //  0042  CALL	R8	1
+      0x60240013,  //  0043  GETGBL	R9	G19
+      0x7C240000,  //  0044  CALL	R9	0
+      0x60280010,  //  0045  GETGBL	R10	G16
+      0x8C2C0905,  //  0046  GETMET	R11	R4	K5
+      0x7C2C0200,  //  0047  CALL	R11	1
+      0x7C280200,  //  0048  CALL	R10	1
+      0xA8020016,  //  0049  EXBLK	0	#0061
+      0x5C2C1400,  //  004A  MOVE	R11	R10
+      0x7C2C0000,  //  004B  CALL	R11	0
+      0xB8322400,  //  004C  GETNGBL	R12	K18
+      0x8C301979,  //  004D  GETMET	R12	R12	K121
+      0x5C381000,  //  004E  MOVE	R14	R8
+      0x5C3C1600,  //  004F  MOVE	R15	R11
+      0x7C300600,  //  0050  CALL	R12	3
+      0x4C340000,  //  0051  LDNIL	R13
+      0x1C34180D,  //  0052  EQ	R13	R12	R13
+      0x78360008,  //  0053  JMPF	R13	#005D
+      0xB8362400,  //  0054  GETNGBL	R13	K18
+      0x8C341B6F,  //  0055  GETMET	R13	R13	K111
+      0x603C0018,  //  0056  GETGBL	R15	G24
+      0x5840007A,  //  0057  LDCONST	R16	K122
+      0x5C441600,  //  0058  MOVE	R17	R11
+      0x7C3C0400,  //  0059  CALL	R15	2
+      0x7C340400,  //  005A  CALL	R13	2
+      0xA8040001,  //  005B  EXBLK	1	1
+      0x80001A00,  //  005C  RET	0
+      0x9434100C,  //  005D  GETIDX	R13	R8	R12
+      0x9438080B,  //  005E  GETIDX	R14	R4	R11
+      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
+      0x7001FFE8,  //  0060  JMP		#004A
+      0x58280007,  //  0061  LDCONST	R10	K7
+      0xAC280200,  //  0062  CATCH	R10	1	0
+      0xB0080000,  //  0063  RAISE	2	R0	R0
+      0x8C280F7B,  //  0064  GETMET	R10	R7	K123
+      0x5C301200,  //  0065  MOVE	R12	R9
+      0x7C280400,  //  0066  CALL	R10	2
+      0x8C280F7C,  //  0067  GETMET	R10	R7	K124
+      0x7C280200,  //  0068  CALL	R10	1
+      0x782A000A,  //  0069  JMPF	R10	#0075
+      0x602C0018,  //  006A  GETGBL	R11	G24
+      0x5830007D,  //  006B  LDCONST	R12	K125
+      0x5C340200,  //  006C  MOVE	R13	R1
+      0x5C381400,  //  006D  MOVE	R14	R10
+      0x7C2C0600,  //  006E  CALL	R11	3
+      0xB8322400,  //  006F  GETNGBL	R12	K18
+      0x8C30197E,  //  0070  GETMET	R12	R12	K126
+      0x5C381600,  //  0071  MOVE	R14	R11
+      0x7C300400,  //  0072  CALL	R12	2
+      0x80041800,  //  0073  RET	1	R12
+      0x70020003,  //  0074  JMP		#0079
+      0xB82E2400,  //  0075  GETNGBL	R11	K18
+      0x8C2C1713,  //  0076  GETMET	R11	R11	K19
+      0x7C2C0200,  //  0077  CALL	R11	1
+      0x80041600,  //  0078  RET	1	R11
+      0xB81E2400,  //  0079  GETNGBL	R7	K18
+      0x8C1C0F6F,  //  007A  GETMET	R7	R7	K111
+      0x5824007F,  //  007B  LDCONST	R9	K127
+      0x7C1C0400,  //  007C  CALL	R7	2
+      0x80000000,  //  007D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_50ms
+********************************************************************/
+be_local_closure(class_Matter_Device_every_50ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_50ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804015A,  //  0000  GETMBR	R1	R0	K90
+      0x00040308,  //  0001  ADD	R1	R1	K8
+      0x9002B401,  //  0002  SETMBR	R0	K90	R1
+      0x8804010A,  //  0003  GETMBR	R1	R0	K10
+      0x8C040380,  //  0004  GETMET	R1	R1	K128
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(class_Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8804013B,  //  0000  GETMBR	R1	R0	K59
+      0x8C040381,  //  0001  GETMET	R1	R1	K129
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8804010A,  //  0003  GETMBR	R1	R0	K10
+      0x8C040381,  //  0004  GETMET	R1	R1	K129
+      0x7C040200,  //  0005  CALL	R1	1
+      0x88040162,  //  0006  GETMBR	R1	R0	K98
+      0x8C040381,  //  0007  GETMET	R1	R1	K129
+      0x7C040200,  //  0008  CALL	R1	1
+      0x8804015C,  //  0009  GETMBR	R1	R0	K92
+      0x8C040381,  //  000A  GETMET	R1	R1	K129
+      0x7C040200,  //  000B  CALL	R1	1
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_read_sensors_schedule
+********************************************************************/
+be_local_closure(class_Matter_Device_add_read_sensors_schedule,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(add_read_sensors_schedule),
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88080182,  //  0000  GETMBR	R2	R0	K130
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C080403,  //  0002  EQ	R2	R2	R3
+      0x740A0002,  //  0003  JMPT	R2	#0007
+      0x88080182,  //  0004  GETMBR	R2	R0	K130
+      0x24080401,  //  0005  GT	R2	R2	R1
+      0x780A0005,  //  0006  JMPF	R2	#000D
+      0x90030401,  //  0007  SETMBR	R0	K130	R1
+      0xB80A7E00,  //  0008  GETNGBL	R2	K63
+      0x8C080584,  //  0009  GETMET	R2	R2	K132
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x90030602,  //  000C  SETMBR	R0	K131	R2
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: load_param
+********************************************************************/
+be_local_closure(class_Matter_Device_load_param,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(load_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[136]) {  /* code */
+      0xA406A800,  //  0000  IMPORT	R1	K84
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0xA8020056,  //  0002  EXBLK	0	#005A
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x8810012B,  //  0004  GETMBR	R4	R0	K43
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C100785,  //  0006  GETMET	R4	R3	K133
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C14072E,  //  0008  GETMET	R5	R3	K46
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4163200,  //  000A  IMPORT	R5	K25
+      0x8C180B86,  //  000B  GETMET	R6	R5	K134
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D17,  //  000E  GETMET	R7	R6	K23
+      0x58240087,  //  000F  LDCONST	R9	K135
+      0x8828011C,  //  0010  GETMBR	R10	R0	K28
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90023807,  //  0012  SETMBR	R0	K28	R7
+      0x8C1C0D17,  //  0013  GETMET	R7	R6	K23
+      0x58240088,  //  0014  LDCONST	R9	K136
+      0x8828011D,  //  0015  GETMBR	R10	R0	K29
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90023A07,  //  0017  SETMBR	R0	K29	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D17,  //  0019  GETMET	R8	R6	K23
+      0x5828001E,  //  001A  LDCONST	R10	K30
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90023C07,  //  001E  SETMBR	R0	K30	R7
+      0x601C0017,  //  001F  GETGBL	R7	G23
+      0x8C200D17,  //  0020  GETMET	R8	R6	K23
+      0x58280021,  //  0021  LDCONST	R10	K33
+      0x502C0000,  //  0022  LDBOOL	R11	0	0
+      0x7C200600,  //  0023  CALL	R8	3
+      0x7C1C0200,  //  0024  CALL	R7	1
+      0x90024207,  //  0025  SETMBR	R0	K33	R7
+      0x8C1C0D17,  //  0026  GETMET	R7	R6	K23
+      0x58240089,  //  0027  LDCONST	R9	K137
+      0x88280122,  //  0028  GETMBR	R10	R0	K34
+      0x7C1C0600,  //  0029  CALL	R7	3
+      0x90024407,  //  002A  SETMBR	R0	K34	R7
+      0x8C1C0D17,  //  002B  GETMET	R7	R6	K23
+      0x5824008A,  //  002C  LDCONST	R9	K138
+      0x60280013,  //  002D  GETGBL	R10	G19
+      0x7C280000,  //  002E  CALL	R10	0
+      0x7C1C0600,  //  002F  CALL	R7	3
+      0x90025007,  //  0030  SETMBR	R0	K40	R7
+      0x601C0017,  //  0031  GETGBL	R7	G23
+      0x8C200D17,  //  0032  GETMET	R8	R6	K23
+      0x58280023,  //  0033  LDCONST	R10	K35
+      0x7C200400,  //  0034  CALL	R8	2
+      0x7C1C0200,  //  0035  CALL	R7	1
+      0x90024607,  //  0036  SETMBR	R0	K35	R7
+      0x881C0128,  //  0037  GETMBR	R7	R0	K40
+      0x4C200000,  //  0038  LDNIL	R8
+      0x201C0E08,  //  0039  NE	R7	R7	R8
+      0x781E000D,  //  003A  JMPF	R7	#0049
+      0xB81E5E00,  //  003B  GETNGBL	R7	K47
+      0x60200018,  //  003C  GETGBL	R8	G24
+      0x5824008B,  //  003D  LDCONST	R9	K139
+      0x88280128,  //  003E  GETMBR	R10	R0	K40
+      0x7C200400,  //  003F  CALL	R8	2
+      0x58240044,  //  0040  LDCONST	R9	K68
+      0x7C1C0400,  //  0041  CALL	R7	2
+      0x8C1C0142,  //  0042  GETMET	R7	R0	K66
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0x8C1C018C,  //  0044  GETMET	R7	R0	K140
+      0x7C1C0200,  //  0045  CALL	R7	1
+      0x5C080E00,  //  0046  MOVE	R2	R7
+      0x501C0200,  //  0047  LDBOOL	R7	1	0
+      0x90024A07,  //  0048  SETMBR	R0	K37	R7
+      0x8C1C0D17,  //  0049  GETMET	R7	R6	K23
+      0x5824008D,  //  004A  LDCONST	R9	K141
+      0x60280013,  //  004B  GETGBL	R10	G19
+      0x7C280000,  //  004C  CALL	R10	0
+      0x7C1C0600,  //  004D  CALL	R7	3
+      0x90023007,  //  004E  SETMBR	R0	K24	R7
+      0x881C0118,  //  004F  GETMBR	R7	R0	K24
+      0x781E0006,  //  0050  JMPF	R7	#0058
+      0xB81E5E00,  //  0051  GETNGBL	R7	K47
+      0x60200008,  //  0052  GETGBL	R8	G8
+      0x88240118,  //  0053  GETMBR	R9	R0	K24
+      0x7C200200,  //  0054  CALL	R8	1
+      0x00231C08,  //  0055  ADD	R8	K142	R8
+      0x58240044,  //  0056  LDCONST	R9	K68
+      0x7C1C0400,  //  0057  CALL	R7	2
+      0xA8040001,  //  0058  EXBLK	1	1
+      0x70020011,  //  0059  JMP		#006C
+      0xAC0C0002,  //  005A  CATCH	R3	0	2
+      0x7002000E,  //  005B  JMP		#006B
+      0x2014078F,  //  005C  NE	R5	R3	K143
+      0x7816000B,  //  005D  JMPF	R5	#006A
+      0xB8165E00,  //  005E  GETNGBL	R5	K47
+      0x60180008,  //  005F  GETGBL	R6	G8
+      0x5C1C0600,  //  0060  MOVE	R7	R3
+      0x7C180200,  //  0061  CALL	R6	1
+      0x001B2006,  //  0062  ADD	R6	K144	R6
+      0x00180D34,  //  0063  ADD	R6	R6	K52
+      0x601C0008,  //  0064  GETGBL	R7	G8
+      0x5C200800,  //  0065  MOVE	R8	R4
+      0x7C1C0200,  //  0066  CALL	R7	1
+      0x00180C07,  //  0067  ADD	R6	R6	R7
+      0x581C0032,  //  0068  LDCONST	R7	K50
+      0x7C140400,  //  0069  CALL	R5	2
+      0x70020000,  //  006A  JMP		#006C
+      0xB0080000,  //  006B  RAISE	2	R0	R0
+      0x880C011C,  //  006C  GETMBR	R3	R0	K28
+      0x4C100000,  //  006D  LDNIL	R4
+      0x1C0C0604,  //  006E  EQ	R3	R3	R4
+      0x780E000A,  //  006F  JMPF	R3	#007B
+      0x8C0C0391,  //  0070  GETMET	R3	R1	K145
+      0x58140032,  //  0071  LDCONST	R5	K50
+      0x7C0C0400,  //  0072  CALL	R3	2
+      0x8C0C074F,  //  0073  GETMET	R3	R3	K79
+      0x58140009,  //  0074  LDCONST	R5	K9
+      0x58180032,  //  0075  LDCONST	R6	K50
+      0x7C0C0600,  //  0076  CALL	R3	3
+      0x54120FFE,  //  0077  LDINT	R4	4095
+      0x2C0C0604,  //  0078  AND	R3	R3	R4
+      0x90023803,  //  0079  SETMBR	R0	K28	R3
+      0x50080200,  //  007A  LDBOOL	R2	1	0
+      0x880C011D,  //  007B  GETMBR	R3	R0	K29
+      0x4C100000,  //  007C  LDNIL	R4
+      0x1C0C0604,  //  007D  EQ	R3	R3	R4
+      0x780E0004,  //  007E  JMPF	R3	#0084
+      0x880C015C,  //  007F  GETMBR	R3	R0	K92
+      0x8C0C0792,  //  0080  GETMET	R3	R3	K146
+      0x7C0C0200,  //  0081  CALL	R3	1
+      0x90023A03,  //  0082  SETMBR	R0	K29	R3
+      0x50080200,  //  0083  LDBOOL	R2	1	0
+      0x780A0001,  //  0084  JMPF	R2	#0087
+      0x8C0C013D,  //  0085  GETMET	R3	R0	K61
+      0x7C0C0200,  //  0086  CALL	R3	1
+      0x80000000,  //  0087  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(class_Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A5E00,  //  0007  GETNGBL	R2	K47
+      0x600C0008,  //  0008  GETGBL	R3	G8
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x000F2603,  //  000B  ADD	R3	K147	R3
+      0x58100032,  //  000C  LDCONST	R4	K50
+      0x7C080400,  //  000D  CALL	R2	2
+      0xB80A7E00,  //  000E  GETNGBL	R2	K63
+      0x8C080594,  //  000F  GETMET	R2	R2	K148
+      0x5C100000,  //  0010  MOVE	R4	R0
+      0x5814000C,  //  0011  LDCONST	R5	K12
+      0x5C180200,  //  0012  MOVE	R6	R1
+      0x7C080800,  //  0013  CALL	R2	4
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080595,  //  0016  GETMET	R2	R2	K149
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: network_up
+********************************************************************/
+be_local_closure(class_Matter_Device_network_up,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(network_up),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060002,  //  0001  JMPF	R1	#0005
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x8C040396,  //  0003  GETMET	R1	R1	K150
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_zigbee_present
+********************************************************************/
+be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(is_zigbee_present),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA4069A00,  //  0000  IMPORT	R1	K77
+      0x8C080397,  //  0001  GETMET	R2	R1	K151
+      0x58100003,  //  0002  LDCONST	R4	K3
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x20080403,  //  0005  NE	R2	R2	R3
+      0x80040400,  //  0006  RET	1	R2
     })
   )
 );
@@ -942,36 +2033,745 @@ be_local_closure(class_Matter_Device_remove_fabric,   /* name */
       0x4C080000,  //  0000  LDNIL	R2
       0x20080202,  //  0001  NE	R2	R1	R2
       0x780A0019,  //  0002  JMPF	R2	#001D
-      0xB80A1400,  //  0003  GETNGBL	R2	K10
-      0x8C0C0343,  //  0004  GETMET	R3	R1	K67
+      0xB80A5E00,  //  0003  GETNGBL	R2	K47
+      0x8C0C0399,  //  0004  GETMET	R3	R1	K153
       0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0744,  //  0006  GETMET	R3	R3	K68
+      0x8C0C079A,  //  0006  GETMET	R3	R3	K154
       0x7C0C0200,  //  0007  CALL	R3	1
-      0x8C0C0745,  //  0008  GETMET	R3	R3	K69
+      0x8C0C079B,  //  0008  GETMET	R3	R3	K155
       0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C0C0746,  //  000A  GETMET	R3	R3	K70
+      0x8C0C079C,  //  000A  GETMET	R3	R3	K156
       0x7C0C0200,  //  000B  CALL	R3	1
-      0x000E8403,  //  000C  ADD	R3	K66	R3
-      0x58100028,  //  000D  LDCONST	R4	K40
+      0x000F3003,  //  000C  ADD	R3	K152	R3
+      0x58100032,  //  000D  LDCONST	R4	K50
       0x7C080400,  //  000E  CALL	R2	2
-      0x88080121,  //  000F  GETMBR	R2	R0	K33
-      0x88080547,  //  0010  GETMBR	R2	R2	K71
-      0x88080548,  //  0011  GETMBR	R2	R2	K72
-      0x8C080549,  //  0012  GETMET	R2	R2	K73
+      0x8808010A,  //  000F  GETMBR	R2	R0	K10
+      0x8808056C,  //  0010  GETMBR	R2	R2	K108
+      0x8808056D,  //  0011  GETMBR	R2	R2	K109
+      0x8C08059D,  //  0012  GETMET	R2	R2	K157
       0x5C100200,  //  0013  MOVE	R4	R1
       0x7C080400,  //  0014  CALL	R2	2
-      0x88080133,  //  0015  GETMBR	R2	R0	K51
-      0x8C08054A,  //  0016  GETMET	R2	R2	K74
+      0x8808015C,  //  0015  GETMBR	R2	R0	K92
+      0x8C08059E,  //  0016  GETMET	R2	R2	K158
       0x5C100200,  //  0017  MOVE	R4	R1
       0x7C080400,  //  0018  CALL	R2	2
-      0x88080100,  //  0019  GETMBR	R2	R0	K0
-      0x8C08054B,  //  001A  GETMET	R2	R2	K75
+      0x8808013B,  //  0019  GETMBR	R2	R0	K59
+      0x8C08059F,  //  001A  GETMET	R2	R2	K159
       0x5C100200,  //  001B  MOVE	R4	R1
       0x7C080400,  //  001C  CALL	R2	2
-      0x88080100,  //  001D  GETMBR	R2	R0	K0
-      0x8C08054C,  //  001E  GETMET	R2	R2	K76
+      0x8808013B,  //  001D  GETMBR	R2	R0	K59
+      0x8C0805A0,  //  001E  GETMET	R2	R2	K160
       0x7C080200,  //  001F  CALL	R2	1
       0x80000000,  //  0020  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update_remotes_info
+********************************************************************/
+be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(update_remotes_info),
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x8808014E,  //  0002  GETMBR	R2	R0	K78
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x20080403,  //  0004  NE	R2	R2	R3
+      0x780A0018,  //  0005  JMPF	R2	#001F
+      0x60080010,  //  0006  GETGBL	R2	G16
+      0x880C014E,  //  0007  GETMBR	R3	R0	K78
+      0x8C0C0705,  //  0008  GETMET	R3	R3	K5
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x7C080200,  //  000A  CALL	R2	1
+      0xA802000F,  //  000B  EXBLK	0	#001C
+      0x5C0C0400,  //  000C  MOVE	R3	R2
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x8810014E,  //  000E  GETMBR	R4	R0	K78
+      0x94100803,  //  000F  GETIDX	R4	R4	R3
+      0x8C1009A1,  //  0010  GETMET	R4	R4	K161
+      0x7C100200,  //  0011  CALL	R4	1
+      0x4C140000,  //  0012  LDNIL	R5
+      0x20140805,  //  0013  NE	R5	R4	R5
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x6014000C,  //  0015  GETGBL	R5	G12
+      0x5C180800,  //  0016  MOVE	R6	R4
+      0x7C140200,  //  0017  CALL	R5	1
+      0x24140B09,  //  0018  GT	R5	R5	K9
+      0x78160000,  //  0019  JMPF	R5	#001B
+      0x98040604,  //  001A  SETIDX	R1	R3	R4
+      0x7001FFEF,  //  001B  JMP		#000C
+      0x58080007,  //  001C  LDCONST	R2	K7
+      0xAC080200,  //  001D  CATCH	R2	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x90023001,  //  001F  SETMBR	R0	K24	R1
+      0x80040200,  //  0020  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_plugin_class_displayname
+********************************************************************/
+be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(get_plugin_class_displayname),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880801A2,  //  0000  GETMBR	R2	R0	K162
+      0x8C080517,  //  0001  GETMET	R2	R2	K23
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x880C05A3,  //  0005  GETMBR	R3	R2	K163
+      0x70020000,  //  0006  JMP		#0008
+      0x580C000C,  //  0007  LDCONST	R3	K12
+      0x80040600,  //  0008  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: adjust_next_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(adjust_next_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080128,  //  0001  GETMBR	R2	R0	K40
+      0x8C080505,  //  0002  GETMET	R2	R2	K5
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000A,  //  0005  EXBLK	0	#0011
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x600C0009,  //  0008  GETGBL	R3	G9
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x88100122,  //  000B  GETMBR	R4	R0	K34
+      0x28100604,  //  000C  GE	R4	R3	R4
+      0x78120001,  //  000D  JMPF	R4	#0010
+      0x00100708,  //  000E  ADD	R4	R3	K8
+      0x90024404,  //  000F  SETMBR	R0	K34	R4
+      0x7001FFF4,  //  0010  JMP		#0006
+      0x58040007,  //  0011  LDCONST	R1	K7
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: bridge_add_endpoint
+********************************************************************/
+be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(bridge_add_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[68]) {  /* code */
+      0x880C01A2,  //  0000  GETMBR	R3	R0	K162
+      0x8C0C0717,  //  0001  GETMET	R3	R3	K23
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x4C100000,  //  0004  LDNIL	R4
+      0x1C100604,  //  0005  EQ	R4	R3	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0xB8125E00,  //  0007  GETNGBL	R4	K47
+      0x60140008,  //  0008  GETGBL	R5	G8
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C140200,  //  000A  CALL	R5	1
+      0x00174805,  //  000B  ADD	R5	K164	R5
+      0x00140BA5,  //  000C  ADD	R5	R5	K165
+      0x58180044,  //  000D  LDCONST	R6	K68
+      0x7C100400,  //  000E  CALL	R4	2
+      0x80000800,  //  000F  RET	0
+      0x88100122,  //  0010  GETMBR	R4	R0	K34
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x5C180800,  //  0012  MOVE	R6	R4
+      0x7C140200,  //  0013  CALL	R5	1
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x5C1C0000,  //  0015  MOVE	R7	R0
+      0x5C200800,  //  0016  MOVE	R8	R4
+      0x5C240400,  //  0017  MOVE	R9	R2
+      0x7C180600,  //  0018  CALL	R6	3
+      0x881C010D,  //  0019  GETMBR	R7	R0	K13
+      0x8C1C0F06,  //  001A  GETMET	R7	R7	K6
+      0x5C240C00,  //  001B  MOVE	R9	R6
+      0x7C1C0400,  //  001C  CALL	R7	2
+      0x601C0013,  //  001D  GETGBL	R7	G19
+      0x7C1C0000,  //  001E  CALL	R7	0
+      0x981E7001,  //  001F  SETIDX	R7	K56	R1
+      0x60200010,  //  0020  GETGBL	R8	G16
+      0x8C240505,  //  0021  GETMET	R9	R2	K5
+      0x7C240200,  //  0022  CALL	R9	1
+      0x7C200200,  //  0023  CALL	R8	1
+      0xA8020004,  //  0024  EXBLK	0	#002A
+      0x5C241000,  //  0025  MOVE	R9	R8
+      0x7C240000,  //  0026  CALL	R9	0
+      0x94280409,  //  0027  GETIDX	R10	R2	R9
+      0x981C120A,  //  0028  SETIDX	R7	R9	R10
+      0x7001FFFA,  //  0029  JMP		#0025
+      0x58200007,  //  002A  LDCONST	R8	K7
+      0xAC200200,  //  002B  CATCH	R8	1	0
+      0xB0080000,  //  002C  RAISE	2	R0	R0
+      0xB8225E00,  //  002D  GETNGBL	R8	K47
+      0x60240018,  //  002E  GETGBL	R9	G24
+      0x582800A6,  //  002F  LDCONST	R10	K166
+      0x5C2C0800,  //  0030  MOVE	R11	R4
+      0x5C300200,  //  0031  MOVE	R12	R1
+      0x8C3401A7,  //  0032  GETMET	R13	R0	K167
+      0x5C3C0400,  //  0033  MOVE	R15	R2
+      0x7C340400,  //  0034  CALL	R13	2
+      0x7C240800,  //  0035  CALL	R9	4
+      0x58280032,  //  0036  LDCONST	R10	K50
+      0x7C200400,  //  0037  CALL	R8	2
+      0x88200128,  //  0038  GETMBR	R8	R0	K40
+      0x98200A07,  //  0039  SETIDX	R8	R5	R7
+      0x50200200,  //  003A  LDBOOL	R8	1	0
+      0x90024A08,  //  003B  SETMBR	R0	K37	R8
+      0x88200122,  //  003C  GETMBR	R8	R0	K34
+      0x00201108,  //  003D  ADD	R8	R8	K8
+      0x90024408,  //  003E  SETMBR	R0	K34	R8
+      0x8C20013D,  //  003F  GETMET	R8	R0	K61
+      0x7C200200,  //  0040  CALL	R8	1
+      0x8C2001A8,  //  0041  GETMET	R8	R0	K168
+      0x7C200200,  //  0042  CALL	R8	1
+      0x80040800,  //  0043  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reset_param
+********************************************************************/
+be_local_closure(class_Matter_Device_reset_param,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(reset_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x90024A01,  //  0001  SETMBR	R0	K37	R1
+      0x8804015B,  //  0002  GETMBR	R1	R0	K91
+      0x90024401,  //  0003  SETMBR	R0	K34	R1
+      0x8C04013D,  //  0004  GETMET	R1	R0	K61
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_sensors_scheduler
+********************************************************************/
+be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(read_sensors_scheduler),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040182,  //  0000  GETMBR	R1	R0	K130
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x78060000,  //  0003  JMPF	R1	#0005
+      0x80000200,  //  0004  RET	0
+      0x88040183,  //  0005  GETMBR	R1	R0	K131
+      0x1C040309,  //  0006  EQ	R1	R1	K9
+      0x74060004,  //  0007  JMPT	R1	#000D
+      0xB8062400,  //  0008  GETNGBL	R1	K18
+      0x8C0403A9,  //  0009  GETMET	R1	R1	K169
+      0x880C0183,  //  000A  GETMBR	R3	R0	K131
+      0x7C040400,  //  000B  CALL	R1	2
+      0x78060006,  //  000C  JMPF	R1	#0014
+      0x8C0401AA,  //  000D  GETMET	R1	R0	K170
+      0x7C040200,  //  000E  CALL	R1	1
+      0xB8062400,  //  000F  GETNGBL	R1	K18
+      0x8C0403AB,  //  0010  GETMET	R1	R1	K171
+      0x880C0182,  //  0011  GETMBR	R3	R0	K130
+      0x7C040400,  //  0012  CALL	R1	2
+      0x90030601,  //  0013  SETMBR	R0	K131	R1
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_config_ep
+********************************************************************/
+be_local_closure(class_Matter_Device_check_config_ep,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(check_config_ep),
+    &be_const_str_solidified,
+    ( &(const binstruction[61]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x600C0010,  //  0003  GETGBL	R3	G16
+      0x88100128,  //  0004  GETMBR	R4	R0	K40
+      0x8C100905,  //  0005  GETMET	R4	R4	K5
+      0x7C100200,  //  0006  CALL	R4	1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0xA8020007,  //  0008  EXBLK	0	#0011
+      0x5C100600,  //  0009  MOVE	R4	R3
+      0x7C100000,  //  000A  CALL	R4	0
+      0x8C140506,  //  000B  GETMET	R5	R2	K6
+      0x601C0009,  //  000C  GETGBL	R7	G9
+      0x5C200800,  //  000D  MOVE	R8	R4
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x7001FFF7,  //  0010  JMP		#0009
+      0x580C0007,  //  0011  LDCONST	R3	K7
+      0xAC0C0200,  //  0012  CATCH	R3	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x600C0010,  //  0014  GETGBL	R3	G16
+      0x5C100400,  //  0015  MOVE	R4	R2
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0xA8020020,  //  0017  EXBLK	0	#0039
+      0x5C100600,  //  0018  MOVE	R4	R3
+      0x7C100000,  //  0019  CALL	R4	0
+      0x1C140908,  //  001A  EQ	R5	R4	K8
+      0x7816001B,  //  001B  JMPF	R5	#0038
+      0x50040200,  //  001C  LDBOOL	R1	1	0
+      0xB8165E00,  //  001D  GETNGBL	R5	K47
+      0x60180018,  //  001E  GETGBL	R6	G24
+      0x581C00AC,  //  001F  LDCONST	R7	K172
+      0x5C200800,  //  0020  MOVE	R8	R4
+      0x88240122,  //  0021  GETMBR	R9	R0	K34
+      0x7C180600,  //  0022  CALL	R6	3
+      0x581C0032,  //  0023  LDCONST	R7	K50
+      0x7C140400,  //  0024  CALL	R5	2
+      0x60140008,  //  0025  GETGBL	R5	G8
+      0x88180122,  //  0026  GETMBR	R6	R0	K34
+      0x7C140200,  //  0027  CALL	R5	1
+      0x88180128,  //  0028  GETMBR	R6	R0	K40
+      0x601C0008,  //  0029  GETGBL	R7	G8
+      0x5C200800,  //  002A  MOVE	R8	R4
+      0x7C1C0200,  //  002B  CALL	R7	1
+      0x88200128,  //  002C  GETMBR	R8	R0	K40
+      0x941C1007,  //  002D  GETIDX	R7	R8	R7
+      0x98180A07,  //  002E  SETIDX	R6	R5	R7
+      0x88140128,  //  002F  GETMBR	R5	R0	K40
+      0x8C140B3A,  //  0030  GETMET	R5	R5	K58
+      0x601C0008,  //  0031  GETGBL	R7	G8
+      0x5C200800,  //  0032  MOVE	R8	R4
+      0x7C1C0200,  //  0033  CALL	R7	1
+      0x7C140400,  //  0034  CALL	R5	2
+      0x88140122,  //  0035  GETMBR	R5	R0	K34
+      0x00140B08,  //  0036  ADD	R5	R5	K8
+      0x90024405,  //  0037  SETMBR	R0	K34	R5
+      0x7001FFDE,  //  0038  JMP		#0018
+      0x580C0007,  //  0039  LDCONST	R3	K7
+      0xAC0C0200,  //  003A  CATCH	R3	1	0
+      0xB0080000,  //  003B  RAISE	2	R0	R0
+      0x80040200,  //  003C  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: signal_endpoints_changed
+********************************************************************/
+be_local_closure(class_Matter_Device_signal_endpoints_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(signal_endpoints_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x8C0401AD,  //  0000  GETMET	R1	R0	K173
+      0x580C0009,  //  0001  LDCONST	R3	K9
+      0x5412001C,  //  0002  LDINT	R4	29
+      0x58140044,  //  0003  LDCONST	R5	K68
+      0x50180000,  //  0004  LDBOOL	R6	0	0
+      0x7C040A00,  //  0005  CALL	R1	5
+      0x8C0401AD,  //  0006  GETMET	R1	R0	K173
+      0x580C0008,  //  0007  LDCONST	R3	K8
+      0x5412001C,  //  0008  LDINT	R4	29
+      0x58140044,  //  0009  LDCONST	R5	K68
+      0x50180000,  //  000A  LDBOOL	R6	0	0
+      0x7C040A00,  //  000B  CALL	R1	5
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_attribute_expansion
+********************************************************************/
+be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(process_attribute_expansion),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x880C030F,  //  0000  GETMBR	R3	R1	K15
+      0x88100347,  //  0001  GETMBR	R4	R1	K71
+      0x88140348,  //  0002  GETMBR	R5	R1	K72
+      0xB81A7E00,  //  0003  GETNGBL	R6	K63
+      0x8C180DAE,  //  0004  GETMET	R6	R6	K174
+      0x5C200000,  //  0005  MOVE	R8	R0
+      0x7C180400,  //  0006  CALL	R6	2
+      0x8C1C0D95,  //  0007  GETMET	R7	R6	K149
+      0x5C240600,  //  0008  MOVE	R9	R3
+      0x5C280800,  //  0009  MOVE	R10	R4
+      0x5C2C0A00,  //  000A  MOVE	R11	R5
+      0x7C1C0800,  //  000B  CALL	R7	4
+      0x8C1C0DAF,  //  000C  GETMET	R7	R6	K175
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0x4C200000,  //  000E  LDNIL	R8
+      0x8C240DB0,  //  000F  GETMET	R9	R6	K176
+      0x7C240200,  //  0010  CALL	R9	1
+      0x5C201200,  //  0011  MOVE	R8	R9
+      0x4C280000,  //  0012  LDNIL	R10
+      0x2024120A,  //  0013  NE	R9	R9	R10
+      0x78260005,  //  0014  JMPF	R9	#001B
+      0x5C240400,  //  0015  MOVE	R9	R2
+      0x8C280DB1,  //  0016  GETMET	R10	R6	K177
+      0x7C280200,  //  0017  CALL	R10	1
+      0x5C2C1000,  //  0018  MOVE	R11	R8
+      0x7C240400,  //  0019  CALL	R9	2
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_http_remote
+********************************************************************/
+be_local_closure(class_Matter_Device_register_http_remote,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(register_http_remote),
+    &be_const_str_solidified,
+    ( &(const binstruction[42]) {  /* code */
+      0x880C014E,  //  0000  GETMBR	R3	R0	K78
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C0C0604,  //  0002  EQ	R3	R3	R4
+      0x780E0002,  //  0003  JMPF	R3	#0007
+      0x600C0013,  //  0004  GETGBL	R3	G19
+      0x7C0C0000,  //  0005  CALL	R3	0
+      0x90029C03,  //  0006  SETMBR	R0	K78	R3
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x8810014E,  //  0008  GETMBR	R4	R0	K78
+      0x8C1009B2,  //  0009  GETMET	R4	R4	K178
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C100400,  //  000B  CALL	R4	2
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x8810014E,  //  000D  GETMBR	R4	R0	K78
+      0x940C0801,  //  000E  GETIDX	R3	R4	R1
+      0x8C1007B3,  //  000F  GETMET	R4	R3	K179
+      0x7C100200,  //  0010  CALL	R4	1
+      0x14100404,  //  0011  LT	R4	R2	R4
+      0x78120002,  //  0012  JMPF	R4	#0016
+      0x8C1007B4,  //  0013  GETMET	R4	R3	K180
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020011,  //  0016  JMP		#0029
+      0xB8127E00,  //  0017  GETNGBL	R4	K63
+      0x8C1009B5,  //  0018  GETMET	R4	R4	K181
+      0x5C180000,  //  0019  MOVE	R6	R0
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0x5C200400,  //  001B  MOVE	R8	R2
+      0x7C100800,  //  001C  CALL	R4	4
+      0x5C0C0800,  //  001D  MOVE	R3	R4
+      0x88100118,  //  001E  GETMBR	R4	R0	K24
+      0x8C1009B2,  //  001F  GETMET	R4	R4	K178
+      0x5C180200,  //  0020  MOVE	R6	R1
+      0x7C100400,  //  0021  CALL	R4	2
+      0x78120003,  //  0022  JMPF	R4	#0027
+      0x8C1007B6,  //  0023  GETMET	R4	R3	K182
+      0x88180118,  //  0024  GETMBR	R6	R0	K24
+      0x94180C01,  //  0025  GETIDX	R6	R6	R1
+      0x7C100400,  //  0026  CALL	R4	2
+      0x8810014E,  //  0027  GETMBR	R4	R0	K78
+      0x98100203,  //  0028  SETIDX	R4	R1	R3
+      0x80040600,  //  0029  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _trigger_read_sensors
+********************************************************************/
+be_local_closure(class_Matter_Device__trigger_read_sensors,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0xA4063200,  //  0000  IMPORT	R1	K25
+      0xB80A2400,  //  0001  GETNGBL	R2	K18
+      0x8C0805B7,  //  0002  GETMET	R2	R2	K183
+      0x7C080200,  //  0003  CALL	R2	1
+      0xB80E2400,  //  0004  GETNGBL	R3	K18
+      0x8C0C07B8,  //  0005  GETMET	R3	R3	K184
+      0x58140044,  //  0006  LDCONST	R5	K68
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x780E0006,  //  0008  JMPF	R3	#0010
+      0xB80E5E00,  //  0009  GETNGBL	R3	K47
+      0x60100008,  //  000A  GETGBL	R4	G8
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C100200,  //  000C  CALL	R4	1
+      0x00137204,  //  000D  ADD	R4	K185	R4
+      0x58140044,  //  000E  LDCONST	R5	K68
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x4C0C0000,  //  0010  LDNIL	R3
+      0x1C0C0403,  //  0011  EQ	R3	R2	R3
+      0x780E0000,  //  0012  JMPF	R3	#0014
+      0x80000600,  //  0013  RET	0
+      0x8C0C0386,  //  0014  GETMET	R3	R1	K134
+      0x5C140400,  //  0015  MOVE	R5	R2
+      0x7C0C0400,  //  0016  CALL	R3	2
+      0x4C100000,  //  0017  LDNIL	R4
+      0x20100604,  //  0018  NE	R4	R3	R4
+      0x7812000D,  //  0019  JMPF	R4	#0028
+      0x58100009,  //  001A  LDCONST	R4	K9
+      0x6014000C,  //  001B  GETGBL	R5	G12
+      0x8818010D,  //  001C  GETMBR	R6	R0	K13
+      0x7C140200,  //  001D  CALL	R5	1
+      0x14140805,  //  001E  LT	R5	R4	R5
+      0x78160006,  //  001F  JMPF	R5	#0027
+      0x8814010D,  //  0020  GETMBR	R5	R0	K13
+      0x94140A04,  //  0021  GETIDX	R5	R5	R4
+      0x8C140BBA,  //  0022  GETMET	R5	R5	K186
+      0x5C1C0600,  //  0023  MOVE	R7	R3
+      0x7C140400,  //  0024  CALL	R5	2
+      0x00100908,  //  0025  ADD	R4	R4	K8
+      0x7001FFF3,  //  0026  JMP		#001B
+      0x70020006,  //  0027  JMP		#002F
+      0xB8125E00,  //  0028  GETNGBL	R4	K47
+      0x60140008,  //  0029  GETGBL	R5	G8
+      0x5C180400,  //  002A  MOVE	R6	R2
+      0x7C140200,  //  002B  CALL	R5	1
+      0x00177605,  //  002C  ADD	R5	K187	R5
+      0x58180044,  //  002D  LDCONST	R6	K68
+      0x7C100400,  //  002E  CALL	R4	2
+      0x80000000,  //  002F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(class_Matter_Device_received_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C0805BC,  //  0001  GETMET	R2	R2	K188
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: button_handler
+********************************************************************/
+be_local_closure(class_Matter_Device_button_handler,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(button_handler),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x58140009,  //  0000  LDCONST	R5	K9
+      0xA41A9A00,  //  0001  IMPORT	R6	K77
+      0x601C000C,  //  0002  GETGBL	R7	G12
+      0x8820010D,  //  0003  GETMBR	R8	R0	K13
+      0x7C1C0200,  //  0004  CALL	R7	1
+      0x141C0A07,  //  0005  LT	R7	R5	R7
+      0x781E0010,  //  0006  JMPF	R7	#0018
+      0x881C010D,  //  0007  GETMBR	R7	R0	K13
+      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
+      0x8C200DB2,  //  0009  GETMET	R8	R6	K178
+      0x5C280E00,  //  000A  MOVE	R10	R7
+      0x582C0046,  //  000B  LDCONST	R11	K70
+      0x7C200600,  //  000C  CALL	R8	3
+      0x78220007,  //  000D  JMPF	R8	#0016
+      0x8820010D,  //  000E  GETMBR	R8	R0	K13
+      0x94201005,  //  000F  GETIDX	R8	R8	R5
+      0x8C201146,  //  0010  GETMET	R8	R8	K70
+      0x5C280200,  //  0011  MOVE	R10	R1
+      0x5C2C0400,  //  0012  MOVE	R11	R2
+      0x5C300600,  //  0013  MOVE	R12	R3
+      0x5C340800,  //  0014  MOVE	R13	R4
+      0x7C200A00,  //  0015  CALL	R8	5
+      0x00140B08,  //  0016  ADD	R5	R5	K8
+      0x7001FFE9,  //  0017  JMP		#0002
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: network_down
+********************************************************************/
+be_local_closure(class_Matter_Device_network_down,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(network_down),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060002,  //  0001  JMPF	R1	#0005
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x8C0403BD,  //  0003  GETMET	R1	R1	K189
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -995,36 +2795,36 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
     be_str_weak(bridge_remove_endpoint),
     &be_const_str_solidified,
     ( &(const binstruction[56]) {  /* code */
-      0xA40A0A00,  //  0000  IMPORT	R2	K5
+      0xA40A3200,  //  0000  IMPORT	R2	K25
       0x600C0008,  //  0001  GETGBL	R3	G8
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C0C0200,  //  0003  CALL	R3	1
       0x4C100000,  //  0004  LDNIL	R4
       0x4C140000,  //  0005  LDNIL	R5
-      0x8818014D,  //  0006  GETMBR	R6	R0	K77
-      0x8C180D4E,  //  0007  GETMET	R6	R6	K78
+      0x88180128,  //  0006  GETMBR	R6	R0	K40
+      0x8C180DB2,  //  0007  GETMET	R6	R6	K178
       0x5C200600,  //  0008  MOVE	R8	R3
       0x7C180400,  //  0009  CALL	R6	2
       0x741A0004,  //  000A  JMPT	R6	#0010
-      0xB81A1400,  //  000B  GETNGBL	R6	K10
-      0x001E9E03,  //  000C  ADD	R7	K79	R3
-      0x58200009,  //  000D  LDCONST	R8	K9
+      0xB81A5E00,  //  000B  GETNGBL	R6	K47
+      0x001F7C03,  //  000C  ADD	R7	K190	R3
+      0x58200044,  //  000D  LDCONST	R8	K68
       0x7C180400,  //  000E  CALL	R6	2
       0x80000C00,  //  000F  RET	0
-      0xB81A1400,  //  0010  GETNGBL	R6	K10
+      0xB81A5E00,  //  0010  GETNGBL	R6	K47
       0x601C0018,  //  0011  GETGBL	R7	G24
-      0x58200050,  //  0012  LDCONST	R8	K80
+      0x582000BF,  //  0012  LDCONST	R8	K191
       0x5C240200,  //  0013  MOVE	R9	R1
       0x7C1C0400,  //  0014  CALL	R7	2
-      0x58200028,  //  0015  LDCONST	R8	K40
+      0x58200032,  //  0015  LDCONST	R8	K50
       0x7C180400,  //  0016  CALL	R6	2
-      0x8818014D,  //  0017  GETMBR	R6	R0	K77
-      0x8C180D41,  //  0018  GETMET	R6	R6	K65
+      0x88180128,  //  0017  GETMBR	R6	R0	K40
+      0x8C180D3A,  //  0018  GETMET	R6	R6	K58
       0x5C200600,  //  0019  MOVE	R8	R3
       0x7C180400,  //  001A  CALL	R6	2
       0x50180200,  //  001B  LDBOOL	R6	1	0
-      0x90020606,  //  001C  SETMBR	R0	K3	R6
-      0x58180002,  //  001D  LDCONST	R6	K2
+      0x90024A06,  //  001C  SETMBR	R0	K37	R6
+      0x58180009,  //  001D  LDCONST	R6	K9
       0x601C000C,  //  001E  GETGBL	R7	G12
       0x8820010D,  //  001F  GETMBR	R8	R0	K13
       0x7C1C0200,  //  0020  CALL	R7	1
@@ -1032,23 +2832,23 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
       0x781E000D,  //  0022  JMPF	R7	#0031
       0x881C010D,  //  0023  GETMBR	R7	R0	K13
       0x941C0E06,  //  0024  GETIDX	R7	R7	R6
-      0x8C1C0F51,  //  0025  GETMET	R7	R7	K81
+      0x8C1C0F16,  //  0025  GETMET	R7	R7	K22
       0x7C1C0200,  //  0026  CALL	R7	1
       0x1C1C0207,  //  0027  EQ	R7	R1	R7
       0x781E0005,  //  0028  JMPF	R7	#002F
       0x881C010D,  //  0029  GETMBR	R7	R0	K13
-      0x8C1C0F41,  //  002A  GETMET	R7	R7	K65
+      0x8C1C0F3A,  //  002A  GETMET	R7	R7	K58
       0x5C240C00,  //  002B  MOVE	R9	R6
       0x7C1C0400,  //  002C  CALL	R7	2
       0x70020002,  //  002D  JMP		#0031
       0x70020000,  //  002E  JMP		#0030
-      0x00180D0F,  //  002F  ADD	R6	R6	K15
+      0x00180D08,  //  002F  ADD	R6	R6	K8
       0x7001FFEC,  //  0030  JMP		#001E
-      0x8C1C0152,  //  0031  GETMET	R7	R0	K82
+      0x8C1C01C0,  //  0031  GETMET	R7	R0	K192
       0x7C1C0200,  //  0032  CALL	R7	1
-      0x8C1C0104,  //  0033  GETMET	R7	R0	K4
+      0x8C1C013D,  //  0033  GETMET	R7	R0	K61
       0x7C1C0200,  //  0034  CALL	R7	1
-      0x8C1C0153,  //  0035  GETMET	R7	R0	K83
+      0x8C1C01A8,  //  0035  GETMET	R7	R0	K168
       0x7C1C0200,  //  0036  CALL	R7	1
       0x80000000,  //  0037  RET	0
     })
@@ -1058,12 +2858,12 @@ be_local_closure(class_Matter_Device_bridge_remove_endpoint,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_250ms
+** Solidified function: find_plugin_by_endpoint
 ********************************************************************/
-be_local_closure(class_Matter_Device_every_250ms,   /* name */
+be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1071,23 +2871,63 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_250ms),
+    be_str_weak(find_plugin_by_endpoint),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080009,  //  0000  LDCONST	R2	K9
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x8810010D,  //  0002  GETMBR	R4	R0	K13
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0008,  //  0005  JMPF	R3	#000F
+      0x880C010D,  //  0006  GETMBR	R3	R0	K13
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100716,  //  0008  GETMET	R4	R3	K22
+      0x7C100200,  //  0009  CALL	R4	1
+      0x1C100801,  //  000A  EQ	R4	R4	R1
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80040600,  //  000C  RET	1	R3
+      0x00080508,  //  000D  ADD	R2	R2	K8
+      0x7001FFF1,  //  000E  JMP		#0001
+      0x4C0C0000,  //  000F  LDNIL	R3
+      0x80040600,  //  0010  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: MtrJoin
+********************************************************************/
+be_local_closure(class_Matter_Device_MtrJoin,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    5,                          /* argc */
+    10,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    &be_ktab_class_Matter_Device,     /* shared constants */
+    be_str_weak(MtrJoin),
     &be_const_str_solidified,
     ( &(const binstruction[15]) {  /* code */
-      0x8C040154,  //  0000  GETMET	R1	R0	K84
-      0x7C040200,  //  0001  CALL	R1	1
-      0x58040002,  //  0002  LDCONST	R1	K2
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C010D,  //  0004  GETMBR	R3	R0	K13
-      0x7C080200,  //  0005  CALL	R2	1
-      0x14080202,  //  0006  LT	R2	R1	R2
-      0x780A0005,  //  0007  JMPF	R2	#000E
-      0x8808010D,  //  0008  GETMBR	R2	R0	K13
-      0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C080555,  //  000A  GETMET	R2	R2	K85
-      0x7C080200,  //  000B  CALL	R2	1
-      0x0004030F,  //  000C  ADD	R1	R1	K15
-      0x7001FFF4,  //  000D  JMP		#0003
+      0x60140009,  //  0000  GETGBL	R5	G9
+      0x5C180600,  //  0001  MOVE	R6	R3
+      0x7C140200,  //  0002  CALL	R5	1
+      0x78160003,  //  0003  JMPF	R5	#0008
+      0x8818015C,  //  0004  GETMBR	R6	R0	K92
+      0x8C180DC1,  //  0005  GETMET	R6	R6	K193
+      0x7C180200,  //  0006  CALL	R6	1
+      0x70020002,  //  0007  JMP		#000B
+      0x8818015C,  //  0008  GETMBR	R6	R0	K92
+      0x8C180DC2,  //  0009  GETMET	R6	R6	K194
+      0x7C180200,  //  000A  CALL	R6	1
+      0xB81A2400,  //  000B  GETNGBL	R6	K18
+      0x8C180D13,  //  000C  GETMET	R6	R6	K19
+      0x7C180200,  //  000D  CALL	R6	1
       0x80000000,  //  000E  RET	0
     })
   )
@@ -1096,11 +2936,11 @@ be_local_closure(class_Matter_Device_every_250ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: save_before_restart
 ********************************************************************/
-be_local_closure(class_Matter_Device_start,   /* name */
+be_local_closure(class_Matter_Device_save_before_restart,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     10,                          /* varg */
     0,                          /* has upvals */
@@ -1109,18 +2949,16 @@ be_local_closure(class_Matter_Device_start,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(start),
+    be_str_weak(save_before_restart),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C040156,  //  0000  GETMET	R1	R0	K86
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040157,  //  0002  GETMET	R1	R0	K87
-      0x880C0158,  //  0003  GETMBR	R3	R0	K88
-      0x7C040400,  //  0004  CALL	R1	2
-      0x88040133,  //  0005  GETMBR	R1	R0	K51
-      0x8C040359,  //  0006  GETMET	R1	R1	K89
-      0x7C040200,  //  0007  CALL	R1	1
-      0x80000000,  //  0008  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x8804015C,  //  0000  GETMBR	R1	R0	K92
+      0x8C0403C2,  //  0001  GETMET	R1	R1	K194
+      0x7C040200,  //  0002  CALL	R1	1
+      0x8804015C,  //  0003  GETMBR	R1	R0	K92
+      0x8C0403C3,  //  0004  GETMET	R1	R1	K195
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -1226,948 +3064,23 @@ be_local_closure(class_Matter_Device_register_commands,   /* name */
     be_str_weak(register_commands),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
-      0xB8060C00,  //  0000  GETNGBL	R1	K6
-      0x8C04035A,  //  0001  GETMET	R1	R1	K90
-      0x580C005B,  //  0002  LDCONST	R3	K91
+      0xB8062400,  //  0000  GETNGBL	R1	K18
+      0x8C0403C4,  //  0001  GETMET	R1	R1	K196
+      0x580C00C5,  //  0002  LDCONST	R3	K197
       0x84100000,  //  0003  CLOSURE	R4	P0
       0x7C040600,  //  0004  CALL	R1	3
-      0xB8060C00,  //  0005  GETNGBL	R1	K6
-      0x8C04035A,  //  0006  GETMET	R1	R1	K90
-      0x580C005C,  //  0007  LDCONST	R3	K92
+      0xB8062400,  //  0005  GETNGBL	R1	K18
+      0x8C0403C4,  //  0006  GETMET	R1	R1	K196
+      0x580C00C6,  //  0007  LDCONST	R3	K198
       0x84100001,  //  0008  CLOSURE	R4	P1
       0x7C040600,  //  0009  CALL	R1	3
-      0xB8060C00,  //  000A  GETNGBL	R1	K6
-      0x8C04035A,  //  000B  GETMET	R1	R1	K90
-      0x580C005D,  //  000C  LDCONST	R3	K93
+      0xB8062400,  //  000A  GETNGBL	R1	K18
+      0x8C0403C4,  //  000B  GETMET	R1	R1	K196
+      0x580C00C7,  //  000C  LDCONST	R3	K199
       0x84100002,  //  000D  CLOSURE	R4	P2
       0x7C040600,  //  000E  CALL	R1	3
       0xA0000000,  //  000F  CLOSE	R0
       0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrInfo
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrInfo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrInfo),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0x1C140723,  //  0000  EQ	R5	R3	K35
-      0x7815FFFF,  //  0001  JMPF	R5	#0002
-      0x1C140723,  //  0002  EQ	R5	R3	K35
-      0x7816000D,  //  0003  JMPF	R5	#0012
-      0x60140010,  //  0004  GETGBL	R5	G16
-      0x8818010D,  //  0005  GETMBR	R6	R0	K13
-      0x7C140200,  //  0006  CALL	R5	1
-      0xA8020005,  //  0007  EXBLK	0	#000E
-      0x5C180A00,  //  0008  MOVE	R6	R5
-      0x7C180000,  //  0009  CALL	R6	0
-      0x8C1C015E,  //  000A  GETMET	R7	R0	K94
-      0x88240D11,  //  000B  GETMBR	R9	R6	K17
-      0x7C1C0400,  //  000C  CALL	R7	2
-      0x7001FFF9,  //  000D  JMP		#0008
-      0x5814001F,  //  000E  LDCONST	R5	K31
-      0xAC140200,  //  000F  CATCH	R5	1	0
-      0xB0080000,  //  0010  RAISE	2	R0	R0
-      0x70020011,  //  0011  JMP		#0024
-      0x60140004,  //  0012  GETGBL	R5	G4
-      0x5C180800,  //  0013  MOVE	R6	R4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x1C140B5F,  //  0015  EQ	R5	R5	K95
-      0x78160003,  //  0016  JMPF	R5	#001B
-      0x8C14015E,  //  0017  GETMET	R5	R0	K94
-      0x5C1C0800,  //  0018  MOVE	R7	R4
-      0x7C140400,  //  0019  CALL	R5	2
-      0x70020008,  //  001A  JMP		#0024
-      0x8C140160,  //  001B  GETMET	R5	R0	K96
-      0x5C1C0600,  //  001C  MOVE	R7	R3
-      0x7C140400,  //  001D  CALL	R5	2
-      0x4C180000,  //  001E  LDNIL	R6
-      0x20180A06,  //  001F  NE	R6	R5	R6
-      0x781A0002,  //  0020  JMPF	R6	#0024
-      0x8C18015E,  //  0021  GETMET	R6	R0	K94
-      0x88200B11,  //  0022  GETMBR	R8	R5	K17
-      0x7C180400,  //  0023  CALL	R6	2
-      0xB8160C00,  //  0024  GETNGBL	R5	K6
-      0x8C140B61,  //  0025  GETMET	R5	R5	K97
-      0x7C140200,  //  0026  CALL	R5	1
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(class_Matter_Device_msg_received,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(msg_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100121,  //  0000  GETMBR	R4	R0	K33
-      0x8C100962,  //  0001  GETMET	R4	R4	K98
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(class_Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[136]) {  /* code */
-      0xA4065200,  //  0000  IMPORT	R1	K41
-      0x50080000,  //  0001  LDBOOL	R2	0	0
-      0xA8020056,  //  0002  EXBLK	0	#005A
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100163,  //  0004  GETMBR	R4	R0	K99
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100764,  //  0006  GETMET	R4	R3	K100
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140765,  //  0008  GETMET	R5	R3	K101
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4160A00,  //  000A  IMPORT	R5	K5
-      0x8C180B0C,  //  000B  GETMET	R6	R5	K12
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D1B,  //  000E  GETMET	R7	R6	K27
-      0x58240067,  //  000F  LDCONST	R9	K103
-      0x88280166,  //  0010  GETMBR	R10	R0	K102
-      0x7C1C0600,  //  0011  CALL	R7	3
-      0x9002CC07,  //  0012  SETMBR	R0	K102	R7
-      0x8C1C0D1B,  //  0013  GETMET	R7	R6	K27
-      0x58240069,  //  0014  LDCONST	R9	K105
-      0x88280168,  //  0015  GETMBR	R10	R0	K104
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x9002D007,  //  0017  SETMBR	R0	K104	R7
-      0x601C0017,  //  0018  GETGBL	R7	G23
-      0x8C200D1B,  //  0019  GETMET	R8	R6	K27
-      0x58280031,  //  001A  LDCONST	R10	K49
-      0x502C0000,  //  001B  LDBOOL	R11	0	0
-      0x7C200600,  //  001C  CALL	R8	3
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90026207,  //  001E  SETMBR	R0	K49	R7
-      0x601C0017,  //  001F  GETGBL	R7	G23
-      0x8C200D1B,  //  0020  GETMET	R8	R6	K27
-      0x58280032,  //  0021  LDCONST	R10	K50
-      0x502C0000,  //  0022  LDBOOL	R11	0	0
-      0x7C200600,  //  0023  CALL	R8	3
-      0x7C1C0200,  //  0024  CALL	R7	1
-      0x90026407,  //  0025  SETMBR	R0	K50	R7
-      0x8C1C0D1B,  //  0026  GETMET	R7	R6	K27
-      0x5824006A,  //  0027  LDCONST	R9	K106
-      0x8828012F,  //  0028  GETMBR	R10	R0	K47
-      0x7C1C0600,  //  0029  CALL	R7	3
-      0x90025E07,  //  002A  SETMBR	R0	K47	R7
-      0x8C1C0D1B,  //  002B  GETMET	R7	R6	K27
-      0x5824006B,  //  002C  LDCONST	R9	K107
-      0x60280013,  //  002D  GETGBL	R10	G19
-      0x7C280000,  //  002E  CALL	R10	0
-      0x7C1C0600,  //  002F  CALL	R7	3
-      0x90029A07,  //  0030  SETMBR	R0	K77	R7
-      0x601C0017,  //  0031  GETGBL	R7	G23
-      0x8C200D1B,  //  0032  GETMET	R8	R6	K27
-      0x5828006C,  //  0033  LDCONST	R10	K108
-      0x7C200400,  //  0034  CALL	R8	2
-      0x7C1C0200,  //  0035  CALL	R7	1
-      0x9002D807,  //  0036  SETMBR	R0	K108	R7
-      0x881C014D,  //  0037  GETMBR	R7	R0	K77
-      0x4C200000,  //  0038  LDNIL	R8
-      0x201C0E08,  //  0039  NE	R7	R7	R8
-      0x781E000D,  //  003A  JMPF	R7	#0049
-      0xB81E1400,  //  003B  GETNGBL	R7	K10
-      0x60200018,  //  003C  GETGBL	R8	G24
-      0x5824006D,  //  003D  LDCONST	R9	K109
-      0x8828014D,  //  003E  GETMBR	R10	R0	K77
-      0x7C200400,  //  003F  CALL	R8	2
-      0x58240009,  //  0040  LDCONST	R9	K9
-      0x7C1C0400,  //  0041  CALL	R7	2
-      0x8C1C016E,  //  0042  GETMET	R7	R0	K110
-      0x7C1C0200,  //  0043  CALL	R7	1
-      0x8C1C016F,  //  0044  GETMET	R7	R0	K111
-      0x7C1C0200,  //  0045  CALL	R7	1
-      0x5C080E00,  //  0046  MOVE	R2	R7
-      0x501C0200,  //  0047  LDBOOL	R7	1	0
-      0x90020607,  //  0048  SETMBR	R0	K3	R7
-      0x8C1C0D1B,  //  0049  GETMET	R7	R6	K27
-      0x58240070,  //  004A  LDCONST	R9	K112
-      0x60280013,  //  004B  GETGBL	R10	G19
-      0x7C280000,  //  004C  CALL	R10	0
-      0x7C1C0600,  //  004D  CALL	R7	3
-      0x90023407,  //  004E  SETMBR	R0	K26	R7
-      0x881C011A,  //  004F  GETMBR	R7	R0	K26
-      0x781E0006,  //  0050  JMPF	R7	#0058
-      0xB81E1400,  //  0051  GETNGBL	R7	K10
-      0x60200008,  //  0052  GETGBL	R8	G8
-      0x8824011A,  //  0053  GETMBR	R9	R0	K26
-      0x7C200200,  //  0054  CALL	R8	1
-      0x0022E208,  //  0055  ADD	R8	K113	R8
-      0x58240009,  //  0056  LDCONST	R9	K9
-      0x7C1C0400,  //  0057  CALL	R7	2
-      0xA8040001,  //  0058  EXBLK	1	1
-      0x70020011,  //  0059  JMP		#006C
-      0xAC0C0002,  //  005A  CATCH	R3	0	2
-      0x7002000E,  //  005B  JMP		#006B
-      0x20140772,  //  005C  NE	R5	R3	K114
-      0x7816000B,  //  005D  JMPF	R5	#006A
-      0xB8161400,  //  005E  GETNGBL	R5	K10
-      0x60180008,  //  005F  GETGBL	R6	G8
-      0x5C1C0600,  //  0060  MOVE	R7	R3
-      0x7C180200,  //  0061  CALL	R6	1
-      0x001AE606,  //  0062  ADD	R6	K115	R6
-      0x00180D74,  //  0063  ADD	R6	R6	K116
-      0x601C0008,  //  0064  GETGBL	R7	G8
-      0x5C200800,  //  0065  MOVE	R8	R4
-      0x7C1C0200,  //  0066  CALL	R7	1
-      0x00180C07,  //  0067  ADD	R6	R6	R7
-      0x581C0028,  //  0068  LDCONST	R7	K40
-      0x7C140400,  //  0069  CALL	R5	2
-      0x70020000,  //  006A  JMP		#006C
-      0xB0080000,  //  006B  RAISE	2	R0	R0
-      0x880C0166,  //  006C  GETMBR	R3	R0	K102
-      0x4C100000,  //  006D  LDNIL	R4
-      0x1C0C0604,  //  006E  EQ	R3	R3	R4
-      0x780E000A,  //  006F  JMPF	R3	#007B
-      0x8C0C0375,  //  0070  GETMET	R3	R1	K117
-      0x58140028,  //  0071  LDCONST	R5	K40
-      0x7C0C0400,  //  0072  CALL	R3	2
-      0x8C0C0776,  //  0073  GETMET	R3	R3	K118
-      0x58140002,  //  0074  LDCONST	R5	K2
-      0x58180028,  //  0075  LDCONST	R6	K40
-      0x7C0C0600,  //  0076  CALL	R3	3
-      0x54120FFE,  //  0077  LDINT	R4	4095
-      0x2C0C0604,  //  0078  AND	R3	R3	R4
-      0x9002CC03,  //  0079  SETMBR	R0	K102	R3
-      0x50080200,  //  007A  LDBOOL	R2	1	0
-      0x880C0168,  //  007B  GETMBR	R3	R0	K104
-      0x4C100000,  //  007C  LDNIL	R4
-      0x1C0C0604,  //  007D  EQ	R3	R3	R4
-      0x780E0004,  //  007E  JMPF	R3	#0084
-      0x880C0133,  //  007F  GETMBR	R3	R0	K51
-      0x8C0C0777,  //  0080  GETMET	R3	R3	K119
-      0x7C0C0200,  //  0081  CALL	R3	1
-      0x9002D003,  //  0082  SETMBR	R0	K104	R3
-      0x50080200,  //  0083  LDBOOL	R2	1	0
-      0x780A0001,  //  0084  JMPF	R2	#0087
-      0x8C0C0104,  //  0085  GETMET	R3	R0	K4
-      0x7C0C0200,  //  0086  CALL	R3	1
-      0x80000000,  //  0087  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: register_http_remote
-********************************************************************/
-be_local_closure(class_Matter_Device_register_http_remote,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(register_http_remote),
-    &be_const_str_solidified,
-    ( &(const binstruction[42]) {  /* code */
-      0x880C0178,  //  0000  GETMBR	R3	R0	K120
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C0C0604,  //  0002  EQ	R3	R3	R4
-      0x780E0002,  //  0003  JMPF	R3	#0007
-      0x600C0013,  //  0004  GETGBL	R3	G19
-      0x7C0C0000,  //  0005  CALL	R3	0
-      0x9002F003,  //  0006  SETMBR	R0	K120	R3
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x88100178,  //  0008  GETMBR	R4	R0	K120
-      0x8C10094E,  //  0009  GETMET	R4	R4	K78
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C100400,  //  000B  CALL	R4	2
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100178,  //  000D  GETMBR	R4	R0	K120
-      0x940C0801,  //  000E  GETIDX	R3	R4	R1
-      0x8C100779,  //  000F  GETMET	R4	R3	K121
-      0x7C100200,  //  0010  CALL	R4	1
-      0x14100404,  //  0011  LT	R4	R2	R4
-      0x78120002,  //  0012  JMPF	R4	#0016
-      0x8C10077A,  //  0013  GETMET	R4	R3	K122
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020011,  //  0016  JMP		#0029
-      0xB8122C00,  //  0017  GETNGBL	R4	K22
-      0x8C10097B,  //  0018  GETMET	R4	R4	K123
-      0x5C180000,  //  0019  MOVE	R6	R0
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0x5C200400,  //  001B  MOVE	R8	R2
-      0x7C100800,  //  001C  CALL	R4	4
-      0x5C0C0800,  //  001D  MOVE	R3	R4
-      0x8810011A,  //  001E  GETMBR	R4	R0	K26
-      0x8C10094E,  //  001F  GETMET	R4	R4	K78
-      0x5C180200,  //  0020  MOVE	R6	R1
-      0x7C100400,  //  0021  CALL	R4	2
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C10077C,  //  0023  GETMET	R4	R3	K124
-      0x8818011A,  //  0024  GETMBR	R6	R0	K26
-      0x94180C01,  //  0025  GETIDX	R6	R6	R1
-      0x7C100400,  //  0026  CALL	R4	2
-      0x88100178,  //  0027  GETMBR	R4	R0	K120
-      0x98100203,  //  0028  SETIDX	R4	R1	R3
-      0x80040600,  //  0029  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reset_param
-********************************************************************/
-be_local_closure(class_Matter_Device_reset_param,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(reset_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x90020601,  //  0001  SETMBR	R0	K3	R1
-      0x88040130,  //  0002  GETMBR	R1	R0	K48
-      0x90025E01,  //  0003  SETMBR	R0	K47	R1
-      0x8C040104,  //  0004  GETMET	R1	R0	K4
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrJoin
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrJoin,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrJoin),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x60140009,  //  0000  GETGBL	R5	G9
-      0x5C180600,  //  0001  MOVE	R6	R3
-      0x7C140200,  //  0002  CALL	R5	1
-      0x78160003,  //  0003  JMPF	R5	#0008
-      0x88180133,  //  0004  GETMBR	R6	R0	K51
-      0x8C180D7D,  //  0005  GETMET	R6	R6	K125
-      0x7C180200,  //  0006  CALL	R6	1
-      0x70020002,  //  0007  JMP		#000B
-      0x88180133,  //  0008  GETMBR	R6	R0	K51
-      0x8C180D7E,  //  0009  GETMET	R6	R6	K126
-      0x7C180200,  //  000A  CALL	R6	1
-      0xB81A0C00,  //  000B  GETNGBL	R6	K6
-      0x8C180D61,  //  000C  GETMET	R6	R6	K97
-      0x7C180200,  //  000D  CALL	R6	1
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: autoconf_device
-********************************************************************/
-be_local_closure(class_Matter_Device_autoconf_device,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(autoconf_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0xA4060A00,  //  0000  IMPORT	R1	K5
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C010D,  //  0002  GETMBR	R3	R0	K13
-      0x7C080200,  //  0003  CALL	R2	1
-      0x24080502,  //  0004  GT	R2	R2	K2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x80000400,  //  0006  RET	0
-      0x8808017F,  //  0007  GETMBR	R2	R0	K127
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x1C080403,  //  0009  EQ	R2	R2	R3
-      0x780A0004,  //  000A  JMPF	R2	#0010
-      0xB80A2C00,  //  000B  GETNGBL	R2	K22
-      0x8C080580,  //  000C  GETMET	R2	R2	K128
-      0x5C100000,  //  000D  MOVE	R4	R0
-      0x7C080400,  //  000E  CALL	R2	2
-      0x9002FE02,  //  000F  SETMBR	R0	K127	R2
-      0x88080103,  //  0010  GETMBR	R2	R0	K3
-      0x740A000F,  //  0011  JMPT	R2	#0022
-      0x8808017F,  //  0012  GETMBR	R2	R0	K127
-      0x8C080581,  //  0013  GETMET	R2	R2	K129
-      0x7C080200,  //  0014  CALL	R2	1
-      0x90029A02,  //  0015  SETMBR	R0	K77	R2
-      0x60080013,  //  0016  GETGBL	R2	G19
-      0x7C080000,  //  0017  CALL	R2	0
-      0x90023402,  //  0018  SETMBR	R0	K26	R2
-      0x8C08016E,  //  0019  GETMET	R2	R0	K110
-      0x7C080200,  //  001A  CALL	R2	1
-      0xB80A1400,  //  001B  GETNGBL	R2	K10
-      0x600C0008,  //  001C  GETGBL	R3	G8
-      0x8810014D,  //  001D  GETMBR	R4	R0	K77
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x000F0403,  //  001F  ADD	R3	K130	R3
-      0x58100009,  //  0020  LDCONST	R4	K9
-      0x7C080400,  //  0021  CALL	R2	2
-      0x8808017F,  //  0022  GETMBR	R2	R0	K127
-      0x8C080583,  //  0023  GETMET	R2	R2	K131
-      0x8810014D,  //  0024  GETMBR	R4	R0	K77
-      0x7C080400,  //  0025  CALL	R2	2
-      0x88080103,  //  0026  GETMBR	R2	R0	K3
-      0x740A0008,  //  0027  JMPT	R2	#0031
-      0x88080100,  //  0028  GETMBR	R2	R0	K0
-      0x8C080501,  //  0029  GETMET	R2	R2	K1
-      0x7C080200,  //  002A  CALL	R2	1
-      0x24080502,  //  002B  GT	R2	R2	K2
-      0x780A0003,  //  002C  JMPF	R2	#0031
-      0x50080200,  //  002D  LDBOOL	R2	1	0
-      0x90020602,  //  002E  SETMBR	R0	K3	R2
-      0x8C080104,  //  002F  GETMET	R2	R0	K4
-      0x7C080200,  //  0030  CALL	R2	1
-      0x80000000,  //  0031  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_zigbee_present
-********************************************************************/
-be_local_closure(class_Matter_Device_is_zigbee_present,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(is_zigbee_present),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xA4070800,  //  0000  IMPORT	R1	K132
-      0x8C080385,  //  0001  GETMET	R2	R1	K133
-      0x58100086,  //  0002  LDCONST	R4	K134
-      0x7C080400,  //  0003  CALL	R2	2
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x20080403,  //  0005  NE	R2	R2	R3
-      0x80040400,  //  0006  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_udp
-********************************************************************/
-be_local_closure(class_Matter_Device__start_udp,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(_start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080187,  //  0000  GETMBR	R2	R0	K135
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A1400,  //  0007  GETNGBL	R2	K10
-      0x600C0008,  //  0008  GETGBL	R3	G8
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x000F1003,  //  000B  ADD	R3	K136	R3
-      0x58100028,  //  000C  LDCONST	R4	K40
-      0x7C080400,  //  000D  CALL	R2	2
-      0xB80A2C00,  //  000E  GETNGBL	R2	K22
-      0x8C080589,  //  000F  GETMET	R2	R2	K137
-      0x5C100000,  //  0010  MOVE	R4	R0
-      0x58140023,  //  0011  LDCONST	R5	K35
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x7C080800,  //  0013  CALL	R2	4
-      0x90030E02,  //  0014  SETMBR	R0	K135	R2
-      0x88080187,  //  0015  GETMBR	R2	R0	K135
-      0x8C08058A,  //  0016  GETMET	R2	R2	K138
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_active_endpoints
-********************************************************************/
-be_local_closure(class_Matter_Device_get_active_endpoints,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_active_endpoints),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x8810010D,  //  0003  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA8020011,  //  0005  EXBLK	0	#0018
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140951,  //  0008  GETMET	R5	R4	K81
-      0x7C140200,  //  0009  CALL	R5	1
-      0x78060002,  //  000A  JMPF	R1	#000E
-      0x1C180B02,  //  000B  EQ	R6	R5	K2
-      0x781A0000,  //  000C  JMPF	R6	#000E
-      0x7001FFF7,  //  000D  JMP		#0006
-      0x8C18051B,  //  000E  GETMET	R6	R2	K27
-      0x5C200A00,  //  000F  MOVE	R8	R5
-      0x7C180400,  //  0010  CALL	R6	2
-      0x4C1C0000,  //  0011  LDNIL	R7
-      0x1C180C07,  //  0012  EQ	R6	R6	R7
-      0x781A0002,  //  0013  JMPF	R6	#0017
-      0x8C18051E,  //  0014  GETMET	R6	R2	K30
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x7C180400,  //  0016  CALL	R6	2
-      0x7001FFED,  //  0017  JMP		#0006
-      0x580C001F,  //  0018  LDCONST	R3	K31
-      0xAC0C0200,  //  0019  CATCH	R3	1	0
-      0xB0080000,  //  001A  RAISE	2	R0	R0
-      0x80040400,  //  001B  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(class_Matter_Device_save_before_restart,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040133,  //  0000  GETMBR	R1	R0	K51
-      0x8C04037E,  //  0001  GETMET	R1	R1	K126
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040133,  //  0003  GETMBR	R1	R0	K51
-      0x8C04038B,  //  0004  GETMET	R1	R1	K139
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(class_Matter_Device_attribute_updated,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8162C00,  //  0004  GETNGBL	R5	K22
-      0x8C140B8C,  //  0005  GETMET	R5	R5	K140
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90162201,  //  0007  SETMBR	R5	K17	R1
-      0x90171A02,  //  0008  SETMBR	R5	K141	R2
-      0x90171C03,  //  0009  SETMBR	R5	K142	R3
-      0x88180121,  //  000A  GETMBR	R6	R0	K33
-      0x88180D47,  //  000B  GETMBR	R6	R6	K71
-      0x88180D48,  //  000C  GETMBR	R6	R6	K72
-      0x8C180D8F,  //  000D  GETMET	R6	R6	K143
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: received_ack
-********************************************************************/
-be_local_closure(class_Matter_Device_received_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(received_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080187,  //  0000  GETMBR	R2	R0	K135
-      0x8C080590,  //  0001  GETMET	R2	R2	K144
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_param
-********************************************************************/
-be_local_closure(class_Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4060A00,  //  0000  IMPORT	R1	K5
-      0x8C080191,  //  0001  GETMET	R2	R0	K145
-      0x7C080200,  //  0002  CALL	R2	1
-      0x60080018,  //  0003  GETGBL	R2	G24
-      0x580C0092,  //  0004  LDCONST	R3	K146
-      0x88100166,  //  0005  GETMBR	R4	R0	K102
-      0x88140168,  //  0006  GETMBR	R5	R0	K104
-      0x88180131,  //  0007  GETMBR	R6	R0	K49
-      0x781A0001,  //  0008  JMPF	R6	#000B
-      0x58180093,  //  0009  LDCONST	R6	K147
-      0x70020000,  //  000A  JMP		#000C
-      0x58180094,  //  000B  LDCONST	R6	K148
-      0x881C0132,  //  000C  GETMBR	R7	R0	K50
-      0x781E0001,  //  000D  JMPF	R7	#0010
-      0x581C0093,  //  000E  LDCONST	R7	K147
-      0x70020000,  //  000F  JMP		#0011
-      0x581C0094,  //  0010  LDCONST	R7	K148
-      0x8820012F,  //  0011  GETMBR	R8	R0	K47
-      0x7C080C00,  //  0012  CALL	R2	6
-      0x880C016C,  //  0013  GETMBR	R3	R0	K108
-      0x780E0000,  //  0014  JMPF	R3	#0016
-      0x00080595,  //  0015  ADD	R2	R2	K149
-      0x880C0103,  //  0016  GETMBR	R3	R0	K3
-      0x780E000E,  //  0017  JMPF	R3	#0027
-      0x00080596,  //  0018  ADD	R2	R2	K150
-      0x8C0C0397,  //  0019  GETMET	R3	R1	K151
-      0x8814014D,  //  001A  GETMBR	R5	R0	K77
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x00080403,  //  001C  ADD	R2	R2	R3
-      0x600C000C,  //  001D  GETGBL	R3	G12
-      0x8810011A,  //  001E  GETMBR	R4	R0	K26
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x240C0702,  //  0020  GT	R3	R3	K2
-      0x780E0004,  //  0021  JMPF	R3	#0027
-      0x00080598,  //  0022  ADD	R2	R2	K152
-      0x8C0C0397,  //  0023  GETMET	R3	R1	K151
-      0x8814011A,  //  0024  GETMBR	R5	R0	K26
-      0x7C0C0400,  //  0025  CALL	R3	2
-      0x00080403,  //  0026  ADD	R2	R2	R3
-      0x00080599,  //  0027  ADD	R2	R2	K153
-      0xA8020017,  //  0028  EXBLK	0	#0041
-      0x600C0011,  //  0029  GETGBL	R3	G17
-      0x88100163,  //  002A  GETMBR	R4	R0	K99
-      0x5814009A,  //  002B  LDCONST	R5	K154
-      0x7C0C0400,  //  002C  CALL	R3	2
-      0x8C10079B,  //  002D  GETMET	R4	R3	K155
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x8C100765,  //  0030  GETMET	R4	R3	K101
-      0x7C100200,  //  0031  CALL	R4	1
-      0xB8121400,  //  0032  GETNGBL	R4	K10
-      0x60140018,  //  0033  GETGBL	R5	G24
-      0x5818009C,  //  0034  LDCONST	R6	K156
-      0x881C0103,  //  0035  GETMBR	R7	R0	K3
-      0x781E0001,  //  0036  JMPF	R7	#0039
-      0x581C009D,  //  0037  LDCONST	R7	K157
-      0x70020000,  //  0038  JMP		#003A
-      0x581C0023,  //  0039  LDCONST	R7	K35
-      0x7C140400,  //  003A  CALL	R5	2
-      0x58180028,  //  003B  LDCONST	R6	K40
-      0x7C100400,  //  003C  CALL	R4	2
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x80040400,  //  003E  RET	1	R2
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8161400,  //  0043  GETNGBL	R5	K10
-      0x60180008,  //  0044  GETGBL	R6	G8
-      0x5C1C0600,  //  0045  MOVE	R7	R3
-      0x7C180200,  //  0046  CALL	R6	1
-      0x001B3C06,  //  0047  ADD	R6	K158	R6
-      0x00180D74,  //  0048  ADD	R6	R6	K116
-      0x601C0008,  //  0049  GETGBL	R7	G8
-      0x5C200800,  //  004A  MOVE	R8	R4
-      0x7C1C0200,  //  004B  CALL	R7	1
-      0x00180C07,  //  004C  ADD	R6	R6	R7
-      0x581C0028,  //  004D  LDCONST	R7	K40
-      0x7C140400,  //  004E  CALL	R5	2
-      0x80040400,  //  004F  RET	1	R2
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: button_handler
-********************************************************************/
-be_local_closure(class_Matter_Device_button_handler,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(button_handler),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x58140002,  //  0000  LDCONST	R5	K2
-      0xA41B0800,  //  0001  IMPORT	R6	K132
-      0x601C000C,  //  0002  GETGBL	R7	G12
-      0x8820010D,  //  0003  GETMBR	R8	R0	K13
-      0x7C1C0200,  //  0004  CALL	R7	1
-      0x141C0A07,  //  0005  LT	R7	R5	R7
-      0x781E0010,  //  0006  JMPF	R7	#0018
-      0x881C010D,  //  0007  GETMBR	R7	R0	K13
-      0x941C0E05,  //  0008  GETIDX	R7	R7	R5
-      0x8C200D4E,  //  0009  GETMET	R8	R6	K78
-      0x5C280E00,  //  000A  MOVE	R10	R7
-      0x582C0027,  //  000B  LDCONST	R11	K39
-      0x7C200600,  //  000C  CALL	R8	3
-      0x78220007,  //  000D  JMPF	R8	#0016
-      0x8820010D,  //  000E  GETMBR	R8	R0	K13
-      0x94201005,  //  000F  GETIDX	R8	R8	R5
-      0x8C201127,  //  0010  GETMET	R8	R8	K39
-      0x5C280200,  //  0011  MOVE	R10	R1
-      0x5C2C0400,  //  0012  MOVE	R11	R2
-      0x5C300600,  //  0013  MOVE	R12	R3
-      0x5C340800,  //  0014  MOVE	R13	R4
-      0x7C200A00,  //  0015  CALL	R8	5
-      0x00140B0F,  //  0016  ADD	R5	R5	K15
-      0x7001FFE9,  //  0017  JMP		#0002
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update_remotes_info
-********************************************************************/
-be_local_closure(class_Matter_Device_update_remotes_info,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(update_remotes_info),
-    &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x88080178,  //  0002  GETMBR	R2	R0	K120
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x20080403,  //  0004  NE	R2	R2	R3
-      0x780A0018,  //  0005  JMPF	R2	#001F
-      0x60080010,  //  0006  GETGBL	R2	G16
-      0x880C0178,  //  0007  GETMBR	R3	R0	K120
-      0x8C0C071D,  //  0008  GETMET	R3	R3	K29
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x7C080200,  //  000A  CALL	R2	1
-      0xA802000F,  //  000B  EXBLK	0	#001C
-      0x5C0C0400,  //  000C  MOVE	R3	R2
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x88100178,  //  000E  GETMBR	R4	R0	K120
-      0x94100803,  //  000F  GETIDX	R4	R4	R3
-      0x8C10099F,  //  0010  GETMET	R4	R4	K159
-      0x7C100200,  //  0011  CALL	R4	1
-      0x4C140000,  //  0012  LDNIL	R5
-      0x20140805,  //  0013  NE	R5	R4	R5
-      0x78160005,  //  0014  JMPF	R5	#001B
-      0x6014000C,  //  0015  GETGBL	R5	G12
-      0x5C180800,  //  0016  MOVE	R6	R4
-      0x7C140200,  //  0017  CALL	R5	1
-      0x24140B02,  //  0018  GT	R5	R5	K2
-      0x78160000,  //  0019  JMPF	R5	#001B
-      0x98040604,  //  001A  SETIDX	R1	R3	R4
-      0x7001FFEF,  //  001B  JMP		#000C
-      0x5808001F,  //  001C  LDCONST	R2	K31
-      0xAC080200,  //  001D  CATCH	R2	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x90023401,  //  001F  SETMBR	R0	K26	R1
-      0x80040200,  //  0020  RET	1	R1
     })
   )
 );
@@ -2191,7 +3104,7 @@ be_local_closure(class_Matter_Device_k2l,   /* name */
     be_str_weak(k2l),
     &be_const_str_solidified,
     ( &(const binstruction[50]) {  /* code */
-      0x5804001C,  //  0000  LDCONST	R1	K28
+      0x58040004,  //  0000  LDCONST	R1	K4
       0x60080012,  //  0001  GETGBL	R2	G18
       0x7C080000,  //  0002  CALL	R2	0
       0x4C0C0000,  //  0003  LDNIL	R3
@@ -2199,193 +3112,48 @@ be_local_closure(class_Matter_Device_k2l,   /* name */
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x80040400,  //  0006  RET	1	R2
       0x600C0010,  //  0007  GETGBL	R3	G16
-      0x8C10011D,  //  0008  GETMET	R4	R0	K29
+      0x8C100105,  //  0008  GETMET	R4	R0	K5
       0x7C100200,  //  0009  CALL	R4	1
       0x7C0C0200,  //  000A  CALL	R3	1
       0xA8020005,  //  000B  EXBLK	0	#0012
       0x5C100600,  //  000C  MOVE	R4	R3
       0x7C100000,  //  000D  CALL	R4	0
-      0x8C14051E,  //  000E  GETMET	R5	R2	K30
+      0x8C140506,  //  000E  GETMET	R5	R2	K6
       0x5C1C0800,  //  000F  MOVE	R7	R4
       0x7C140400,  //  0010  CALL	R5	2
       0x7001FFF9,  //  0011  JMP		#000C
-      0x580C001F,  //  0012  LDCONST	R3	K31
+      0x580C0007,  //  0012  LDCONST	R3	K7
       0xAC0C0200,  //  0013  CATCH	R3	1	0
       0xB0080000,  //  0014  RAISE	2	R0	R0
       0x600C0010,  //  0015  GETGBL	R3	G16
       0x6010000C,  //  0016  GETGBL	R4	G12
       0x5C140400,  //  0017  MOVE	R5	R2
       0x7C100200,  //  0018  CALL	R4	1
-      0x0410090F,  //  0019  SUB	R4	R4	K15
-      0x40121E04,  //  001A  CONNECT	R4	K15	R4
+      0x04100908,  //  0019  SUB	R4	R4	K8
+      0x40121004,  //  001A  CONNECT	R4	K8	R4
       0x7C0C0200,  //  001B  CALL	R3	1
       0xA8020010,  //  001C  EXBLK	0	#002E
       0x5C100600,  //  001D  MOVE	R4	R3
       0x7C100000,  //  001E  CALL	R4	0
       0x94140404,  //  001F  GETIDX	R5	R2	R4
       0x5C180800,  //  0020  MOVE	R6	R4
-      0x241C0D02,  //  0021  GT	R7	R6	K2
+      0x241C0D09,  //  0021  GT	R7	R6	K9
       0x781E0008,  //  0022  JMPF	R7	#002C
-      0x041C0D0F,  //  0023  SUB	R7	R6	K15
+      0x041C0D08,  //  0023  SUB	R7	R6	K8
       0x941C0407,  //  0024  GETIDX	R7	R2	R7
       0x241C0E05,  //  0025  GT	R7	R7	R5
       0x781E0004,  //  0026  JMPF	R7	#002C
-      0x041C0D0F,  //  0027  SUB	R7	R6	K15
+      0x041C0D08,  //  0027  SUB	R7	R6	K8
       0x941C0407,  //  0028  GETIDX	R7	R2	R7
       0x98080C07,  //  0029  SETIDX	R2	R6	R7
-      0x04180D0F,  //  002A  SUB	R6	R6	K15
+      0x04180D08,  //  002A  SUB	R6	R6	K8
       0x7001FFF4,  //  002B  JMP		#0021
       0x98080C05,  //  002C  SETIDX	R2	R6	R5
       0x7001FFEE,  //  002D  JMP		#001D
-      0x580C001F,  //  002E  LDCONST	R3	K31
+      0x580C0007,  //  002E  LDCONST	R3	K7
       0xAC0C0200,  //  002F  CATCH	R3	1	0
       0xB0080000,  //  0030  RAISE	2	R0	R0
       0x80040400,  //  0031  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(class_Matter_Device_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C0403A0,  //  0001  GETMET	R1	R1	K160
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040121,  //  0003  GETMBR	R1	R0	K33
-      0x8C0403A0,  //  0004  GETMET	R1	R1	K160
-      0x7C040200,  //  0005  CALL	R1	1
-      0x88040139,  //  0006  GETMBR	R1	R0	K57
-      0x8C0403A0,  //  0007  GETMET	R1	R1	K160
-      0x7C040200,  //  0008  CALL	R1	1
-      0x88040133,  //  0009  GETMBR	R1	R0	K51
-      0x8C0403A0,  //  000A  GETMET	R1	R1	K160
-      0x7C040200,  //  000B  CALL	R1	1
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: adjust_next_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_adjust_next_ep,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(adjust_next_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x8808014D,  //  0001  GETMBR	R2	R0	K77
-      0x8C08051D,  //  0002  GETMET	R2	R2	K29
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000A,  //  0005  EXBLK	0	#0011
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x600C0009,  //  0008  GETGBL	R3	G9
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x8810012F,  //  000B  GETMBR	R4	R0	K47
-      0x28100604,  //  000C  GE	R4	R3	R4
-      0x78120001,  //  000D  JMPF	R4	#0010
-      0x0010070F,  //  000E  ADD	R4	R3	K15
-      0x90025E04,  //  000F  SETMBR	R0	K47	R4
-      0x7001FFF4,  //  0010  JMP		#0006
-      0x5804001F,  //  0011  LDCONST	R1	K31
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(class_Matter_Device_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0xB8060C00,  //  0000  GETNGBL	R1	K6
-      0x8C0403A1,  //  0001  GETMET	R1	R1	K161
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040187,  //  0004  GETMBR	R1	R0	K135
-      0x78060002,  //  0005  JMPF	R1	#0009
-      0x88040187,  //  0006  GETMBR	R1	R0	K135
-      0x8C0403A2,  //  0007  GETMET	R1	R1	K162
-      0x7C040200,  //  0008  CALL	R1	1
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_plugin_class_displayname
-********************************************************************/
-be_local_closure(class_Matter_Device_get_plugin_class_displayname,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(get_plugin_class_displayname),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880801A3,  //  0000  GETMBR	R2	R0	K163
-      0x8C08051B,  //  0001  GETMET	R2	R2	K27
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x880C05A4,  //  0005  GETMBR	R3	R2	K164
-      0x70020000,  //  0006  JMP		#0008
-      0x580C0023,  //  0007  LDCONST	R3	K35
-      0x80040600,  //  0008  RET	1	R3
     })
   )
 );
@@ -2409,559 +3177,26 @@ be_local_closure(class_Matter_Device_MtrInfo_one,   /* name */
     be_str_weak(MtrInfo_one),
     &be_const_str_solidified,
     ( &(const binstruction[20]) {  /* code */
-      0x8C0801A5,  //  0000  GETMET	R2	R0	K165
+      0x8C080149,  //  0000  GETMET	R2	R0	K73
       0x5C100200,  //  0001  MOVE	R4	R1
       0x7C080400,  //  0002  CALL	R2	2
       0x4C0C0000,  //  0003  LDNIL	R3
       0x1C0C0403,  //  0004  EQ	R3	R2	R3
       0x780E0000,  //  0005  JMPF	R3	#0007
       0x80000600,  //  0006  RET	0
-      0x8C0C05A6,  //  0007  GETMET	R3	R2	K166
+      0x8C0C057C,  //  0007  GETMET	R3	R2	K124
       0x7C0C0200,  //  0008  CALL	R3	1
       0x780E0008,  //  0009  JMPF	R3	#0013
       0x60100018,  //  000A  GETGBL	R4	G24
-      0x581400A7,  //  000B  LDCONST	R5	K167
+      0x581400C8,  //  000B  LDCONST	R5	K200
       0x5C180600,  //  000C  MOVE	R6	R3
       0x7C100400,  //  000D  CALL	R4	2
-      0xB8160C00,  //  000E  GETNGBL	R5	K6
-      0x8C140BA8,  //  000F  GETMET	R5	R5	K168
+      0xB8162400,  //  000E  GETNGBL	R5	K18
+      0x8C140BC9,  //  000F  GETMET	R5	R5	K201
       0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x58200023,  //  0011  LDCONST	R8	K35
+      0x5820000C,  //  0011  LDCONST	R8	K12
       0x7C140600,  //  0012  CALL	R5	3
       0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: bridge_add_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_bridge_add_endpoint,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(bridge_add_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0x880C01A3,  //  0000  GETMBR	R3	R0	K163
-      0x8C0C071B,  //  0001  GETMET	R3	R3	K27
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x4C100000,  //  0004  LDNIL	R4
-      0x1C100604,  //  0005  EQ	R4	R3	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0xB8121400,  //  0007  GETNGBL	R4	K10
-      0x60140008,  //  0008  GETGBL	R5	G8
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x7C140200,  //  000A  CALL	R5	1
-      0x00175205,  //  000B  ADD	R5	K169	R5
-      0x00140BAA,  //  000C  ADD	R5	R5	K170
-      0x58180009,  //  000D  LDCONST	R6	K9
-      0x7C100400,  //  000E  CALL	R4	2
-      0x80000800,  //  000F  RET	0
-      0x8810012F,  //  0010  GETMBR	R4	R0	K47
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x5C180800,  //  0012  MOVE	R6	R4
-      0x7C140200,  //  0013  CALL	R5	1
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x5C1C0000,  //  0015  MOVE	R7	R0
-      0x5C200800,  //  0016  MOVE	R8	R4
-      0x5C240400,  //  0017  MOVE	R9	R2
-      0x7C180600,  //  0018  CALL	R6	3
-      0x881C010D,  //  0019  GETMBR	R7	R0	K13
-      0x8C1C0F1E,  //  001A  GETMET	R7	R7	K30
-      0x5C240C00,  //  001B  MOVE	R9	R6
-      0x7C1C0400,  //  001C  CALL	R7	2
-      0x601C0013,  //  001D  GETGBL	R7	G19
-      0x7C1C0000,  //  001E  CALL	R7	0
-      0x981E4A01,  //  001F  SETIDX	R7	K37	R1
-      0x60200010,  //  0020  GETGBL	R8	G16
-      0x8C24051D,  //  0021  GETMET	R9	R2	K29
-      0x7C240200,  //  0022  CALL	R9	1
-      0x7C200200,  //  0023  CALL	R8	1
-      0xA8020004,  //  0024  EXBLK	0	#002A
-      0x5C241000,  //  0025  MOVE	R9	R8
-      0x7C240000,  //  0026  CALL	R9	0
-      0x94280409,  //  0027  GETIDX	R10	R2	R9
-      0x981C120A,  //  0028  SETIDX	R7	R9	R10
-      0x7001FFFA,  //  0029  JMP		#0025
-      0x5820001F,  //  002A  LDCONST	R8	K31
-      0xAC200200,  //  002B  CATCH	R8	1	0
-      0xB0080000,  //  002C  RAISE	2	R0	R0
-      0xB8221400,  //  002D  GETNGBL	R8	K10
-      0x60240018,  //  002E  GETGBL	R9	G24
-      0x582800AB,  //  002F  LDCONST	R10	K171
-      0x5C2C0800,  //  0030  MOVE	R11	R4
-      0x5C300200,  //  0031  MOVE	R12	R1
-      0x8C3401AC,  //  0032  GETMET	R13	R0	K172
-      0x5C3C0400,  //  0033  MOVE	R15	R2
-      0x7C340400,  //  0034  CALL	R13	2
-      0x7C240800,  //  0035  CALL	R9	4
-      0x58280028,  //  0036  LDCONST	R10	K40
-      0x7C200400,  //  0037  CALL	R8	2
-      0x8820014D,  //  0038  GETMBR	R8	R0	K77
-      0x98200A07,  //  0039  SETIDX	R8	R5	R7
-      0x50200200,  //  003A  LDBOOL	R8	1	0
-      0x90020608,  //  003B  SETMBR	R0	K3	R8
-      0x8820012F,  //  003C  GETMBR	R8	R0	K47
-      0x0020110F,  //  003D  ADD	R8	R8	K15
-      0x90025E08,  //  003E  SETMBR	R0	K47	R8
-      0x8C200104,  //  003F  GETMET	R8	R0	K4
-      0x7C200200,  //  0040  CALL	R8	1
-      0x8C200153,  //  0041  GETMET	R8	R0	K83
-      0x7C200200,  //  0042  CALL	R8	1
-      0x80040800,  //  0043  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resolve_attribute_read_solo
-********************************************************************/
-be_local_closure(class_Matter_Device_resolve_attribute_read_solo,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(resolve_attribute_read_solo),
-    &be_const_str_solidified,
-    ( &(const binstruction[44]) {  /* code */
-      0x88080311,  //  0000  GETMBR	R2	R1	K17
-      0x880C038D,  //  0001  GETMBR	R3	R1	K141
-      0x8810038E,  //  0002  GETMBR	R4	R1	K142
-      0x4C140000,  //  0003  LDNIL	R5
-      0x1C140405,  //  0004  EQ	R5	R2	R5
-      0x74160005,  //  0005  JMPT	R5	#000C
-      0x4C140000,  //  0006  LDNIL	R5
-      0x1C140605,  //  0007  EQ	R5	R3	R5
-      0x74160002,  //  0008  JMPT	R5	#000C
-      0x4C140000,  //  0009  LDNIL	R5
-      0x1C140805,  //  000A  EQ	R5	R4	R5
-      0x78160001,  //  000B  JMPF	R5	#000E
-      0x4C140000,  //  000C  LDNIL	R5
-      0x80040A00,  //  000D  RET	1	R5
-      0x8C1401A5,  //  000E  GETMET	R5	R0	K165
-      0x5C1C0400,  //  000F  MOVE	R7	R2
-      0x7C140400,  //  0010  CALL	R5	2
-      0x4C180000,  //  0011  LDNIL	R6
-      0x1C180A06,  //  0012  EQ	R6	R5	R6
-      0x781A0004,  //  0013  JMPF	R6	#0019
-      0x541A007E,  //  0014  LDINT	R6	127
-      0x90062606,  //  0015  SETMBR	R1	K19	R6
-      0x4C180000,  //  0016  LDNIL	R6
-      0x80040C00,  //  0017  RET	1	R6
-      0x70020011,  //  0018  JMP		#002B
-      0x8C180BAD,  //  0019  GETMET	R6	R5	K173
-      0x5C200600,  //  001A  MOVE	R8	R3
-      0x7C180400,  //  001B  CALL	R6	2
-      0x741A0004,  //  001C  JMPT	R6	#0022
-      0x541A00C2,  //  001D  LDINT	R6	195
-      0x90062606,  //  001E  SETMBR	R1	K19	R6
-      0x4C180000,  //  001F  LDNIL	R6
-      0x80040C00,  //  0020  RET	1	R6
-      0x70020008,  //  0021  JMP		#002B
-      0x8C180BAE,  //  0022  GETMET	R6	R5	K174
-      0x5C200600,  //  0023  MOVE	R8	R3
-      0x5C240800,  //  0024  MOVE	R9	R4
-      0x7C180600,  //  0025  CALL	R6	3
-      0x741A0003,  //  0026  JMPT	R6	#002B
-      0x541A0085,  //  0027  LDINT	R6	134
-      0x90062606,  //  0028  SETMBR	R1	K19	R6
-      0x4C180000,  //  0029  LDNIL	R6
-      0x80040C00,  //  002A  RET	1	R6
-      0x80040A00,  //  002B  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(class_Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080187,  //  0000  GETMBR	R2	R0	K135
-      0x8C0805AF,  //  0001  GETMET	R2	R2	K175
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: clean_remotes
-********************************************************************/
-be_local_closure(class_Matter_Device_clean_remotes,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(clean_remotes),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA4070800,  //  0000  IMPORT	R1	K132
-      0x88080178,  //  0001  GETMBR	R2	R0	K120
-      0x780A004B,  //  0002  JMPF	R2	#004F
-      0x60080013,  //  0003  GETGBL	R2	G19
-      0x7C080000,  //  0004  CALL	R2	0
-      0x600C0010,  //  0005  GETGBL	R3	G16
-      0x88100178,  //  0006  GETMBR	R4	R0	K120
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020003,  //  0008  EXBLK	0	#000D
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x98080902,  //  000B  SETIDX	R2	R4	K2
-      0x7001FFFB,  //  000C  JMP		#0009
-      0x580C001F,  //  000D  LDCONST	R3	K31
-      0xAC0C0200,  //  000E  CATCH	R3	1	0
-      0xB0080000,  //  000F  RAISE	2	R0	R0
-      0x600C0010,  //  0010  GETGBL	R3	G16
-      0x8810010D,  //  0011  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0xA802000F,  //  0013  EXBLK	0	#0024
-      0x5C100600,  //  0014  MOVE	R4	R3
-      0x7C100000,  //  0015  CALL	R4	0
-      0x8C140376,  //  0016  GETMET	R5	R1	K118
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x582000B0,  //  0018  LDCONST	R8	K176
-      0x7C140600,  //  0019  CALL	R5	3
-      0x4C180000,  //  001A  LDNIL	R6
-      0x20180A06,  //  001B  NE	R6	R5	R6
-      0x781A0005,  //  001C  JMPF	R6	#0023
-      0x8C18051B,  //  001D  GETMET	R6	R2	K27
-      0x5C200A00,  //  001E  MOVE	R8	R5
-      0x58240002,  //  001F  LDCONST	R9	K2
-      0x7C180600,  //  0020  CALL	R6	3
-      0x00180D0F,  //  0021  ADD	R6	R6	K15
-      0x98080A06,  //  0022  SETIDX	R2	R5	R6
-      0x7001FFEF,  //  0023  JMP		#0014
-      0x580C001F,  //  0024  LDCONST	R3	K31
-      0xAC0C0200,  //  0025  CATCH	R3	1	0
-      0xB0080000,  //  0026  RAISE	2	R0	R0
-      0x600C0012,  //  0027  GETGBL	R3	G18
-      0x7C0C0000,  //  0028  CALL	R3	0
-      0x60100010,  //  0029  GETGBL	R4	G16
-      0x8C14051D,  //  002A  GETMET	R5	R2	K29
-      0x7C140200,  //  002B  CALL	R5	1
-      0x7C100200,  //  002C  CALL	R4	1
-      0xA8020008,  //  002D  EXBLK	0	#0037
-      0x5C140800,  //  002E  MOVE	R5	R4
-      0x7C140000,  //  002F  CALL	R5	0
-      0x94180405,  //  0030  GETIDX	R6	R2	R5
-      0x1C180D02,  //  0031  EQ	R6	R6	K2
-      0x781A0002,  //  0032  JMPF	R6	#0036
-      0x8C18071E,  //  0033  GETMET	R6	R3	K30
-      0x5C200A00,  //  0034  MOVE	R8	R5
-      0x7C180400,  //  0035  CALL	R6	2
-      0x7001FFF6,  //  0036  JMP		#002E
-      0x5810001F,  //  0037  LDCONST	R4	K31
-      0xAC100200,  //  0038  CATCH	R4	1	0
-      0xB0080000,  //  0039  RAISE	2	R0	R0
-      0x60100010,  //  003A  GETGBL	R4	G16
-      0x5C140600,  //  003B  MOVE	R5	R3
-      0x7C100200,  //  003C  CALL	R4	1
-      0xA802000D,  //  003D  EXBLK	0	#004C
-      0x5C140800,  //  003E  MOVE	R5	R4
-      0x7C140000,  //  003F  CALL	R5	0
-      0xB81A1400,  //  0040  GETNGBL	R6	K10
-      0x881C0BB2,  //  0041  GETMBR	R7	R5	K178
-      0x001F6207,  //  0042  ADD	R7	K177	R7
-      0x58200009,  //  0043  LDCONST	R8	K9
-      0x7C180400,  //  0044  CALL	R6	2
-      0x8C180B65,  //  0045  GETMET	R6	R5	K101
-      0x7C180200,  //  0046  CALL	R6	1
-      0x88180178,  //  0047  GETMBR	R6	R0	K120
-      0x8C180D41,  //  0048  GETMET	R6	R6	K65
-      0x88200BB2,  //  0049  GETMBR	R8	R5	K178
-      0x7C180400,  //  004A  CALL	R6	2
-      0x7001FFF1,  //  004B  JMP		#003E
-      0x5810001F,  //  004C  LDCONST	R4	K31
-      0xAC100200,  //  004D  CATCH	R4	1	0
-      0xB0080000,  //  004E  RAISE	2	R0	R0
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: MtrUpdate
-********************************************************************/
-be_local_closure(class_Matter_Device_MtrUpdate,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    5,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(MtrUpdate),
-    &be_const_str_solidified,
-    ( &(const binstruction[126]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160004,  //  0002  JMPF	R5	#0008
-      0xB8160C00,  //  0003  GETNGBL	R5	K6
-      0x8C140BB3,  //  0004  GETMET	R5	R5	K179
-      0x581C00B4,  //  0005  LDCONST	R7	K180
-      0x7C140400,  //  0006  CALL	R5	2
-      0x80040A00,  //  0007  RET	1	R5
-      0xB8160C00,  //  0008  GETNGBL	R5	K6
-      0x8C140BB5,  //  0009  GETMET	R5	R5	K181
-      0x5C1C0800,  //  000A  MOVE	R7	R4
-      0x582000B6,  //  000B  LDCONST	R8	K182
-      0x7C140600,  //  000C  CALL	R5	3
-      0xB81A0C00,  //  000D  GETNGBL	R6	K6
-      0x8C180DB5,  //  000E  GETMET	R6	R6	K181
-      0x5C200800,  //  000F  MOVE	R8	R4
-      0x582400B7,  //  0010  LDCONST	R9	K183
-      0x7C180600,  //  0011  CALL	R6	3
-      0x74160000,  //  0012  JMPT	R5	#0014
-      0x781A0064,  //  0013  JMPF	R6	#0079
-      0x4C1C0000,  //  0014  LDNIL	R7
-      0x78160010,  //  0015  JMPF	R5	#0027
-      0x60200009,  //  0016  GETGBL	R8	G9
-      0x94240805,  //  0017  GETIDX	R9	R4	R5
-      0x7C200200,  //  0018  CALL	R8	1
-      0x18241102,  //  0019  LE	R9	R8	K2
-      0x78260004,  //  001A  JMPF	R9	#0020
-      0xB8260C00,  //  001B  GETNGBL	R9	K6
-      0x8C2413B3,  //  001C  GETMET	R9	R9	K179
-      0x582C00B8,  //  001D  LDCONST	R11	K184
-      0x7C240400,  //  001E  CALL	R9	2
-      0x80041200,  //  001F  RET	1	R9
-      0x8C2401A5,  //  0020  GETMET	R9	R0	K165
-      0x5C2C1000,  //  0021  MOVE	R11	R8
-      0x7C240400,  //  0022  CALL	R9	2
-      0x5C1C1200,  //  0023  MOVE	R7	R9
-      0x8C240941,  //  0024  GETMET	R9	R4	K65
-      0x5C2C0A00,  //  0025  MOVE	R11	R5
-      0x7C240400,  //  0026  CALL	R9	2
-      0x781A0009,  //  0027  JMPF	R6	#0032
-      0x4C200000,  //  0028  LDNIL	R8
-      0x1C200E08,  //  0029  EQ	R8	R7	R8
-      0x78220003,  //  002A  JMPF	R8	#002F
-      0x8C200160,  //  002B  GETMET	R8	R0	K96
-      0x94280806,  //  002C  GETIDX	R10	R4	R6
-      0x7C200400,  //  002D  CALL	R8	2
-      0x5C1C1000,  //  002E  MOVE	R7	R8
-      0x8C200941,  //  002F  GETMET	R8	R4	K65
-      0x5C280C00,  //  0030  MOVE	R10	R6
-      0x7C200400,  //  0031  CALL	R8	2
-      0x4C200000,  //  0032  LDNIL	R8
-      0x1C200E08,  //  0033  EQ	R8	R7	R8
-      0x78220004,  //  0034  JMPF	R8	#003A
-      0xB8220C00,  //  0035  GETNGBL	R8	K6
-      0x8C2011B3,  //  0036  GETMET	R8	R8	K179
-      0x582800B9,  //  0037  LDCONST	R10	K185
-      0x7C200400,  //  0038  CALL	R8	2
-      0x80041000,  //  0039  RET	1	R8
-      0x88200FBA,  //  003A  GETMBR	R8	R7	K186
-      0x74220004,  //  003B  JMPT	R8	#0041
-      0xB8220C00,  //  003C  GETNGBL	R8	K6
-      0x8C2011B3,  //  003D  GETMET	R8	R8	K179
-      0x582800BB,  //  003E  LDCONST	R10	K187
-      0x7C200400,  //  003F  CALL	R8	2
-      0x80041000,  //  0040  RET	1	R8
-      0x8C200FBC,  //  0041  GETMET	R8	R7	K188
-      0x7C200200,  //  0042  CALL	R8	1
-      0x60240013,  //  0043  GETGBL	R9	G19
-      0x7C240000,  //  0044  CALL	R9	0
-      0x60280010,  //  0045  GETGBL	R10	G16
-      0x8C2C091D,  //  0046  GETMET	R11	R4	K29
-      0x7C2C0200,  //  0047  CALL	R11	1
-      0x7C280200,  //  0048  CALL	R10	1
-      0xA8020016,  //  0049  EXBLK	0	#0061
-      0x5C2C1400,  //  004A  MOVE	R11	R10
-      0x7C2C0000,  //  004B  CALL	R11	0
-      0xB8320C00,  //  004C  GETNGBL	R12	K6
-      0x8C3019BD,  //  004D  GETMET	R12	R12	K189
-      0x5C381000,  //  004E  MOVE	R14	R8
-      0x5C3C1600,  //  004F  MOVE	R15	R11
-      0x7C300600,  //  0050  CALL	R12	3
-      0x4C340000,  //  0051  LDNIL	R13
-      0x1C34180D,  //  0052  EQ	R13	R12	R13
-      0x78360008,  //  0053  JMPF	R13	#005D
-      0xB8360C00,  //  0054  GETNGBL	R13	K6
-      0x8C341BB3,  //  0055  GETMET	R13	R13	K179
-      0x603C0018,  //  0056  GETGBL	R15	G24
-      0x584000BE,  //  0057  LDCONST	R16	K190
-      0x5C441600,  //  0058  MOVE	R17	R11
-      0x7C3C0400,  //  0059  CALL	R15	2
-      0x7C340400,  //  005A  CALL	R13	2
-      0xA8040001,  //  005B  EXBLK	1	1
-      0x80001A00,  //  005C  RET	0
-      0x9434100C,  //  005D  GETIDX	R13	R8	R12
-      0x9438080B,  //  005E  GETIDX	R14	R4	R11
-      0x98241A0E,  //  005F  SETIDX	R9	R13	R14
-      0x7001FFE8,  //  0060  JMP		#004A
-      0x5828001F,  //  0061  LDCONST	R10	K31
-      0xAC280200,  //  0062  CATCH	R10	1	0
-      0xB0080000,  //  0063  RAISE	2	R0	R0
-      0x8C280FBF,  //  0064  GETMET	R10	R7	K191
-      0x5C301200,  //  0065  MOVE	R12	R9
-      0x7C280400,  //  0066  CALL	R10	2
-      0x8C280FA6,  //  0067  GETMET	R10	R7	K166
-      0x7C280200,  //  0068  CALL	R10	1
-      0x782A000A,  //  0069  JMPF	R10	#0075
-      0x602C0018,  //  006A  GETGBL	R11	G24
-      0x583000C0,  //  006B  LDCONST	R12	K192
-      0x5C340200,  //  006C  MOVE	R13	R1
-      0x5C381400,  //  006D  MOVE	R14	R10
-      0x7C2C0600,  //  006E  CALL	R11	3
-      0xB8320C00,  //  006F  GETNGBL	R12	K6
-      0x8C3019C1,  //  0070  GETMET	R12	R12	K193
-      0x5C381600,  //  0071  MOVE	R14	R11
-      0x7C300400,  //  0072  CALL	R12	2
-      0x80041800,  //  0073  RET	1	R12
-      0x70020003,  //  0074  JMP		#0079
-      0xB82E0C00,  //  0075  GETNGBL	R11	K6
-      0x8C2C1761,  //  0076  GETMET	R11	R11	K97
-      0x7C2C0200,  //  0077  CALL	R11	1
-      0x80041600,  //  0078  RET	1	R11
-      0xB81E0C00,  //  0079  GETNGBL	R7	K6
-      0x8C1C0FB3,  //  007A  GETMET	R7	R7	K179
-      0x582400C2,  //  007B  LDCONST	R9	K194
-      0x7C1C0400,  //  007C  CALL	R7	2
-      0x80000000,  //  007D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: button_pressed
-********************************************************************/
-be_local_closure(class_Matter_Device_button_pressed,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(button_pressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x540E000F,  //  0000  LDINT	R3	16
-      0x3C0C0403,  //  0001  SHR	R3	R2	R3
-      0x541200FE,  //  0002  LDINT	R4	255
-      0x2C0C0604,  //  0003  AND	R3	R3	R4
-      0x54120007,  //  0004  LDINT	R4	8
-      0x3C100404,  //  0005  SHR	R4	R2	R4
-      0x541600FE,  //  0006  LDINT	R5	255
-      0x2C100805,  //  0007  AND	R4	R4	R5
-      0x541600FE,  //  0008  LDINT	R5	255
-      0x2C140405,  //  0009  AND	R5	R2	R5
-      0x541A0017,  //  000A  LDINT	R6	24
-      0x3C180406,  //  000B  SHR	R6	R2	R6
-      0x541E00FE,  //  000C  LDINT	R7	255
-      0x2C180C07,  //  000D  AND	R6	R6	R7
-      0x8C1C0127,  //  000E  GETMET	R7	R0	K39
-      0x00240B0F,  //  000F  ADD	R9	R5	K15
-      0x20280604,  //  0010  NE	R10	R3	R4
-      0x782A0001,  //  0011  JMPF	R10	#0014
-      0x5828000F,  //  0012  LDCONST	R10	K15
-      0x70020000,  //  0013  JMP		#0015
-      0x58280002,  //  0014  LDCONST	R10	K2
-      0x780E0001,  //  0015  JMPF	R3	#0018
-      0x582C0002,  //  0016  LDCONST	R11	K2
-      0x70020000,  //  0017  JMP		#0019
-      0x582C000F,  //  0018  LDCONST	R11	K15
-      0x5C300C00,  //  0019  MOVE	R12	R6
-      0x7C1C0A00,  //  001A  CALL	R7	5
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_sensors_scheduler
-********************************************************************/
-be_local_closure(class_Matter_Device_read_sensors_scheduler,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(read_sensors_scheduler),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040114,  //  0000  GETMBR	R1	R0	K20
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x78060000,  //  0003  JMPF	R1	#0005
-      0x80000200,  //  0004  RET	0
-      0x88040115,  //  0005  GETMBR	R1	R0	K21
-      0x1C040302,  //  0006  EQ	R1	R1	K2
-      0x74060004,  //  0007  JMPT	R1	#000D
-      0xB8060C00,  //  0008  GETNGBL	R1	K6
-      0x8C0403C3,  //  0009  GETMET	R1	R1	K195
-      0x880C0115,  //  000A  GETMBR	R3	R0	K21
-      0x7C040400,  //  000B  CALL	R1	2
-      0x78060006,  //  000C  JMPF	R1	#0014
-      0x8C0401C4,  //  000D  GETMET	R1	R0	K196
-      0x7C040200,  //  000E  CALL	R1	1
-      0xB8060C00,  //  000F  GETNGBL	R1	K6
-      0x8C0403C5,  //  0010  GETMET	R1	R1	K197
-      0x880C0114,  //  0011  GETMBR	R3	R0	K20
-      0x7C040400,  //  0012  CALL	R1	2
-      0x90022A01,  //  0013  SETMBR	R0	K21	R1
-      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -2985,10 +3220,10 @@ be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
     be_str_weak(create_zb_mapper),
     &be_const_str_solidified,
     ( &(const binstruction[ 8]) {  /* code */
-      0x8808013B,  //  0000  GETMBR	R2	R0	K59
+      0x88080164,  //  0000  GETMBR	R2	R0	K100
       0x780A0004,  //  0001  JMPF	R2	#0007
-      0x8808013B,  //  0002  GETMBR	R2	R0	K59
-      0x8C0805C6,  //  0003  GETMET	R2	R2	K198
+      0x88080164,  //  0002  GETMBR	R2	R0	K100
+      0x8C0805CA,  //  0003  GETMET	R2	R2	K202
       0x5C100200,  //  0004  MOVE	R4	R1
       0x7C080400,  //  0005  CALL	R2	2
       0x80040400,  //  0006  RET	1	R2
@@ -3000,144 +3235,9 @@ be_local_closure(class_Matter_Device_create_zb_mapper,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_attribute_expansion
+** Solidified function: start
 ********************************************************************/
-be_local_closure(class_Matter_Device_process_attribute_expansion,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(process_attribute_expansion),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x880C0311,  //  0000  GETMBR	R3	R1	K17
-      0x8810038D,  //  0001  GETMBR	R4	R1	K141
-      0x8814038E,  //  0002  GETMBR	R5	R1	K142
-      0xB81A2C00,  //  0003  GETNGBL	R6	K22
-      0x8C180DC7,  //  0004  GETMET	R6	R6	K199
-      0x5C200000,  //  0005  MOVE	R8	R0
-      0x7C180400,  //  0006  CALL	R6	2
-      0x8C1C0D8A,  //  0007  GETMET	R7	R6	K138
-      0x5C240600,  //  0008  MOVE	R9	R3
-      0x5C280800,  //  0009  MOVE	R10	R4
-      0x5C2C0A00,  //  000A  MOVE	R11	R5
-      0x7C1C0800,  //  000B  CALL	R7	4
-      0x8C1C0DC8,  //  000C  GETMET	R7	R6	K200
-      0x7C1C0200,  //  000D  CALL	R7	1
-      0x4C200000,  //  000E  LDNIL	R8
-      0x8C240DC9,  //  000F  GETMET	R9	R6	K201
-      0x7C240200,  //  0010  CALL	R9	1
-      0x5C201200,  //  0011  MOVE	R8	R9
-      0x4C280000,  //  0012  LDNIL	R10
-      0x2024120A,  //  0013  NE	R9	R9	R10
-      0x78260005,  //  0014  JMPF	R9	#001B
-      0x5C240400,  //  0015  MOVE	R9	R2
-      0x8C280DCA,  //  0016  GETMET	R10	R6	K202
-      0x7C280200,  //  0017  CALL	R10	1
-      0x5C2C1000,  //  0018  MOVE	R11	R8
-      0x7C240400,  //  0019  CALL	R9	2
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x80000000,  //  001B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_config_ep
-********************************************************************/
-be_local_closure(class_Matter_Device_check_config_ep,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(check_config_ep),
-    &be_const_str_solidified,
-    ( &(const binstruction[61]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x600C0010,  //  0003  GETGBL	R3	G16
-      0x8810014D,  //  0004  GETMBR	R4	R0	K77
-      0x8C10091D,  //  0005  GETMET	R4	R4	K29
-      0x7C100200,  //  0006  CALL	R4	1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0xA8020007,  //  0008  EXBLK	0	#0011
-      0x5C100600,  //  0009  MOVE	R4	R3
-      0x7C100000,  //  000A  CALL	R4	0
-      0x8C14051E,  //  000B  GETMET	R5	R2	K30
-      0x601C0009,  //  000C  GETGBL	R7	G9
-      0x5C200800,  //  000D  MOVE	R8	R4
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x7001FFF7,  //  0010  JMP		#0009
-      0x580C001F,  //  0011  LDCONST	R3	K31
-      0xAC0C0200,  //  0012  CATCH	R3	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x600C0010,  //  0014  GETGBL	R3	G16
-      0x5C100400,  //  0015  MOVE	R4	R2
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0xA8020020,  //  0017  EXBLK	0	#0039
-      0x5C100600,  //  0018  MOVE	R4	R3
-      0x7C100000,  //  0019  CALL	R4	0
-      0x1C14090F,  //  001A  EQ	R5	R4	K15
-      0x7816001B,  //  001B  JMPF	R5	#0038
-      0x50040200,  //  001C  LDBOOL	R1	1	0
-      0xB8161400,  //  001D  GETNGBL	R5	K10
-      0x60180018,  //  001E  GETGBL	R6	G24
-      0x581C00CB,  //  001F  LDCONST	R7	K203
-      0x5C200800,  //  0020  MOVE	R8	R4
-      0x8824012F,  //  0021  GETMBR	R9	R0	K47
-      0x7C180600,  //  0022  CALL	R6	3
-      0x581C0028,  //  0023  LDCONST	R7	K40
-      0x7C140400,  //  0024  CALL	R5	2
-      0x60140008,  //  0025  GETGBL	R5	G8
-      0x8818012F,  //  0026  GETMBR	R6	R0	K47
-      0x7C140200,  //  0027  CALL	R5	1
-      0x8818014D,  //  0028  GETMBR	R6	R0	K77
-      0x601C0008,  //  0029  GETGBL	R7	G8
-      0x5C200800,  //  002A  MOVE	R8	R4
-      0x7C1C0200,  //  002B  CALL	R7	1
-      0x8820014D,  //  002C  GETMBR	R8	R0	K77
-      0x941C1007,  //  002D  GETIDX	R7	R8	R7
-      0x98180A07,  //  002E  SETIDX	R6	R5	R7
-      0x8814014D,  //  002F  GETMBR	R5	R0	K77
-      0x8C140B41,  //  0030  GETMET	R5	R5	K65
-      0x601C0008,  //  0031  GETGBL	R7	G8
-      0x5C200800,  //  0032  MOVE	R8	R4
-      0x7C1C0200,  //  0033  CALL	R7	1
-      0x7C140400,  //  0034  CALL	R5	2
-      0x8814012F,  //  0035  GETMBR	R5	R0	K47
-      0x00140B0F,  //  0036  ADD	R5	R5	K15
-      0x90025E05,  //  0037  SETMBR	R0	K47	R5
-      0x7001FFDE,  //  0038  JMP		#0018
-      0x580C001F,  //  0039  LDCONST	R3	K31
-      0xAC0C0200,  //  003A  CATCH	R3	1	0
-      0xB0080000,  //  003B  RAISE	2	R0	R0
-      0x80040200,  //  003C  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init_zigbee
-********************************************************************/
-be_local_closure(class_Matter_Device_init_zigbee,   /* name */
+be_local_closure(class_Matter_Device_start,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -3148,58 +3248,18 @@ be_local_closure(class_Matter_Device_init_zigbee,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(init_zigbee),
+    be_str_weak(start),
     &be_const_str_solidified,
     ( &(const binstruction[ 9]) {  /* code */
-      0x8C0401CC,  //  0000  GETMET	R1	R0	K204
+      0x8C0401CB,  //  0000  GETMET	R1	R0	K203
       0x7C040200,  //  0001  CALL	R1	1
-      0x78060004,  //  0002  JMPF	R1	#0008
-      0xA4070C00,  //  0003  IMPORT	R1	K134
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x5C0C0000,  //  0005  MOVE	R3	R0
-      0x7C080200,  //  0006  CALL	R2	1
-      0x80040400,  //  0007  RET	1	R2
+      0x8C0401CC,  //  0002  GETMET	R1	R0	K204
+      0x880C01CD,  //  0003  GETMBR	R3	R0	K205
+      0x7C040400,  //  0004  CALL	R1	2
+      0x8804015C,  //  0005  GETMBR	R1	R0	K92
+      0x8C0403CE,  //  0006  GETMET	R1	R1	K206
+      0x7C040200,  //  0007  CALL	R1	1
       0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_plugin_by_endpoint
-********************************************************************/
-be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    10,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    &be_ktab_class_Matter_Device,     /* shared constants */
-    be_str_weak(find_plugin_by_endpoint),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080002,  //  0000  LDCONST	R2	K2
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x8810010D,  //  0002  GETMBR	R4	R0	K13
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0008,  //  0005  JMPF	R3	#000F
-      0x880C010D,  //  0006  GETMBR	R3	R0	K13
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x8C100751,  //  0008  GETMET	R4	R3	K81
-      0x7C100200,  //  0009  CALL	R4	1
-      0x1C100801,  //  000A  EQ	R4	R4	R1
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80040600,  //  000C  RET	1	R3
-      0x0008050F,  //  000D  ADD	R2	R2	K15
-      0x7001FFF1,  //  000E  JMP		#0001
-      0x4C0C0000,  //  000F  LDNIL	R3
-      0x80040600,  //  0010  RET	1	R3
     })
   )
 );
@@ -3212,63 +3272,62 @@ be_local_closure(class_Matter_Device_find_plugin_by_endpoint,   /* name */
 be_local_class(Matter_Device,
     24,
     NULL,
-    be_nested_map(82,
+    be_nested_map(84,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(event_fabrics_saved, 81), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
-        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(commissioning, -1), be_const_var(8) },
+        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
         { be_const_key_weak(plugins_config, -1), be_const_var(3) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(find_plugin_by_endpoint, 8), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
-        { be_const_key_weak(add_read_sensors_schedule, 30), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
-        { be_const_key_weak(init_zigbee, 43), be_const_closure(class_Matter_Device_init_zigbee_closure) },
-        { be_const_key_weak(plugins, -1), be_const_var(1) },
-        { be_const_key_weak(check_config_ep, 39), be_const_closure(class_Matter_Device_check_config_ep_closure) },
-        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(5) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(19) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(init, -1), be_const_closure(class_Matter_Device_init_closure) },
-        { be_const_key_weak(k2l_num, -1), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
-        { be_const_key_weak(every_50ms, 34), be_const_closure(class_Matter_Device_every_50ms_closure) },
-        { be_const_key_weak(process_attribute_expansion, 49), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(events, 22), be_const_var(14) },
-        { be_const_key_weak(create_zb_mapper, -1), be_const_closure(class_Matter_Device_create_zb_mapper_closure) },
-        { be_const_key_weak(profiler, -1), be_const_var(6) },
-        { be_const_key_weak(zigbee, 66), be_const_var(11) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(17) },
-        { be_const_key_weak(get_plugin_remote_info, 14), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
-        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(class_Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(10) },
-        { be_const_key_weak(bridge_remove_endpoint, 51), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
-        { be_const_key_weak(every_250ms, 56), be_const_closure(class_Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(start, -1), be_const_closure(class_Matter_Device_start_closure) },
-        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
-        { be_const_key_weak(register_commands, -1), be_const_closure(class_Matter_Device_register_commands_closure) },
+        { be_const_key_weak(k2l_num, 37), be_const_static_closure(class_Matter_Device_k2l_num_closure) },
+        { be_const_key_weak(msg_received, 73), be_const_closure(class_Matter_Device_msg_received_closure) },
+        { be_const_key_weak(EP, -1), be_const_int(2) },
         { be_const_key_weak(MtrInfo, -1), be_const_closure(class_Matter_Device_MtrInfo_closure) },
-        { be_const_key_weak(is_zigbee_present, -1), be_const_closure(class_Matter_Device_is_zigbee_present_closure) },
-        { be_const_key_weak(conf_to_log, -1), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(class_Matter_Device_load_param_closure) },
-        { be_const_key_weak(sort_distinct, 74), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(http_remotes, -1), be_const_var(15) },
-        { be_const_key_weak(reset_param, -1), be_const_closure(class_Matter_Device_reset_param_closure) },
-        { be_const_key_weak(probe_sensor_time, -1), be_const_var(22) },
-        { be_const_key_weak(tick, 73), be_const_var(13) },
-        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_Device_received_ack_closure) },
-        { be_const_key_weak(plugins_config_remotes, 54), be_const_var(4) },
-        { be_const_key_weak(bridge_add_endpoint, 79), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
-        { be_const_key_weak(started, -1), be_const_var(0) },
-        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(save_before_restart, -1), be_const_closure(class_Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(class_Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(EP, 19), be_const_int(2) },
-        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
-        { be_const_key_weak(plugins_persist, 41), be_const_var(2) },
         { be_const_key_weak(probe_sensor_timestamp, -1), be_const_var(23) },
-        { be_const_key_weak(button_multi_pressed, 55), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(class_Matter_Device_msg_received_closure) },
-        { be_const_key_weak(plugins_classes, 33), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(every_250ms, 77), be_const_closure(class_Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(k2l, -1), be_const_static_closure(class_Matter_Device_k2l_closure) },
+        { be_const_key_weak(init_zigbee, 15), be_const_closure(class_Matter_Device_init_zigbee_closure) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(class_Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(register_commands, -1), be_const_closure(class_Matter_Device_register_commands_closure) },
+        { be_const_key_weak(plugins_config_remotes, -1), be_const_var(4) },
+        { be_const_key_weak(save_param, 33), be_const_closure(class_Matter_Device_save_param_closure) },
+        { be_const_key_weak(MtrJoin, 65), be_const_closure(class_Matter_Device_MtrJoin_closure) },
+        { be_const_key_weak(debug, 42), be_const_var(21) },
+        { be_const_key_weak(stop, 66), be_const_closure(class_Matter_Device_stop_closure) },
+        { be_const_key_weak(udp_server, 49), be_const_var(5) },
+        { be_const_key_weak(find_plugin_by_endpoint, 38), be_const_closure(class_Matter_Device_find_plugin_by_endpoint_closure) },
+        { be_const_key_weak(events, -1), be_const_var(14) },
+        { be_const_key_weak(bridge_remove_endpoint, -1), be_const_closure(class_Matter_Device_bridge_remove_endpoint_closure) },
+        { be_const_key_weak(event_fabrics_saved, -1), be_const_closure(class_Matter_Device_event_fabrics_saved_closure) },
+        { be_const_key_weak(autoconf_device, -1), be_const_closure(class_Matter_Device_autoconf_device_closure) },
+        { be_const_key_weak(network_down, -1), be_const_closure(class_Matter_Device_network_down_closure) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(root_passcode, -1), be_const_var(17) },
+        { be_const_key_weak(zigbee, -1), be_const_var(11) },
+        { be_const_key_weak(sessions, -1), be_const_var(10) },
+        { be_const_key_weak(resolve_attribute_read_solo, -1), be_const_closure(class_Matter_Device_resolve_attribute_read_solo_closure) },
+        { be_const_key_weak(clean_remotes, -1), be_const_closure(class_Matter_Device_clean_remotes_closure) },
+        { be_const_key_weak(get_plugin_remote_info, 7), be_const_closure(class_Matter_Device_get_plugin_remote_info_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(button_handler, -1), be_const_closure(class_Matter_Device_button_handler_closure) },
+        { be_const_key_weak(root_discriminator, -1), be_const_var(16) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(class_Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(probe_sensor_time, -1), be_const_var(22) },
+        { be_const_key_weak(plugins, -1), be_const_var(1) },
+        { be_const_key_weak(ipv4only, -1), be_const_var(18) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(find_plugin_by_friendly_name, -1), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
+        { be_const_key_weak(disable_bridge_mode, -1), be_const_var(19) },
+        { be_const_key_weak(register_http_remote, 79), be_const_closure(class_Matter_Device_register_http_remote_closure) },
+        { be_const_key_weak(MtrUpdate, 12), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
+        { be_const_key_weak(every_50ms, -1), be_const_closure(class_Matter_Device_every_50ms_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(class_Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(add_read_sensors_schedule, -1), be_const_closure(class_Matter_Device_add_read_sensors_schedule_closure) },
+        { be_const_key_weak(signal_endpoints_changed, -1), be_const_closure(class_Matter_Device_signal_endpoints_changed_closure) },
+        { be_const_key_weak(check_config_ep, 13), be_const_closure(class_Matter_Device_check_config_ep_closure) },
+        { be_const_key_weak(sort_distinct, 56), be_const_static_closure(class_Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(network_up, 48), be_const_closure(class_Matter_Device_network_up_closure) },
+        { be_const_key_weak(is_zigbee_present, 68), be_const_closure(class_Matter_Device_is_zigbee_present_closure) },
+        { be_const_key_weak(plugins_classes, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(60,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(gensw_btn, -1), be_const_class(be_class_Matter_Plugin_Sensor_GenericSwitch_Btn) },
@@ -3332,33 +3391,36 @@ be_local_class(Matter_Device,
         { be_const_key_weak(illuminance, -1), be_const_class(be_class_Matter_Plugin_Sensor_Illuminance) },
         { be_const_key_weak(v_light3, -1), be_const_class(be_class_Matter_Plugin_Virt_Light3) },
     }))    ) } )) },
-        { be_const_key_weak(autoconf, 65), be_const_var(9) },
-        { be_const_key_weak(adjust_next_ep, 60), be_const_closure(class_Matter_Device_adjust_next_ep_closure) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(next_ep, 57), be_const_var(20) },
-        { be_const_key_weak(every_second, -1), be_const_closure(class_Matter_Device_every_second_closure) },
-        { be_const_key_weak(k2l, -1), be_const_static_closure(class_Matter_Device_k2l_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(class_Matter_Device_stop_closure) },
-        { be_const_key_weak(get_plugin_class_displayname, -1), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(read_sensors_scheduler, -1), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(class_Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(_start_udp, -1), be_const_closure(class_Matter_Device__start_udp_closure) },
+        { be_const_key_weak(bridge_add_endpoint, -1), be_const_closure(class_Matter_Device_bridge_add_endpoint_closure) },
+        { be_const_key_weak(started, 62), be_const_var(0) },
+        { be_const_key_weak(ui, 61), be_const_var(12) },
+        { be_const_key_weak(PRODUCT_ID, 57), be_const_int(32768) },
         { be_const_key_weak(message_handler, -1), be_const_var(7) },
-        { be_const_key_weak(commissioning, -1), be_const_var(8) },
-        { be_const_key_weak(save_param, -1), be_const_closure(class_Matter_Device_save_param_closure) },
-        { be_const_key_weak(ui, -1), be_const_var(12) },
-        { be_const_key_weak(resolve_attribute_read_solo, -1), be_const_closure(class_Matter_Device_resolve_attribute_read_solo_closure) },
-        { be_const_key_weak(button_handler, 4), be_const_closure(class_Matter_Device_button_handler_closure) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(class_Matter_Device_msg_send_closure) },
-        { be_const_key_weak(clean_remotes, -1), be_const_closure(class_Matter_Device_clean_remotes_closure) },
-        { be_const_key_weak(MtrUpdate, -1), be_const_closure(class_Matter_Device_MtrUpdate_closure) },
-        { be_const_key_weak(debug, 24), be_const_var(21) },
-        { be_const_key_weak(MtrJoin, 53), be_const_closure(class_Matter_Device_MtrJoin_closure) },
-        { be_const_key_weak(register_http_remote, -1), be_const_closure(class_Matter_Device_register_http_remote_closure) },
-        { be_const_key_weak(update_remotes_info, 17), be_const_closure(class_Matter_Device_update_remotes_info_closure) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(read_sensors_scheduler, 12), be_const_closure(class_Matter_Device_read_sensors_scheduler_closure) },
-        { be_const_key_weak(_start_udp, 11), be_const_closure(class_Matter_Device__start_udp_closure) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(18) },
-        { be_const_key_weak(find_plugin_by_friendly_name, 6), be_const_closure(class_Matter_Device_find_plugin_by_friendly_name_closure) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(16) },
+        { be_const_key_weak(adjust_next_ep, -1), be_const_closure(class_Matter_Device_adjust_next_ep_closure) },
+        { be_const_key_weak(load_param, 54), be_const_closure(class_Matter_Device_load_param_closure) },
+        { be_const_key_weak(next_ep, 53), be_const_var(20) },
+        { be_const_key_weak(get_plugin_class_displayname, 2), be_const_closure(class_Matter_Device_get_plugin_class_displayname_closure) },
+        { be_const_key_weak(update_remotes_info, -1), be_const_closure(class_Matter_Device_update_remotes_info_closure) },
+        { be_const_key_weak(attribute_updated, 46), be_const_closure(class_Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(autoconf, -1), be_const_var(9) },
+        { be_const_key_weak(http_remotes, 41), be_const_var(15) },
+        { be_const_key_weak(reset_param, 39), be_const_closure(class_Matter_Device_reset_param_closure) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(class_Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(class_Matter_Device_received_ack_closure) },
+        { be_const_key_weak(plugins_persist, -1), be_const_var(2) },
+        { be_const_key_weak(button_multi_pressed, 24), be_const_closure(class_Matter_Device_button_multi_pressed_closure) },
+        { be_const_key_weak(init, 21), be_const_closure(class_Matter_Device_init_closure) },
+        { be_const_key_weak(conf_to_log, 19), be_const_static_closure(class_Matter_Device_conf_to_log_closure) },
+        { be_const_key_weak(button_pressed, -1), be_const_closure(class_Matter_Device_button_pressed_closure) },
+        { be_const_key_weak(save_before_restart, -1), be_const_closure(class_Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(profiler, 5), be_const_var(6) },
+        { be_const_key_weak(tick, 9), be_const_var(13) },
+        { be_const_key_weak(MtrInfo_one, -1), be_const_closure(class_Matter_Device_MtrInfo_one_closure) },
+        { be_const_key_weak(create_zb_mapper, -1), be_const_closure(class_Matter_Device_create_zb_mapper_closure) },
+        { be_const_key_weak(start, -1), be_const_closure(class_Matter_Device_start_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -1639,8 +1639,32 @@ void WifiShutdown(bool option) {
  */
 void WifiDisable(void) {
   if (!TasmotaGlobal.global_state.wifi_down) {
+#ifdef USE_WEBSERVER
+    // Close the webserver listening socket BEFORE WiFi teardown.
+    // WifiShutdown() contains delay() calls that yield to the RTOS,
+    // during which the lwIP task can queue new TCP connections into
+    // the accept backlog via the WiFi netif. When WiFi.disconnect()
+    // then destroys the netif, those connections have dangling pbufs.
+    // By closing the socket first, there is no backlog to poison.
+    WebserverStopSocket();
+#endif  // USE_WEBSERVER
+    // Notify all drivers to close their sockets BEFORE WiFi teardown.
+    // Any socket with queued data referencing the WiFi netif will have
+    // dangling pbufs after WiFi.disconnect() destroys the netif.
+    XdrvXsnsCall(FUNC_NETWORK_DOWN);
     WifiShutdown();
     WifiSetMode(WIFI_OFF);
+#ifdef USE_WEBSERVER
+    // Reopen the listening socket with a clean accept backlog.
+    // This is needed when Ethernet is active so the webserver
+    // continues to serve requests on the Ethernet interface.
+    WebserverStartSocket();
+#endif  // USE_WEBSERVER
+    if (!TasmotaGlobal.global_state.eth_down) {
+      // If Ethernet is still up, notify drivers that network is available
+      // so they can reopen their sockets on the Ethernet interface.
+      XdrvXsnsCall(FUNC_NETWORK_UP);
+    }
   }
   TasmotaGlobal.global_state.wifi_down = 1;
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -706,6 +706,25 @@ void StopWebserver(void) {
 
 /*-------------------------------------------------------------------------------------------*/
 
+// Close the webserver listening socket so that no new TCP connections
+// can accumulate in the accept backlog during WiFi teardown.
+// Must be called BEFORE WifiShutdown() to prevent dangling pbufs.
+void WebserverStopSocket(void) {
+  if (Webserver) {
+    Webserver->close();
+  }
+}
+
+// Reopen the webserver listening socket after WiFi teardown is complete.
+// This creates a fresh socket with an empty accept backlog.
+void WebserverStartSocket(void) {
+  if (Webserver) {
+    Webserver->begin();
+  }
+}
+
+/*-------------------------------------------------------------------------------------------*/
+
 void WifiManagerBegin(bool reset_only) {
   // setup AP
   if (!Web.initial_config) { AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_WCFG_2_WIFIMANAGER " " D_ACTIVE_FOR_3_MINUTES)); }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -981,6 +981,13 @@ bool Xdrv52(uint32_t function)
       callBerryEventDispatcher(PSTR("after_teleperiod"), nullptr, 0, nullptr);
       break;
 
+    case FUNC_NETWORK_UP:
+      callBerryEventDispatcher(PSTR("network_up"), nullptr, 0, nullptr);
+      break;
+    case FUNC_NETWORK_DOWN:
+      callBerryEventDispatcher(PSTR("network_down"), nullptr, 0, nullptr);
+      break;
+
     case FUNC_ACTIVE:
       result = true;
       break;


### PR DESCRIPTION
## Description:

Fix a long standing crash when Wifi gets disconnected with command `Wifi 0`. The fix ensures that Webserver and UDPserver are closed and reopened each time Wifi gets disconnected

Here is the full analysis by Claude:

# Wifi Shutdown Crash Analysis — `Wifi 0` Command

## The Bug

Executing `Wifi 0` (`CmndWifi()`) while there is active Web or UDP traffic causes a crash. The crash does not occur when there is no traffic at the time of shutdown.

## Crash Traces (call chain, caller → callee)

TCP (webserver):
```
Xdrv01() → WebServer::handleClient() → NetworkServer::accept() →
lwip_accept → netconn_delete → netconn_free → netconn_drain →
pbuf_free → esp_pbuf_free   ← CRASH
```

UDP (Berry/Matter):
```
Xdrv52() → be_pcall → be_udp_read → NetworkUDP::parsePacket() →
lwip_recvfrom → lwip_recvfrom_udp_raw → netbuf_delete →
pbuf_free → esp_pbuf_free   ← CRASH
```

## Architecture Context

Tasmota is **single-threaded and synchronous**. The main loop calls `Every250mSeconds()` which runs a state machine, and also calls `FUNC_LOOP` which runs driver loops including `PollDnsWebserver()` → `Webserver->handleClient()`.

The webserver uses a **listening TCP socket** managed by lwIP. Incoming TCP connections land in the socket's **accept backlog** — a queue of pending connections with associated `pbuf` chains that reference the network interface (`netif`) they arrived on.

UDP sockets similarly queue received packets in lwIP's internal receive buffer, with `pbuf` chains referencing the `netif` the packet arrived on.

## Chain of Events Leading to Crash

The main loop is `Scheduler()` in `tasmota.ino`. Each iteration runs, in order:
1. `XdrvXsnsCall(FUNC_LOOP)` — calls all driver loops, including `Xdrv01()` → `PollDnsWebserver()` → `Webserver->handleClient()`
2. (various 50ms/100ms handlers)
3. `Every250mSeconds()` — state machine, runs every 250ms

### Step 1: `CmndWifi(0)` is called (in `support_command.ino`)
- Sets `Settings->flag4.network_wifi = 0` (that's all it does for payload 0)
- Does NOT immediately disable WiFi — just sets the flag
- Returns to the main loop

### Step 2: `Every250mSeconds()` state machine, `case 2` (in `support_tasmota.ino`)
- Runs every 250ms at the `x.5` second mark
- Checks `Settings->flag4.network_wifi`: if 0, calls `WifiDisable()`
- `WifiDisable()` (in `support_wifi.ino`) → `WifiShutdown()` → `WiFi.disconnect(true, true)` + `WifiSetMode(WIFI_OFF)`
- This **tears down the WiFi `netif` in lwIP**, freeing its memory structures
- Meanwhile, any socket (TCP or UDP) still has queued data with `pbuf` pointers to the now-destroyed WiFi `netif`

### Step 3: Next `Scheduler()` iteration, `FUNC_LOOP` runs
- TCP: `Xdrv01(FUNC_LOOP)` → `PollDnsWebserver()` → `Webserver->handleClient()` → `lwip_accept()` → `pbuf_free()` on dangling pointer → **crash**
- UDP: `Xdrv52(FUNC_LOOP)` → Berry `udp.read()` → `lwip_recvfrom()` → `netbuf_delete` → `pbuf_free()` on dangling pointer → **crash**

Note: the crash can also happen later (e.g. when WiFi is re-enabled) if the socket read is somehow skipped — the poison persists in the socket until the socket is closed.

## Why the Poison Persists

The dangling references live inside lwIP-internal queues (TCP accept backlog, UDP receive buffer). The only way to clear them is to **close the socket** (`lwip_close`), which properly frees all queued data.

Critically, `WifiShutdown()` contains multiple `delay()` calls (totaling ~300ms) that **yield to the RTOS scheduler**. During these yields, the lwIP TCP/IP task runs and can queue new incoming data into sockets. This means even if you flush a socket right before `WifiShutdown()` and immediately reopen it, the new socket gets re-poisoned during the delays before `WiFi.disconnect()` destroys the netif.

## Approaches That Don't Work

1. **Guarding `PollDnsWebserver()` to skip `handleClient()`**: Only postpones the crash. When WiFi is re-enabled, the listening socket still has the poisoned backlog. The next `lwip_accept()` crashes.

2. **Selectively draining WiFi connections from the backlog**: The crash happens *inside* `lwip_accept()` before the connection is returned to user code. There is no opportunity to inspect or filter.

3. **Timing flags (`disable_in_progress`)**: The crash happens after `WifiDisable()` returns, in the same main loop iteration. No flag-based deferral helps.

4. **`close()` + `begin()` before `WifiShutdown()`**: The fresh socket gets re-poisoned during the `delay()` calls inside `WifiShutdown()`, which yield to the RTOS and allow the lwIP task to queue new WiFi connections before `WiFi.disconnect()` destroys the netif.

## The Fix

**Close all sockets before WiFi teardown, reopen them after.**

### TCP Webserver (C level)

`WebserverStopSocket()` / `WebserverStartSocket()` in `xdrv_01_9_webserver.ino`:
```cpp
void WebserverStopSocket(void) {
  if (Webserver) { Webserver->close(); }
}
void WebserverStartSocket(void) {
  if (Webserver) { Webserver->begin(); }
}
```

### UDP and other sockets (driver notification)

`WifiDisable()` dispatches `FUNC_NETWORK_DOWN` before teardown and `FUNC_NETWORK_UP` after (if Ethernet is still up). Berry's xdrv_52 forwards these as driver events `"network_down"` / `"network_up"`.

### `WifiDisable()` (in `support_wifi.ino`)
```cpp
void WifiDisable(void) {
  if (!TasmotaGlobal.global_state.wifi_down) {
    WebserverStopSocket();             // close TCP listening socket
    XdrvXsnsCall(FUNC_NETWORK_DOWN);  // notify drivers (Berry, emulation, etc.)
    WifiShutdown();                    // delay() calls yield to RTOS — no open sockets to poison
    WifiSetMode(WIFI_OFF);
    WebserverStartSocket();            // reopen TCP listening socket
    if (!TasmotaGlobal.global_state.eth_down) {
      XdrvXsnsCall(FUNC_NETWORK_UP);  // notify drivers to reopen sockets
    }
  }
  TasmotaGlobal.global_state.wifi_down = 1;
}
```

### Berry/Matter UDP (Berry level)

Berry events are dispatched via `tasmota.event()` to **Tasmota drivers** (objects registered with `tasmota.add_driver()`). They are NOT dispatched to rules (`tasmota.add_rule()`). The method name on the driver must match the event name.

`Matter_Device` (in `Matter_zz_Device.be`) is already a Tasmota driver. Added methods:
```berry
def network_down()
  if self.udp_server
    self.udp_server.flush_socket()
  end
end

def network_up()
  if self.udp_server
    self.udp_server.reopen_socket()
  end
end
```

`Matter_UDPServer` (in `Matter_UDPServer.be`) — new methods:
```berry
def flush_socket()
  if self.listening && self.udp_socket != nil
    self.udp_socket.close()       # Berry udp class uses 'close', not 'stop'
    self.udp_socket = nil
    self.packets_sent = []        # clear retransmit queue, remote will retry
  end
end

def reopen_socket()
  if self.listening && self.udp_socket == nil
    self.udp_socket = udp()
    var ok = self.udp_socket.begin(self.addr, self.port)
    if !ok  log("MTR: error reopening UDP server", 2)  end
  end
end
```

The `loop()` method already guards against `udp_socket == nil` (`if self.udp_socket == nil return end`). A nil guard was also added to `send()` to prevent crashes during the brief window when the socket is closed.

### Why `EspRestart()` / deep sleep don't need the fix
Other callers of `WifiShutdown()` (`EspRestart`, `DeepSleepStart`, ULP sleep) don't need the flush because the device is shutting down — the dangling pointer never gets dereferenced.

## Gotchas Discovered

1. **Berry `udp` class uses `close()`, not `stop()`**: The native method is mapped as `close` in `be_udp_lib.c`. Using `.stop()` raises `attribute_error`. The existing `Matter_UDPServer.stop()` method had the same latent bug (fixed).

2. **Berry event dispatch goes to drivers, not rules**: `callBerryEventDispatcher()` calls `tasmota.event()` which dispatches to driver methods via `introspect.get(driver, event_name)`. It does NOT trigger `tasmota.add_rule()` callbacks. To receive these events, a class must be registered as a driver (`tasmota.add_driver(self)`) and have a method matching the event name.

3. **`FUNC_NETWORK_DOWN` is already called in `Every250mSeconds` case 3**: But only when `network_down` is true (both WiFi AND Ethernet down), and 250ms after `WifiDisable()` — too late. Our new call in `WifiDisable()` fires before teardown regardless of Ethernet state.

## Key Files

| File | Role |
|------|------|
| `tasmota/tasmota_support/support_wifi.ino` | `WifiDisable()`, `WifiShutdown()`, `EspRestart()` |
| `tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino` | `WebserverStopSocket()`, `WebserverStartSocket()`, `PollDnsWebserver()` |
| `tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino` | Berry event dispatch for `FUNC_NETWORK_DOWN` / `FUNC_NETWORK_UP` |
| `lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be` | `network_down()` / `network_up()` driver methods |
| `lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be` | `flush_socket()` / `reopen_socket()` / `send()` nil guard |
| `lib/libesp32/berry_tasmota/src/be_udp_lib.c` | Berry `udp` class definition (method is `close`, not `stop`) |
| `tasmota/tasmota_support/support_tasmota.ino` | `Every250mSeconds()` state machine (case 2 triggers `WifiDisable`) |
| `tasmota/tasmota.ino` | `WIFI` struct definition |
| Framework: `NetworkServer` | `sockfd` is private, no accessor — cannot patch externally |
| Framework: `WebServer` | `handleClient()` calls `_server.accept()` → `lwip_accept()` |
| Framework: `NetworkUDP` | `parsePacket()` calls `recvfrom()` → `lwip_recvfrom()` |


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
