### PR TITLE
Berry remove BE_USE_PRECOMPILED_OBJECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - ESP8266 heap drain and exception 29 when DHCP provides NTP server (#24515)
 
 ### Removed
+- Berry removed `BE_USE_PRECOMPILED_OBJECT` which is enforced in Tasmota
 
 ## [15.3.0.2] 20260315
 ### Added

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -393,7 +393,4 @@ BERRY_API void be_load_custom_libs(bvm *vm)
     (void)vm;   /* prevent a compiler warning */
     
     /* add here custom libs */
-#if !BE_USE_PRECOMPILED_OBJECT
-    /* be_load_xxxlib(vm); */
-#endif
 }

--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -53,13 +53,6 @@
  **/
 #define BE_BYTES_MAX_SIZE               (32*1024)   /* 32 kb default value */
 
-/* Macro: BE_USE_PRECOMPILED_OBJECT
- * Use precompiled objects to avoid creating these objects at
- * runtime. Enable this macro can greatly optimize RAM usage.
- * Default: 1
- **/
-#define BE_USE_PRECOMPILED_OBJECT       1
-
 /* Macro: BE_DEBUG_SOURCE_FILE
  * Indicate if each function remembers its source file name
  * 0: do not keep the file name (saves 4 bytes per function)

--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -80,17 +80,10 @@ BERRY_API void be_regfunc(bvm *vm, const char *name, bntvfunc f)
 {
     bvalue *var;
     bstring *s = be_newstr(vm, name);
-#if !BE_USE_PRECOMPILED_OBJECT
-    int idx = be_builtin_find(vm, s);
-    be_assert(idx < 0);
-    if (idx < 0) { /* new function */
-        idx = be_builtin_new(vm, s);
-#else
     int idx = be_global_find(vm, s);
     be_assert(idx < be_builtin_count(vm));
     if (idx < be_builtin_count(vm)) { /* new function */
         idx = be_global_new(vm, s);
-#endif
         var = be_global_var(vm, idx);
         var_setntvfunc(var, f);
     } /* error case, do nothing */
