### PR TITLE
optimize C5 / C6 safeboot

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -154,6 +154,9 @@ build_flags             = ${env:tasmota32_idf55_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 custom_sdkconfig        = 
+                          '# CONFIG_ULP_COPROC_ENABLED is not set'
+                          '# CONFIG_IEEE802154_ENABLED is not set'
+                          '# CONFIG_ESP_GDBSTUB_ENABLED is not set'
                           '# CONFIG_BT_ENABLED is not set'
                           '# CONFIG_BT_NIMBLE_ENABLED is not set'
                           '# CONFIG_BT_CONTROLLER_ENABLED is not set'
@@ -162,11 +165,7 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
-                          '# CONFIG_ETH_ENABLED is not set'
-                          '# CONFIG_ETH_USE_SPI_ETHERNET is not set'
-                          '# CONFIG_ETH_TRANSMIT_MUTEX is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
-                          '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
@@ -180,6 +179,9 @@ build_flags             = ${env:tasmota32_idf55_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 custom_sdkconfig        = 
+                          '# CONFIG_ULP_COPROC_ENABLED is not set'
+                          '# CONFIG_IEEE802154_ENABLED is not set'
+                          '# CONFIG_ESP_GDBSTUB_ENABLED is not set'
                           '# CONFIG_BT_ENABLED is not set'
                           '# CONFIG_BT_NIMBLE_ENABLED is not set'
                           '# CONFIG_BT_CONTROLLER_ENABLED is not set'
@@ -188,11 +190,7 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
-                          '# CONFIG_ETH_ENABLED is not set'
-                          '# CONFIG_ETH_USE_SPI_ETHERNET is not set'
-                          '# CONFIG_ETH_TRANSMIT_MUTEX is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
-                          '# CONFIG_ETH_SPI_ETHERNET_W5500 is not set'
                           '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
@@ -205,7 +203,10 @@ build_flags             = ${env:tasmota32_idf55_base.build_flags}
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
-custom_sdkconfig        = 
+custom_sdkconfig        =
+                          '# CONFIG_ULP_COPROC_ENABLED is not set'
+                          '# CONFIG_IEEE802154_ENABLED is not set'
+                          '# CONFIG_ESP_GDBSTUB_ENABLED is not set'
                           '# CONFIG_BT_ENABLED is not set'
                           '# CONFIG_BT_NIMBLE_ENABLED is not set'
                           '# CONFIG_BT_CONTROLLER_ENABLED is not set'
@@ -214,6 +215,8 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6ser-safeboot]
@@ -226,6 +229,9 @@ build_flags             = ${env:tasmota32_idf55_base.build_flags}
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 custom_sdkconfig        = 
+                          '# CONFIG_ULP_COPROC_ENABLED is not set'
+                          '# CONFIG_IEEE802154_ENABLED is not set'
+                          '# CONFIG_ESP_GDBSTUB_ENABLED is not set'
                           '# CONFIG_BT_ENABLED is not set'
                           '# CONFIG_BT_NIMBLE_ENABLED is not set'
                           '# CONFIG_BT_CONTROLLER_ENABLED is not set'
@@ -234,6 +240,8 @@ custom_sdkconfig        =
                           '# CONFIG_LWIP_IPV4_NAPT is not set'
                           '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_DM9051 is not set'
+                          '# CONFIG_ETH_SPI_ETHERNET_KSZ8851SNL is not set'
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32s3ser-safeboot]


### PR DESCRIPTION
## Description:

- enable ETHERNET W5500
- disable not common ethernet Phy to save flash

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
