### PR TITLE
Remove redundant logs when TLS error 296

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -1400,13 +1400,15 @@ void MqttReconnect(void) {
       AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "TLS connection error: %d"), tlsClient->getLastError());
 
 #if defined(ESP32) || (defined(ESP8266) && defined(USE_MQTT_TLS_ECDSA))
-      if (tlsClient->getLastError() == 296) {
-        // in this special case of cipher mismatch, we force enable ECDSA
-        // this would be the case for newer letsencrypt certificates now defaulting
-        // to EC certificates requiring ECDSA instead of RSA
-        Settings->flag6.tls_use_ecdsa = true;
-        tlsClient->setECDSA(Settings->flag6.tls_use_ecdsa);
-        AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "TLS now enabling ECDSA 'SetOption165 1'"), tlsClient->getLastError());
+      if (tlsClient->getLastError() == 296 /* BR_ALERT_HANDSHAKE_FAILURE */) {
+        if (!Settings->flag6.tls_use_ecdsa) {
+          // in this special case of cipher mismatch, we force enable ECDSA
+          // this would be the case for newer letsencrypt certificates now defaulting
+          // to EC certificates requiring ECDSA instead of RSA
+          Settings->flag6.tls_use_ecdsa = true;
+          tlsClient->setECDSA(Settings->flag6.tls_use_ecdsa);
+          AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "TLS now enabling ECDSA 'SetOption165 1'"), tlsClient->getLastError());
+        }
       }
 #endif // defined(ESP32) || (defined(ESP8266) && defined(USE_MQTT_TLS_ECDSA))
     }


### PR DESCRIPTION
## Description:

When TLS error `296` happens, a log entry signals that ECDSA is enabled with `SetOption165 1`, but remove this log if the SetOption is already set.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
