### PR TITLE
Prepare switch to IDF 5.5.3 based Tasmota Arduino 

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -23,6 +23,7 @@
 from genericpath import exists
 import os
 from os.path import join, getsize
+import re
 import csv
 from littlefs import LittleFS
 import requests
@@ -307,13 +308,22 @@ def esp32_create_combined_bin(source, target, env):
             "--flash-size",
             flash_size,
         ]
-        # platformio estimates the flash space used to store the firmware.
-        # the estimation is inaccurate. perform a final check on the firmware
-        # size by comparing it against the partition size.
+        # Platformio estimates the flash space used to store the firmware.
+        # The estimation is inaccurate. Get the exact firmware flash usage
+        # from the size tool (same value as PlatformIO's "Flash:" line)
         max_size = env.BoardConfig().get("upload.maximum_size", 1)
-        fw_size = getsize(firmware_name)
+        elf_file = os.path.normpath(env.subst("$BUILD_DIR/${PROGNAME}.elf"))
+        fw_size = 0
+        size_cmd = env.subst("$SIZETOOL") + " -A -d " + elf_file
+        size_output = subprocess.check_output(size_cmd, shell=True, text=True)
+        size_regexp = re.compile(env.get("SIZEPROGREGEXP"))
+        for line in size_output.splitlines():
+            m = size_regexp.match(line)
+            if m:
+                fw_size += int(m.group(1))
         if (fw_size > max_size):
-            raise Exception(Fore.RED + "firmware binary too large: %d > %d" % (fw_size, max_size))
+            print(Fore.RED + "firmware binary too large: %d > %d" % (fw_size, max_size))
+            exit(1)
 
         print()
         print("    Offset   | File")

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -113,6 +113,30 @@ build_flags             = ${env:tasmota32_base.build_flags}
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
+custom_sdkconfig        =
+;                          '# CONFIG_LWIP_IPV6 is not set'
+                          '# CONFIG_LWIP_IPV6_AUTOCONFIG is not set'
+                          '# CONFIG_LWIP_PPP_SUPPORT is not set'
+                          '# CONFIG_LWIP_IP6_FRAG is not set'
+                          '# CONFIG_LWIP_IP_FORWARD is not set'
+                          '# CONFIG_LWIP_IPV4_NAPT is not set'
+                          '# CONFIG_LWIP_IPV4_NAPT_PORTMAP is not set'
+                          '# CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND is not set'
+                          '# CONFIG_ESP_SLEEP_GPIO_RESET_WORKAROUND is not set'
+                          '# CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH is not set'
+                          '# CONFIG_RINGBUF_PLACE_ISR_FUNCTIONS_INTO_FLASH is not set'
+                          '# CONFIG_FREERTOS_DEBUG_OCDAWARE is not set'
+                          '# CONFIG_FREERTOS_ENABLE_TASK_SNAPSHOT is not set'
+                          '# CONFIG_FREERTOS_PLACE_SNAPSHOT_FUNS_INTO_FLASH is not set'
+                          CONFIG_BT_CONTROLLER_DISABLED=y
+                          '# CONFIG_BT_ENABLED is not set'
+                          '# CONFIG_BT_NIMBLE_ENABLED is not set'
+                          '# CONFIG_BT_CONTROLLER_ENABLED is not set'
+                          '# CONFIG_ESP_GDBSTUB_ENABLED is not set'
+                          '# CONFIG_ESP_DEBUG_OCDAWARE is not set'
+                          '# CONFIG_ESP_MAC_ADDR_UNIVERSE_BT is not set'
+                          '# CONFIG_ESP_MAC_ADDR_UNIVERSE_ETH is not set'
+                          '# CONFIG_ETH_ENABLED is not set'
 
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

The C2 safeboot was slightly to big in size for using with the special ESP32-C2 2Mbyte Tasmota variant, when build with IDF 5.5.3 based Arduino framework. By removing not needed features in C2 safeboot (by using HybridCompile mode to build) it was possible to shrink to fit in the partition.

The size warning script was needed to refactor since it was alarming a few bytes to early ;-)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
