### PR TITLE
add initial basic clangd config

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,7 @@
+CompileFlags:
+  Remove:
+    - -fstrict-volatile-bitfields
+    - -fno-tree-switch-conversion
+    - -free
+    - -fipa-pta
+    - -march=*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ managed_components
 .gcc-flags.json
 .cache
 .dummy
+compile_commands.json
 sdkconfig.*
 sdkconfig.defaults
 CMakeLists.txt


### PR DESCRIPTION
## Description:

to make using clangd possible and add it to .gitignore.

Background: pioarduino VSC extension v1.3.0 does now support clangd for intellisense 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
