### PR TITLE
fix: C++26 warning

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -248,8 +248,8 @@ void callBerryRunDeferred(void) {
 /*********************************************************************************************\
  * VM Observability
 \*********************************************************************************************/
-void BerryObservability(bvm *vm, int event...);
-void BerryObservability(bvm *vm, int event...) {
+void BerryObservability(bvm *vm, int event, ...);
+void BerryObservability(bvm *vm, int event, ...) {
   va_list param;
   va_start(param, event);
   static int32_t vm_usage = 0;


### PR DESCRIPTION
## Description:

nitpick change to fix warning with C++26. No code change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
