### PR TITLE
NeoPool fix possible IntegerDivideByZero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Athom esp32 2-3-4 gang change led behaviour after firmware update (#24509)
 - ESP8266 heap drain and exception 29 when DHCP provides NTP server (#24515)
+- NeoPool fix possible IntegerDivideByZero
 
 ### Removed
 - Berry removed `BE_USE_PRECOMPILED_OBJECT` which is enforced in Tasmota (#24565)

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -2173,8 +2173,8 @@ void NeoPoolShow(bool json)
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_MAX  "\":"  NEOPOOL_FMT_HIDRO), decimals, &fvalue);
 
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_PERCENT  "\":{"));
-      ResponseAppend_P(PSTR( "\""  D_JSON_DATA  "\":%d"), data * 100 / max);
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_SETPOINT  "\":%d"), setpoint * 100 / max);
+      ResponseAppend_P(PSTR( "\""  D_JSON_DATA  "\":%d"), max ? (data * 100 / max) : 0);
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_SETPOINT  "\":%d"), max ? (setpoint * 100 / max) : 0);
       ResponseJsonEnd();
 
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME  "\":{"));


### PR DESCRIPTION
## Description:

This fix a possible IntegerDivideByZero crash in NeoPool sensor module, which could happen for newer Sugar Valley systems (originally [posted in HA forum](https://community.home-assistant.io/t/ha-neopool-mqtt-integration-of-tasmota-neopool-for-sugar-valley-hayward-aquarite-bayrol-devices/632517/461) )

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
