### PR TITLE
Add devcontainer and automations configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "Tasmota",
+	"image": "mcr.microsoft.com/devcontainers/python:3",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"platformio.platformio-ide"
+			]
+		}
+	}
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,19 @@
+tasks:
+  install-platformio:
+    name: Install PlatformIO
+    description: Install the PlatformIO CLI and its dependencies via pip.
+    command: |
+      pip install --upgrade platformio
+      pio --version
+    triggeredBy:
+      - postDevcontainerStart
+
+  build:
+    name: Build firmware
+    description: Build a Tasmota firmware variant. Defaults to tasmota (ESP8266). Override with PIO_ENV env var, e.g. PIO_ENV=tasmota32 ona auto task start build.
+    command: |
+      pio run -e ${PIO_ENV:-tasmota}
+    triggeredBy:
+      - manual
+    dependsOn:
+      - install-platformio


### PR DESCRIPTION
Sets up a reproducible development environment using the Ona devcontainer format.

**`devcontainer.json`**
- Base image: `mcr.microsoft.com/devcontainers/python:3` (Python is the PlatformIO runtime)
- VS Code extension: `platformio.platformio-ide`

**`.ona/automations.yaml`**
- `install-platformio`: installs PlatformIO CLI via pip on `postDevcontainerStart`
- `build`: manual task running `pio run -e ${PIO_ENV:-tasmota}`; defaults to the ESP8266 `tasmota` variant, override with `PIO_ENV=tasmota32` etc.