@@ -100,17 +93,10 @@ BERRY_API void be_regclass(bvm *vm, const char *name, const bnfuncinfo *lib)
 {
     bvalue *var;
     bstring *s = be_newstr(vm, name);
-#if !BE_USE_PRECOMPILED_OBJECT
-    int idx = be_builtin_find(vm, s);
-    be_assert(idx < 0);
-    if (idx < 0) { /* new function */
-        idx = be_builtin_new(vm, s);
-#else
     int idx = be_global_find(vm, s);
     be_assert(idx < be_builtin_count(vm));
     if (idx < be_builtin_count(vm)) { /* new function */
         idx = be_global_new(vm, s);
-#endif
         var = be_global_var(vm, idx);
         var_setclass(var, class_auto_make(vm, s, lib));
     } /* error case, do nothing */

--- a/lib/libesp32/berry/src/be_baselib.c
+++ b/lib/libesp32/berry/src/be_baselib.c
@@ -201,15 +201,11 @@ int be_baselib_super(bvm *vm)
 int be_baselib_type(bvm *vm)
 {
     if (be_top(vm)) {
-#if BE_USE_PRECOMPILED_OBJECT
         bvalue *v = be_indexof(vm, 1);
         bstring *s = be_vtype2bstring(v);
         bvalue *reg = be_incrtop(vm);
         be_assert(reg < vm->stacktop);
         var_setstr(reg, s);
-#else
-        be_pushstring(vm, be_typename(vm, 1));
-#endif
         be_return(vm);
     }
     be_return_nil(vm);
@@ -490,36 +486,6 @@ int be_baselib_isinstance(bvm *vm)
     return _issubv(vm, be_isinstance);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_baselib(bvm *vm)
-{
-    be_regfunc(vm, "assert", be_baselib_assert);
-    be_regfunc(vm, "print", be_baselib_print);
-    be_regfunc(vm, "input", be_baselib_input);
-    be_regfunc(vm, "super", be_baselib_super);
-    be_regfunc(vm, "type", be_baselib_type);
-    be_regfunc(vm, "classname", be_baselib_classname);
-    be_regfunc(vm, "classof", be_baselib_classof);
-    be_regfunc(vm, "number", be_baselib_number);
-    be_regfunc(vm, "str", be_baselib_str);
-    be_regfunc(vm, "int", be_baselib_int);
-    be_regfunc(vm, "real", be_baselib_real);
-    be_regfunc(vm, "module", be_baselib_module);
-    be_regfunc(vm, "size", be_baselib_size);
-    be_regfunc(vm, "compile", be_baselib_compile);
-    be_regfunc(vm, "issubclass", be_baselib_issubclass);
-    be_regfunc(vm, "isinstance", be_baselib_isinstance);
-    be_regfunc(vm, "__iterator__", be_baselib_iterator);
-}
-
-/* call must be added later to respect order of builtins */
-void be_load_baselib_next(bvm *vm)
-{
-    be_regfunc(vm, "call", l_call);
-    be_regfunc(vm, "bool", l_bool);
-    be_regfunc(vm, "format", be_str_format);
-}
-#else
 extern const bclass be_class_list;
 extern const bclass be_class_map;
 extern const bclass be_class_range;
@@ -561,4 +527,3 @@ void be_load_baselib(bvm *vm)
 {
     be_const_builtin_set(vm, &m_builtin_map, &m_builtin_vector);
 }
-#endif

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -1905,61 +1905,6 @@ be_local_closure(setbits,   /* name */
 );
 /*******************************************************************/
 
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_byteslib(bvm *vm)
-{
-    static const bnfuncinfo members[] = {
-        { ".p", NULL },
-        { ".len", NULL },
-        { ".size", NULL },
-        { "_buffer", m_buffer },
-        { "_change_buffer", m_change_buffer },
-        { "ismapped", m_is_mapped },
-        { "isreadonly", m_is_readonly },
-        { "init", m_init },
-        { "deinit", m_deinit },
-        { "tostring", m_tostring },
-        { "asstring", m_asstring },
-        { "tobool", m_tobool },
-        { "fromstring", m_fromstring },
-        { "tob64", m_tob64 },
-        { "fromb64", m_fromb64 },
-        { "fromhex", m_fromhex },
-        { "tohex", m_tohex },
-        { "add", m_add },
-        { "get", m_getu },
-        { "geti", m_geti },
-        { "set", m_set },
-        { "seti", m_set },      // setters for signed and unsigned are identical
-        { "setbytes", m_setbytes },
-        { "getfloat", m_getfloat },
-        { "setfloat", m_setfloat },
-        { "addfloat", m_addfloat },
-        { "item", m_item },
-        { "setitem", m_setitem },
-        { "size", m_size },
-        { "resize", m_resize },
-        { "clear", m_clear },
-        { "reverse", m_reverse },
-        { "copy", m_copy },
-        { "append", m_connect },
-        { "appendhex", m_appendhex },
-        { "appendb64", m_appendb64 },
-        { "+", m_merge },
-        { "..", m_connect },
-        { "==", m_equal },
-        { "!=", m_nequal },
-
-        { NULL, (bntvfunc) BE_CLOSURE }, /* mark section for berry closures */
-        { "getbits", (bntvfunc) &getbits_closure },
-        { "setbits", (bntvfunc) &setbits_closure },
-
-        { NULL, NULL }
-    };
-    be_regclass(vm, "bytes", members);
-}
-#else
-
 #include "../generate/be_const_bytes_def.h"
 
 /* @const_object_info_begin
@@ -2010,4 +1955,3 @@ class be_class_bytes (scope: global, name: bytes) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_be_class_bytes.h"
-#endif

--- a/lib/libesp32/berry/src/be_byteslib.h
+++ b/lib/libesp32/berry/src/be_byteslib.h
@@ -37,8 +37,6 @@ typedef struct buf_impl {
 
 size_t be_bytes_tohex(char * out, size_t outsz, const uint8_t * in, size_t insz);
 
-#if BE_USE_PRECOMPILED_OBJECT
 #include "../generate/be_const_bytes.h"
-#endif
 
 #endif

--- a/lib/libesp32/berry/src/be_debuglib.c
+++ b/lib/libesp32/berry/src/be_debuglib.c
@@ -240,29 +240,6 @@ static int m_reallocs(bvm *vm) {
 #endif
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(debug) {
-    be_native_module_function("attrdump", m_attrdump),
-    be_native_module_function("codedump", m_codedump),
-    be_native_module_function("traceback", m_traceback),
-#if BE_USE_DEBUG_HOOK
-    be_native_module_function("sethook", m_sethook),
-#endif
-#if BE_USE_PERF_COUNTERS
-    be_native_module_function("counters", m_counters),
-#endif
-    be_native_module_function("calldepth", m_calldepth),
-    be_native_module_function("top", m_top),
-#if BE_DEBUG_VAR_INFO
-    be_native_module_function("varname", m_varname),
-    be_native_module_function("upvname", m_upvname),
-#endif
-    be_native_module_function("caller", m_caller),
-    be_native_module_function("gcdebug", m_gcdebug)
-};
-
-be_define_native_module(debug, NULL);
-#else
 /* @const_object_info_begin
 module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     attrdump, func(m_attrdump)
@@ -284,6 +261,5 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_debug.h"
-#endif
 
 #endif /* BE_USE_DEBUG_MODULE */

--- a/lib/libesp32/berry/src/be_filelib.c
+++ b/lib/libesp32/berry/src/be_filelib.c
@@ -214,11 +214,7 @@ static int i_savecode(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-static int m_open(bvm *vm)
-#else
 int be_nfunc_open(bvm *vm)
-#endif
 {
     int argc = be_top(vm);
     const char *fname, *mode;
@@ -256,10 +252,3 @@ int be_nfunc_open(bvm *vm)
     }
     be_return_nil(vm);
 }
-
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_filelib(bvm *vm)
-{
-    be_regfunc(vm, "open", m_open);
-}
-#endif

--- a/lib/libesp32/berry/src/be_gclib.c
+++ b/lib/libesp32/berry/src/be_gclib.c
@@ -33,14 +33,6 @@ static int m_collect(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(gc){
-    be_native_module_function("allocated", m_allocated),
-    be_native_module_function("collect", m_collect)
-};
-
-be_define_native_module(gc, NULL);
-#else
 /* @const_object_info_begin
 module gc (scope: global, depend: BE_USE_GC_MODULE) {
     allocated, func(m_allocated)
@@ -48,6 +40,5 @@ module gc (scope: global, depend: BE_USE_GC_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_gc.h"
-#endif
 
 #endif /* BE_USE_SYS_MODULE */

--- a/lib/libesp32/berry/src/be_globallib.c
+++ b/lib/libesp32/berry/src/be_globallib.c
@@ -92,17 +92,6 @@ static int m_undef(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(global) {
-    be_native_module_function("()", m_globals),
-    be_native_module_function("contains", m_contains),
-    be_native_module_function("member", m_findglobal),
-    be_native_module_function("setmember", m_setglobal),
-    be_native_module_function("undef", m_undef),
-};
-
-be_define_native_module(global, NULL);
-#else
 /* @const_object_info_begin
 module global (scope: global, depend: BE_USE_GLOBAL_MODULE) {
     (), func(m_globals)
@@ -113,6 +102,5 @@ module global (scope: global, depend: BE_USE_GLOBAL_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_global.h"
-#endif
 
 #endif /* BE_USE_GLOBAL_MODULE */

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -250,28 +250,6 @@ static int m_name(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(introspect) {
-    be_native_module_function("members", m_attrlist),
-
-    be_native_module_function("get", m_findmember),
-    be_native_module_function("set", m_setmember),
-    be_native_module_function("contains", m_contains),
-
-    be_native_module_function("module", m_getmodule),
-    be_native_module_function("setmodule", m_setmodule),
-
-    be_native_module_function("toptr", m_toptr),
-    be_native_module_function("fromptr", m_fromptr),
-    be_native_module_function("solidified", m_solidified),
-
-    be_native_module_function("name", m_name),
-
-    be_native_module_function("ismethod", m_ismethod),
-};
-
-be_define_native_module(introspect, NULL);
-#else
 /* @const_object_info_begin
 module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
     members, func(m_attrlist)
@@ -293,6 +271,5 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_introspect.h"
-#endif
 
 #endif /* BE_USE_INTROSPECT_MODULE */

--- a/lib/libesp32/berry/src/be_jsonlib.c
+++ b/lib/libesp32/berry/src/be_jsonlib.c
@@ -624,14 +624,6 @@ static int m_json_dump(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(json) {
-    be_native_module_function("load", m_json_load),
-    be_native_module_function("dump", m_json_dump)
-};
-
-be_define_native_module(json, NULL);
-#else
 /* @const_object_info_begin
 module json (scope: global, depend: BE_USE_JSON_MODULE) {
     load, func(m_json_load)
@@ -639,6 +631,5 @@ module json (scope: global, depend: BE_USE_JSON_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_json.h"
-#endif
 
 #endif /* BE_USE_JSON_MODULE */

--- a/lib/libesp32/berry/src/be_libs.c
+++ b/lib/libesp32/berry/src/be_libs.c
@@ -18,12 +18,4 @@ extern void be_load_byteslib(bvm *vm);
 void be_loadlibs(bvm *vm)
 {
     be_load_baselib(vm);
-#if !BE_USE_PRECOMPILED_OBJECT
-    be_load_listlib(vm);
-    be_load_maplib(vm);
-    be_load_rangelib(vm);
-    be_load_filelib(vm);
-    be_load_byteslib(vm);
-    be_load_baselib_next(vm);
-#endif
 }

--- a/lib/libesp32/berry/src/be_listlib.c
+++ b/lib/libesp32/berry/src/be_listlib.c
@@ -493,38 +493,6 @@ static int m_nequal(bvm *vm)
     return list_equal(vm, bfalse);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_listlib(bvm *vm)
-{
-    static const bnfuncinfo members[] = {
-        { ".p", NULL },
-        { "init", m_init },
-        { "tostring", m_tostring },
-        { "push", m_push },
-        { "pop", m_pop },
-        { "insert", m_insert },
-        { "remove", m_remove },
-        { "item", m_item },
-        { "find", m_find },
-        { "setitem", m_setitem },
-        { "size", m_size },
-        { "resize", m_resize },
-        { "clear", m_clear },
-        { "iter", m_iter },
-        { "concat", m_concat },
-        { "reverse", m_reverse },
-        { "copy", m_copy },
-        { "keys", m_keys },
-        { "tobool", m_tobool },
-        { "..", m_connect },
-        { "+", m_merge },
-        { "==", m_equal },
-        { "!=", m_nequal },
-        { NULL, NULL }
-    };
-    be_regclass(vm, "list", members);
-}
-#else
 /* @const_object_info_begin
 class be_class_list (scope: global, name: list) {
     .p, var
@@ -553,4 +521,3 @@ class be_class_list (scope: global, name: list) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_be_class_list.h"
-#endif

--- a/lib/libesp32/berry/src/be_maplib.c
+++ b/lib/libesp32/berry/src/be_maplib.c
@@ -220,29 +220,6 @@ static int m_keys(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_maplib(bvm *vm)
-{
-    static const bnfuncinfo members[] = {
-        { ".p", NULL },
-        { "init", m_init },
-        { "tostring", m_tostring },
-        { "remove", m_remove },
-        { "item", m_item },
-        { "setitem", m_setitem },
-        { "find", m_find },
-        { "contains", m_contains },
-        { "has", m_contains },  /* deprecated */
-        { "size", m_size },
-        { "insert", m_insert },
-        { "iter", m_iter },
-        { "keys", m_keys },
-        { "tobool", m_tobool },
-        { NULL, NULL }
-    };
-    be_regclass(vm, "map", members);
-}
-#else
 /* @const_object_info_begin
 class be_class_map (scope: global, name: map) {
     .p, var
@@ -262,4 +239,3 @@ class be_class_map (scope: global, name: map) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_be_class_map.h"
-#endif

--- a/lib/libesp32/berry/src/be_mathlib.c
+++ b/lib/libesp32/berry/src/be_mathlib.c
@@ -358,44 +358,6 @@ int m_max(bvm *vm)
     return m_min_max(vm, 0);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(math) {
-    be_native_module_function("isnan", m_isnan),
-    be_native_module_function("isinf", m_isinf),
-    be_native_module_function("abs", m_abs),
-    be_native_module_function("ceil", m_ceil),
-    be_native_module_function("floor", m_floor),
-    be_native_module_function("round", m_round),
-    be_native_module_function("sin", m_sin),
-    be_native_module_function("cos", m_cos),
-    be_native_module_function("tan", m_tan),
-    be_native_module_function("asin", m_asin),
-    be_native_module_function("acos", m_acos),
-    be_native_module_function("atan", m_atan),
-    be_native_module_function("atan2", m_atan2),
-    be_native_module_function("sinh", m_sinh),
-    be_native_module_function("cosh", m_cosh),
-    be_native_module_function("tanh", m_tanh),
-    be_native_module_function("sqrt", m_sqrt),
-    be_native_module_function("exp", m_exp),
-    be_native_module_function("log", m_log),
-    be_native_module_function("log10", m_log10),
-    be_native_module_function("deg", m_deg),
-    be_native_module_function("rad", m_rad),
-    be_native_module_function("pow", m_pow),
-    be_native_module_function("srand", m_srand),
-    be_native_module_function("rand", m_rand),
-    be_native_module_function("min", m_min),
-    be_native_module_function("max", m_max),
-    be_native_module_real("pi", M_PI),
-    be_native_module_real("nan", NAN),
-    be_native_module_real("inf", INFINITY),
-    be_native_module_int("imax", M_IMAX),
-    be_native_module_int("imin", M_IMIN),
-};
-
-be_define_native_module(math, NULL);
-#else
 /* @const_object_info_begin
 module math (scope: global, depend: BE_USE_MATH_MODULE) {
     isnan, func(m_isnan)
@@ -433,6 +395,5 @@ module math (scope: global, depend: BE_USE_MATH_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_math.h"
-#endif
 
 #endif /* BE_USE_MATH_MODULE */

--- a/lib/libesp32/berry/src/be_object.c
+++ b/lib/libesp32/berry/src/be_object.c
@@ -36,7 +36,6 @@ const char* be_vtype2str(bvalue *v)
     }
 }
 
-#if BE_USE_PRECOMPILED_OBJECT
 extern const bcstring be_const_str_nil;
 extern const bcstring be_const_str_int;
 extern const bcstring be_const_str_real;
@@ -52,11 +51,9 @@ extern const bcstring be_const_str_module;
 extern const bcstring be_const_str_var;
 extern const bcstring be_const_str_ptr;
 extern const bcstring be_const_str_invalid_type;
-#endif
 
 bstring* be_vtype2bstring(bvalue *v)
 {
-#if BE_USE_PRECOMPILED_OBJECT
     switch(var_primetype(v)) {
     case BE_NIL: return (bstring*) &be_const_str_nil;
     case BE_INT: return (bstring*) &be_const_str_int;
@@ -75,9 +72,6 @@ bstring* be_vtype2bstring(bvalue *v)
     case BE_COMPTR: return (bstring*) &be_const_str_ptr;
     default: return (bstring*) &be_const_str_invalid_type;
     }
-#else
-    return be_newstr(vm, be_vtype2str(v));
-#endif
 }
 
 bvalue* be_indexof(bvm *vm, int idx)

--- a/lib/libesp32/berry/src/be_oslib.c
+++ b/lib/libesp32/berry/src/be_oslib.c
@@ -216,31 +216,6 @@ static int m_path_join(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(path) {
-    be_native_module_function("isdir", m_path_isdir),
-    be_native_module_function("isfile", m_path_isfile),
-    be_native_module_function("exists", m_path_exists),
-    be_native_module_function("split", m_path_split),
-    be_native_module_function("splitext", m_path_splitext),
-    be_native_module_function("join", m_path_join)
-};
-
-static be_define_native_module(path, NULL);
-
-be_native_module_attr_table(os) {
-    be_native_module_function("getcwd", m_getcwd),
-    be_native_module_function("chdir", m_chdir),
-    be_native_module_function("mkdir", m_mkdir),
-    be_native_module_function("remove", m_remove),
-    be_native_module_function("listdir", m_listdir),
-    be_native_module_function("system", m_system),
-    be_native_module_function("exit", m_exit),
-    be_native_module_module("path", be_native_module(path))
-};
-
-be_define_native_module(os, NULL);
-#else
 /* @const_object_info_begin
 module path (scope: local, file: os_path, depend: BE_USE_OS_MODULE) {
     isdir, func(m_path_isdir)
@@ -266,6 +241,5 @@ module os (scope: global, depend: BE_USE_OS_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_os.h"
-#endif
 
 #endif /* BE_USE_OS_MODULE */

--- a/lib/libesp32/berry/src/be_rangelib.c
+++ b/lib/libesp32/berry/src/be_rangelib.c
@@ -151,24 +151,6 @@ static int m_iter(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-void be_load_rangelib(bvm *vm)
-{
-    static const bnfuncinfo members[] = {
-        { "__lower__", NULL },
-        { "__upper__", NULL },
-        { "__incr__", NULL },
-        { "init", m_init },
-        { "tostring", m_tostring },
-        { "lower", m_lower },
-        { "upper", m_upper },
-        { "setrange", m_setrange },
-        { "iter", m_iter },
-        { NULL, NULL }
-    };
-    be_regclass(vm, "range", members);
-}
-#else
 /* @const_object_info_begin
 class be_class_range (scope: global, name: range) {
     __lower__, var
@@ -184,4 +166,3 @@ class be_class_range (scope: global, name: range) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_be_class_range.h"
-#endif

--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -868,14 +868,6 @@ static int m_nocompact(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(solidify) {
-    be_native_module_function("dump", m_dump),
-    be_native_module_function("compact", m_compact),
-};
-
-be_define_native_module(solidify, NULL);
-#else
 /* @const_object_info_begin
 module solidify (scope: global, depend: BE_USE_SOLIDIFY_MODULE) {
     dump, func(m_dump)
@@ -884,6 +876,5 @@ module solidify (scope: global, depend: BE_USE_SOLIDIFY_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_solidify.h"
-#endif
 
 #endif /* BE_USE_SOLIFIDY_MODULE */

--- a/lib/libesp32/berry/src/be_strictlib.c
+++ b/lib/libesp32/berry/src/be_strictlib.c
@@ -22,19 +22,11 @@ static int m_init(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(strict) {
-    be_native_module_function("init", m_init),
-};
-
-be_define_native_module(strict, NULL);
-#else
 /* @const_object_info_begin
 module strict (scope: strict, depend: BE_USE_STRICT_MODULE) {
     init, func(m_init)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_strict.h"
-#endif
 
 #endif /* BE_USE_STRICT_MODULE */

--- a/lib/libesp32/berry/src/be_string.c
+++ b/lib/libesp32/berry/src/be_string.c
@@ -45,9 +45,7 @@ struct bconststrtab {
     int size;
 };
 
-#if BE_USE_PRECOMPILED_OBJECT
 #include "../generate/be_const_strtab_def.h"
-#endif
 
 int be_eqstr(bstring *s1, bstring *s2)
 {
@@ -134,11 +132,6 @@ static uint32_t str_hash(const char *str, size_t len)
 void be_string_init(bvm *vm)
 {
     resize(vm, 8);
-#if !BE_USE_PRECOMPILED_OBJECT
-    /* the destructor name deinit needs to exist all the time, to ensure
-     * that it does not need to be created when the heap is exhausted. */
-    be_gc_fix(vm, cast(bgcobject*, str_literal(vm, "deinit")));
-#endif
     /* be_const_str_deinit --> for precompiled */
 }
 
@@ -171,7 +164,6 @@ static bstring* createstrobj(bvm *vm, size_t len, int islong)
     return s;
 }
 
-#if BE_USE_PRECOMPILED_OBJECT
 static bstring* find_conststr(const char *str, size_t len)
 {
     const struct bconststrtab *tab = &m_const_string_table;
@@ -190,7 +182,6 @@ static bstring* find_conststr(const char *str, size_t len)
     }
     return NULL;
 }
-#endif
 
 static bstring* newshortstr(bvm *vm, const char *str, size_t len)
 {
@@ -246,12 +237,8 @@ bstring* be_newstr(bvm *vm, const char *str)
 bstring *be_newstrn(bvm *vm, const char *str, size_t len)
 {
     if (len <= SHORT_STR_MAX_LEN) {
-#if BE_USE_PRECOMPILED_OBJECT
         bstring *s = find_conststr(str, len);
         return s ? s : newshortstr(vm, str, len);
-#else
-        return newshortstr(vm, str, len);
-#endif
     }
     return be_newlongstr(vm, str, len); /* long string */
 }

--- a/lib/libesp32/berry/src/be_string.h
+++ b/lib/libesp32/berry/src/be_string.h
@@ -45,9 +45,7 @@ typedef struct {
 #define str_extra(_s)           ((_s)->extra)
 #define str_literal(_vm, _s)    be_newstrn((_vm), (_s), sizeof(_s) - 1)
 
-#if BE_USE_PRECOMPILED_OBJECT
 #include "../generate/be_const_strtab.h"
-#endif
 
 void be_string_init(bvm *vm);
 void be_string_deleteall(bvm *vm);

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -1135,26 +1135,6 @@ static int str_endswith(bvm *vm)
     be_return_nil(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(string) {
-    be_native_module_function("format", be_str_format),
-    be_native_module_function("count", str_count),
-    be_native_module_function("split", str_split),
-    be_native_module_function("find", str_find),
-    be_native_module_function("hex", str_i2hex),
-    be_native_module_function("byte", str_byte),
-    be_native_module_function("char", str_char),
-    be_native_module_function("tolower", str_tolower),
-    be_native_module_function("toupper", str_toupper),
-    be_native_module_function("tr", str_tr),
-    be_native_module_function("escape", str_escape),
-    be_native_module_function("replace", str_replace),
-    be_native_module_function("startswith", str_startswith),
-    be_native_module_function("endswith", str_endswith),
-};
-
-be_define_native_module(string, NULL);
-#else
 /* @const_object_info_begin
 module string (scope: global, depend: BE_USE_STRING_MODULE) {
     format, func(be_str_format)
@@ -1174,6 +1154,5 @@ module string (scope: global, depend: BE_USE_STRING_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_string.h"
-#endif
 
 #endif /* BE_USE_STRING_MODULE */

--- a/lib/libesp32/berry/src/be_syslib.c
+++ b/lib/libesp32/berry/src/be_syslib.c
@@ -18,19 +18,11 @@ static int m_path(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(sys){
-    be_native_module_function("path", m_path)
-};
-
-be_define_native_module(sys, NULL);
-#else
 /* @const_object_info_begin
 module sys (scope: global, depend: BE_USE_SYS_MODULE) {
     path, func(m_path)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_sys.h"
-#endif
 
 #endif /* BE_USE_SYS_MODULE */

--- a/lib/libesp32/berry/src/be_timelib.c
+++ b/lib/libesp32/berry/src/be_timelib.c
@@ -50,15 +50,6 @@ static int m_clock(bvm *vm)
     be_return(vm);
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(time) {
-    be_native_module_function("time", m_time),
-    be_native_module_function("dump", m_dump),
-    be_native_module_function("clock", m_clock)
-};
-
-be_define_native_module(time, NULL);
-#else
 /* @const_object_info_begin
 module time (scope: global, depend: BE_USE_TIME_MODULE) {
     time, func(m_time)
@@ -67,6 +58,5 @@ module time (scope: global, depend: BE_USE_TIME_MODULE) {
 }
 @const_object_info_end */
 #include "../generate/be_fixed_time.h"
-#endif
 
 #endif /* BE_USE_TIME_MODULE */

--- a/lib/libesp32/berry/src/be_undefinedlib.c
+++ b/lib/libesp32/berry/src/be_undefinedlib.c
@@ -17,18 +17,9 @@
 #include "be_gc.h"
 #include <string.h>
 
-
-#if !BE_USE_PRECOMPILED_OBJECT
-be_native_module_attr_table(undefined) {
-    be_native_module_nil(".p"),         /* not needed but can't be empty */
-};
-
-be_define_native_module(undefined, NULL);
-#else
 /* @const_object_info_begin
 module undefined (scope: global) {
     .p, nil()
 }
 @const_object_info_end */
 #include "../generate/be_fixed_undefined.h"
-#endif

--- a/lib/libesp32/berry/src/be_var.c
+++ b/lib/libesp32/berry/src/be_var.c
@@ -24,21 +24,12 @@ void be_globalvar_init(bvm *vm)
     global(vm).vtab = be_map_new(vm);
     be_gc_fix(vm, gc_object(global(vm).vtab));
     be_vector_init(vm, &global(vm).vlist, sizeof(bvalue));
-#if !BE_USE_PRECOMPILED_OBJECT
-    builtin(vm).vtab = be_map_new(vm);
-    be_vector_init(vm, &builtin(vm).vlist, sizeof(bvalue));
-    be_gc_fix(vm, gc_object(builtin(vm).vtab));
-#endif
 }
 
 void be_globalvar_deinit(bvm *vm)
 {
     global(vm).vtab = NULL;
     be_vector_delete(vm, &global(vm).vlist);
-#if !BE_USE_PRECOMPILED_OBJECT
-    builtin(vm).vtab = NULL;
-    be_vector_delete(vm, &builtin(vm).vlist);
-#endif
 }
 
 /* This function is called when the global was not found */
@@ -171,31 +162,8 @@ bstring* be_builtin_name(bvm *vm, int index)
     return NULL;
 }
 
-#if !BE_USE_PRECOMPILED_OBJECT
-int be_builtin_new(bvm *vm, bstring *name)
-{
-    int idx = be_builtin_find(vm, name);
-    if (idx == -1) {
-        bvalue *desc;
-        idx = be_map_count(builtin(vm).vtab);
-        desc = be_map_insertstr(vm, builtin(vm).vtab, name, NULL);
-        var_setint(desc, idx);
-        be_vector_resize(vm, &builtin(vm).vlist, idx + 1);
-        /* set the new variable to nil */
-        var_setnil((bvalue*)(builtin(vm).vlist.end));
-    }
-    return idx;
-}
-
-void be_bulitin_release_space(bvm *vm)
-{
-    be_map_compact(vm, builtin(vm).vtab);
-    be_vector_release(vm, &builtin(vm).vlist);
-}
-#else
 void be_const_builtin_set(bvm *vm, const bmap *map, const bvector *vec)
 {
     builtin(vm).vtab = cast(bmap*, map);
     builtin(vm).vlist = *vec;
 }
-#endif

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -2137,11 +2137,6 @@ BERRY_API void be_stop_iteration(bvm *vm);
  * @note exception API
  * @brief register a native function
  *
- * The specific behavior of this function is related to the value of the BE_USE_PRECOMPILED_OBJECT macro
- * (although the FFI is still available when using the compile-time construction technique,
- * it cannot dynamically register the built-in variables.
- * In this case, please refer to the method of registering the built-in objects.
- *
  * @param vm virtual machine instance
  * @param name name of the native function
  * @param f pointer of the native function


### PR DESCRIPTION
## Description:

Berry simplification of code: removed `BE_USE_PRECOMPILED_OBJECT` option which is anyways always enforced in Tasmota.

No functional change, no code change in compiled firmware.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
