### PR TITLE
Berry add `loglevel` to `mqtt.publish()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Environment sensors CCS811, SGP30 and SGP40 second I2C bus support
 - Real Time Clocks BM8563, PCF85063 and PCF85363 second I2C bus support
 - LCD second I2C bus support
+- Berry add `loglevel` to `mqtt.publish()`
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
@@ -23,7 +23,7 @@
 
 #include "berry.h"
 
-// Berry: `tasmota.publish(topic, payload [, retain:bool, start:int, len:int]) -> nil``
+// Berry: `mqtt.publish(topic, payload [, retain:bool, start:int, len:int, loglevel:int]) -> nil`
 // is_method is true if called from Tasmota class, false if called from mqtt module
 extern "C" {
   int32_t be_mqtt_publish(struct bvm *vm);
@@ -34,13 +34,15 @@ extern "C" {
       int32_t payload_start = 0;
       int32_t len = -1;   // send all of it
       bool is_binary = be_isbytes(vm, 3);       // is this a binary payload (or false = string)
-      if (top >= 4) { retain = be_tobool(vm, 4); }
-      if (top >= 5) {
+      int32_t loglevel = LOG_LEVEL_INFO;
+      if (top >= 4 && !be_isnil(vm, 4)) { retain = be_tobool(vm, 4); }
+      if (top >= 5 && !be_isnil(vm, 5)) {
         if (!is_binary) { be_raise(vm, "argument_error", "start and len are not allowed with string payloads"); }
         payload_start = be_toint(vm, 5);
         if (payload_start < 0) { payload_start = 0; }
       }
-      if (top >= 6) { len = be_toint(vm, 6); }
+      if (top >= 6 && !be_isnil(vm, 6)) { len = be_toint(vm, 6); }
+      if (top >= 7 && !be_isnil(vm, 7)) { loglevel = be_toint(vm, 7); }
       const char * topic = be_tostring(vm, 2);
       const char * payload = nullptr;
       size_t payload_len = 0;
@@ -62,7 +64,7 @@ extern "C" {
 
       be_pop(vm, be_top(vm));   // clear stack to avoid any indirect warning message in subsequent calls to Berry
 
-      MqttPublishPayload(topic, payload, is_binary ? len : 0 /*if string don't send length*/, retain);
+      MqttPublishPayload(topic, payload, is_binary ? len : 0 /*if string don't send length*/, retain, loglevel);
       if (!is_binary) {
         XdrvRulesProcess(0, payload);  // Process rules on berry publish
       }


### PR DESCRIPTION
## Description:

Berry add an optional `loglevel` to `mqtt.publish()` to select the loglevel per message, instead of the default `LOG_LEVEL_INFO`(`2`). Setting `0` disables logging at all.

`mqtt.publish(topic, payload [, retain:bool, start:int, len:int, loglevel:int]) -> nil`

Since `loglevel` is the last optional argument, you can pass `nil` to the previous optional argument to ignore them and set the default valude, ex: `mqtt.publish('{"k":"Testpayload"}', "/my/topic", nil, nil, nil, 0)`

Follow-up of #21308 and https://github.com/arendst/Tasmota/commit/a932b3d991caf9911614dbb77bc6382c64b65c46

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
