### PR TITLE
fix: Regression from PR #24518 forgotten change ESP8266WebServer to TasmotaWebServer

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -192,7 +192,7 @@ struct {
   uint8_t  stream_active;
 #ifndef USE_WEBCAM_SETUP_ONLY
   WiFiClient client;
-  ESP8266WebServer *CamServer;
+  TasmotaWebServer *CamServer;
   struct PICSTORE picstore[MAX_PICSTORE];
 #ifdef ENABLE_RTSPSERVER
   WiFiServer *rtspp;
@@ -1059,7 +1059,7 @@ uint32_t WcSetStreamserver(uint32_t flag) {
   if (flag) {
     if (!Wc.CamServer) {
       Wc.stream_active = 0;
-      Wc.CamServer = new ESP8266WebServer(81);
+      Wc.CamServer = new TasmotaWebServer(81);
       Wc.CamServer->on("/", HandleWebcamRoot);
       Wc.CamServer->on("/cam.mjpeg", HandleWebcamMjpeg);
       Wc.CamServer->on("/cam.jpg", HandleWebcamMjpeg);

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -157,7 +157,7 @@ SemaphoreHandle_t WebcamMutex = nullptr;
 
 #ifndef USE_WEBCAM_SETUP_ONLY
 bool HttpCheckPriviledgedAccess(bool);
-extern ESP8266WebServer *Webserver;
+extern TasmotaWebServer *Webserver;
 
 // use mutex like:
 // TasAutoMutex localmutex(&WebcamMutex, "somename");

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -1084,7 +1084,7 @@ void WcInterruptControl() {
 
   WcSetStreamserver(Settings->webcam_config.stream);
   if(Wc.up == 0) {
-    WcSetup(Settings->webcam_config.resolution);
+    WcSetup((int32_t)Settings->webcam_config.resolution);
   }
 
 }
@@ -1501,7 +1501,7 @@ void CmndWebcamClock(void){
 }
 
 void CmndWebcamInit(void) {
-  WcSetup(Settings->webcam_config.resolution);
+  WcSetup((int32_t)Settings->webcam_config.resolution);
   WcInterruptControl();
   ResponseCmndDone();
 }
@@ -1594,7 +1594,7 @@ bool Xdrv81(uint32_t function) {
       WcInit();
       break;
     case FUNC_INIT:
-      if(Wc.up == 0) WcSetup(Settings->webcam_config.resolution);
+      if(Wc.up == 0) WcSetup((int32_t)Settings->webcam_config.resolution);
       break;
     case FUNC_ACTIVE:
       result = true;


### PR DESCRIPTION
## Description:

fix compile of `xdrv_81_esp32_webcam.ino`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
