### PR TITLE
Clear default Wi-Fi gateway/subnet and reset DNS to 0.0.0.0

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -66,9 +66,9 @@
 
 // -- Wi-Fi ---------------------------------------
 #define WIFI_IP_ADDRESS        "0.0.0.0"         // [IpAddress1] Set to 0.0.0.0 for using DHCP or enter a static IP address
-#define WIFI_GATEWAY           "192.168.1.1"     // [IpAddress2] If not using DHCP set Gateway IP address
-#define WIFI_SUBNETMASK        "255.255.255.0"   // [IpAddress3] If not using DHCP set Network mask
-#define WIFI_DNS               "192.168.1.1"     // [IpAddress4] If not using DHCP set DNS1 IP address (might be equal to WIFI_GATEWAY)
+#define WIFI_GATEWAY           ""                // [IpAddress2] If not using DHCP set Gateway IP address
+#define WIFI_SUBNETMASK        ""                // [IpAddress3] If not using DHCP set Network mask
+#define WIFI_DNS               "0.0.0.0"         // [IpAddress4] If not using DHCP set DNS1 IP address (might be equal to WIFI_GATEWAY)
 #define WIFI_DNS2              "0.0.0.0"         // [IpAddress5] If not using DHCP set DNS2 IP address (might be equal to WIFI_GATEWAY)
 
 #ifndef STA_SSID1


### PR DESCRIPTION
Remove hardcoded `192.168.1.1` defaults for `WIFI_GATEWAY`, `WIFI_SUBNETMASK`, and `WIFI_DNS` in `my_user_config.h` to avoid unintended static IP configuration when DHCP is in use.