### PR TITLE
Platform 2026.03.50 to support IDF 55 Arduino based Tasmota builds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.10
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'arendst/Tasmota' && github.ref_name == 'development'
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -57,7 +57,7 @@ jobs:
     if: github.repository == 'arendst/Tasmota' && github.ref_name == 'development'
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -103,7 +103,7 @@ jobs:
           - tasmota32p4-safeboot
           - tasmota32p4ser-safeboot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: development
       - name: Set up Python
@@ -154,7 +154,7 @@ jobs:
           - tasmota-zbbridge
           - tasmota-zigbee
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: development
       - name: Set up Python
@@ -211,7 +211,7 @@ jobs:
           - tasmota32s3
           - tasmota32solo1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: development
       - name: Set up Python
@@ -262,7 +262,7 @@ jobs:
         variant: [ tasmota, tasmota32 ]
         language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: development
       - name: Set up Python

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -38,7 +38,7 @@ jobs:
           - tasmota32p4-safeboot
           - tasmota32p4ser-safeboot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Set up Python
@@ -86,7 +86,7 @@ jobs:
           - tasmota-zbbridge
           - tasmota-zigbee
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Set up Python
@@ -142,7 +142,7 @@ jobs:
           - tasmota32s3
           - tasmota32solo1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Set up Python
@@ -191,7 +191,7 @@ jobs:
         variant: [ tasmota, tasmota32 ]
         language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Set up Python
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Download all Tasmota artifacts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -27,7 +27,7 @@ jobs:
         variant:
           - tasmota32-webcam
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -59,7 +59,7 @@ jobs:
         variant:
           - tasmota32solo1-safeboot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -125,7 +125,7 @@ jobs:
           - tasmota32c6-safeboot
           - tasmota32p4-safeboot
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -158,7 +158,7 @@ jobs:
         variant: [ tasmota ]
         language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/copy_change.yml
+++ b/.github/workflows/copy_change.yml
@@ -20,7 +20,7 @@ jobs:
           - name: 'BUILDS.md'
             message: 'Builds.md changed'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Push ${{ matrix.file.name }} to docs repo
       uses: Jason2866/copy_file_to_another_repo_action@main
       env:

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -76,9 +76,11 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 
 [env:tasmota32_base]
-; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
+; Override settings for esp32, esp32s2, esp32s3, esp32c2 and esp32c3 
+; *** Uncomment next line ";" to enable development Tasmota Arduino IDF 53 based platform.
+;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53_gcc151
+; *** OR uncomment next line ";" to enable development Tasmota Arduino IDF 55 based platform.
 ;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-
 ;platform_packages       = framework-arduinoespressif32 @ 
 ;build_unflags           = ${esp32_defaults.build_unflags}
 ;build_flags             = ${esp32_defaults.build_flags}
@@ -106,6 +108,22 @@ lib_extra_dirs           = ${library.lib_extra_dirs}
 ; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
 ;                          lib/libesp32_eink
 
+[env:tasmota32_idf55_base]
+; Override settings for esp32c5, esp32c6 and esp32p4. ONLY IDF 55 based is possible here!!    
+; *** Uncomment next lines ";" to enable development Tasmota Arduino IDF 55 based platform.
+;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
+;platform_packages       = framework-arduinoespressif32 @ 
+monitor_speed           = 115200
+;upload_resetmethod      = ${common.upload_resetmethod}
+lib_extra_dirs           = ${library.lib_extra_dirs}
+; *** ESP32 lib. ALWAYS needed for ESP32 !!!
+                          lib/libesp32
+; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
+                          lib/libesp32_lvgl
+; *** uncomment the following line if you use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
+                          lib/libesp32_div
+; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
+;                          lib/libesp32_eink
 
 [library]
 shared_libdeps_dir      = lib

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -101,3 +101,9 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+
+[core32_IDF55]
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.03.50/platform-espressif32.zip
+platform_packages           =
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -217,18 +217,18 @@ lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib
 lib_ignore                  = Micro-RTSP
 
 [env:tasmota32c5-mi32]
-extends                     = env:tasmota32_base
+extends                     = env:tasmota32_idf55_base
 board                       = esp32c5
-build_flags                 = ${env:tasmota32_base.build_flags}
+build_flags                 = ${env:tasmota32_idf55_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 
 [env:tasmota32c6-mi32]
-extends                     = env:tasmota32_base
+extends                     = env:tasmota32_idf55_base
 board                       = esp32c6
-build_flags                 = ${env:tasmota32_base.build_flags}
+build_flags                 = ${env:tasmota32_idf55_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_BERRY_ULP

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -26,6 +26,34 @@ lib_ignore              = ${esp32_defaults.lib_ignore}
 ; tasmota/berry/modules/Partition_Manager.tapp
 custom_files_upload     = no_files
 
+[env:tasmota32_idf55_base]
+framework               = ${common.framework}
+platform                = ${core32_IDF55.platform}
+platform_packages       = ${core32_IDF55.platform_packages}
+board_build.filesystem  = ${common.board_build.filesystem}
+custom_unpack_dir       = ${common.custom_unpack_dir}
+board_build.variants_dir = ${common.board_build.variants_dir}
+board                   = esp32
+monitor_speed           = ${common.monitor_speed}
+monitor_echo            = ${common.monitor_echo}
+upload_resetmethod      = ${common.upload_resetmethod}
+check_skip_packages     = ${common.check_skip_packages}
+extra_scripts           = ${esp32_defaults.extra_scripts}
+monitor_filters         = ${esp32_defaults.monitor_filters}
+build_unflags           = ${core32_IDF55.build_unflags}
+build_flags             = ${core32_IDF55.build_flags}
+lib_ldf_mode            = ${common.lib_ldf_mode}
+lib_compat_mode         = ${common.lib_compat_mode}
+lib_extra_dirs          = ${common.lib_extra_dirs}
+                          lib/libesp32
+                          lib/libesp32_lvgl
+lib_ignore              = ${esp32_defaults.lib_ignore}
+; Add files to Filesystem for all env (global). Remove no files entry and add a line with the file to include
+; Example for adding the Partition Manager
+; custom_files_upload =
+; tasmota/berry/modules/Partition_Manager.tapp
+custom_files_upload     = no_files
+
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32-solo1
@@ -117,11 +145,10 @@ lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32c5-safeboot]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c5
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -144,11 +171,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c5ser-safeboot]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c5ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -171,10 +197,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6-safeboot]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c6
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -191,10 +217,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6ser-safeboot]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c6ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -221,42 +247,40 @@ lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4-safeboot]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4r3-safeboot]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4r3
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4ser-safeboot]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4r3ser-safeboot]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4r3ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -319,40 +343,38 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 [env:tasmota32c5]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c5
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
                           Micro-RTSP
 [env:tasmota32c6]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32c6
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32p4]
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32p4r3]
-platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32_idf55_base
 board                   = esp32p4r3
-build_flags             = ${env:tasmota32_base.build_flags}
+build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3.bin"'
-lib_ignore              = ${env:tasmota32_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32s3]


### PR DESCRIPTION
## Description:

add Platform 2026.03.50 which uses Tasmota Arduino framework build with IDF 5.5.3+
The Platform build uses GCC 15.2 and has `picolib` enabled instead of newlib / nanolib

The IDF 5.5 base platform is used now for C5, C6 and P4 Tasmota build variants.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
