### PR TITLE
Berry remove `mdns.stop()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Crash when shutting down Wifi with `Wifi 0` (#24536)
 
 ### Removed
+- Berry remove `mdns.stop()`
 
 ## [15.3.0.1] 20260308
 ### Added

--- a/lib/libesp32/berry_tasmota/src/be_mdns_module.c
+++ b/lib/libesp32/berry_tasmota/src/be_mdns_module.c
@@ -14,9 +14,6 @@
 extern void m_mdns_start(struct bvm *vm, const char* hostname);
 BE_FUNC_CTYPE_DECLARE(m_mdns_start, "", "@[s]")
 
-extern void m_mdns_stop(void);
-BE_FUNC_CTYPE_DECLARE(m_mdns_stop, "", "")
-
 extern void m_mdns_set_hostname(struct bvm *vm, const char * hostname);
 BE_FUNC_CTYPE_DECLARE(m_mdns_set_hostname, "", "@s")
 
@@ -29,7 +26,6 @@ extern int m_dns_find_service(struct bvm *vm);
 /* @const_object_info_begin
 module mdns (scope: global) {
     start, ctype_func(m_mdns_start)
-    stop, ctype_func(m_mdns_stop)
     set_hostname, ctype_func(m_mdns_set_hostname)
     add_service, func(m_mdns_add_service)
     add_hostname, func(m_dns_add_hostname)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
@@ -46,14 +46,6 @@ extern "C" {
   BE_FUNC_CTYPE_DECLARE(m_mdns_start, "", "@[s]")
 
   //
-  // `msdn.stop() -> nil`
-  // free all mdns resources
-  void m_mdns_stop(void) {
-    mdns_free();
-  }
-  BE_FUNC_CTYPE_DECLARE(m_mdns_stop, "", "")
-
-  //
   // `mdns.set_hostname(hostname:string) -> nil`
   // change the hostname
   void m_mdns_set_hostname(struct bvm *vm, const char * hostname) {


### PR DESCRIPTION
## Description:

Berry remove `mdns.stop()`. It should never be called anyways.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
