### PR TITLE
fix zopfli import error

### DIFF
--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -194,6 +194,6 @@ try:
 
         return _compress_with_zopfli(data, **kw)
 
-except ModuleNotFoundError:
+except (ImportError, ModuleNotFoundError):
     def compress(data, level=9, **kw):
         return _compress_with_gzip(data, level)


### PR DESCRIPTION
## Description:

fix fail when zopfli can not imported. Fall back to gzip in this case. Solves #24630

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
