### PR TITLE
Update Platforms to 2026.04.xx

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.10 / V.3.3.7
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio.ini
+++ b/platformio.ini
@@ -141,7 +141,7 @@ lib_ignore                  = ESP8266Audio
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2026.03.00/platform-espressif8266.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2026.04.00/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,13 +97,13 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.03.30/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.04.30/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32_IDF55]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.03.50/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.04.50/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- all 2026.04.xx Platforms, update and fixes in Platform setup
- Arduino core 3.3.8 with Platform 2026.04.50 / Update IDF 5.5.4.260407
- Arduino core 3.1.11 with Platform 2026.04.30 / no changes in Arduino Core and IDF

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
