### PR TITLE
Do not use script port-vsc.py for pioarduino >= 1.3.6

### DIFF
--- a/pio-tools/port-vsc.py
+++ b/pio-tools/port-vsc.py
@@ -1,51 +1,72 @@
 env = DefaultEnvironment()
 
 import os
+import glob as fileglob
 
 if os.environ.get("PLATFORMIO_CALLER") == "vscode":
     print("PIO called from VS Code extension")
     import platform
-    import sqlite3
     import json
-    from platformio.project.helpers import get_project_dir
 
+    # Check if pioarduino IDE >= 1.3.6 is installed (handles port natively)
     os_name = platform.system()
-    print("OS Platform:", os_name)
-    os_paths = {
-        "Darwin": "~/Library/Application Support/Code/User/globalStorage/state.vscdb",
-        "Linux": "~/.config/Code/User/globalStorage/state.vscdb",
-        "Windows": r"%APPDATA%\Code\User\globalStorage\state.vscdb"
-    }
-    project_path = get_project_dir()
+    if os_name == "Windows":
+        ext_base = os.path.join(os.environ.get("USERPROFILE", ""), ".vscode", "extensions")
+    else:
+        ext_base = os.path.expanduser("~/.vscode/extensions")
 
-    try:
-        db_path = os.path.expanduser(os.path.expandvars(os_paths[os_name]))
-    except KeyError:
-        print("Unknown OS: " + os_name)
-
-    # If the database is not found, check if running in WSL
-    # and try to find the database in the Windows file system
-    if not os.path.exists(db_path) and os_name == "Linux":
+    skip = False
+    for ext_dir in fileglob.glob(os.path.join(ext_base, "pioarduino.pioarduino-ide-*")):
         try:
-            db_path = os.path.expanduser(os.path.expandvars(os_paths["Windows"]))
-            print("Windows running PIO in WSL")
-        except KeyError:
+            ver_str = os.path.basename(ext_dir).split("pioarduino.pioarduino-ide-")[1]
+            ver_parts = tuple(int(x) for x in ver_str.split(".")[:3])
+            if ver_parts >= (1, 3, 6):
+                print("pioarduino IDE %s detected, port handled by extension" % ver_str)
+                skip = True
+                break
+        except (IndexError, ValueError):
             pass
 
-    # Only when the database is found we can go on
-    if os.path.exists(db_path):
-        conn = sqlite3.connect(db_path)
-        cursor = conn.cursor()
+    if not skip:
+        import sqlite3
+        from platformio.project.helpers import get_project_dir
 
-        for key in ['pioarduino.pioarduino-ide', 'platformio.platformio-ide']:
-            cursor.execute("SELECT value FROM ItemTable WHERE key = ?", (key,))
-            row = cursor.fetchone()
-            if row:
-                data = json.loads(row[0])
-                projects = data.get("projects", {})
-                project = projects.get(project_path)
-                if project and "customPort" in project:
-                    print("USB port set in VSC:", project["customPort"])
-                    env["UPLOAD_PORT"] = project["customPort"]
-                    break
-        conn.close()
+        print("OS Platform:", os_name)
+        os_paths = {
+            "Darwin": "~/Library/Application Support/Code/User/globalStorage/state.vscdb",
+            "Linux": "~/.config/Code/User/globalStorage/state.vscdb",
+            "Windows": r"%APPDATA%\Code\User\globalStorage\state.vscdb"
+        }
+        project_path = get_project_dir()
+
+        try:
+            db_path = os.path.expanduser(os.path.expandvars(os_paths[os_name]))
+        except KeyError:
+            print("Unknown OS: " + os_name)
+
+        # If the database is not found, check if running in WSL
+        # and try to find the database in the Windows file system
+        if not os.path.exists(db_path) and os_name == "Linux":
+            try:
+                db_path = os.path.expanduser(os.path.expandvars(os_paths["Windows"]))
+                print("Windows running PIO in WSL")
+            except KeyError:
+                pass
+
+        # Only when the database is found we can go on
+        if os.path.exists(db_path):
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
+
+            for key in ['pioarduino.pioarduino-ide', 'platformio.platformio-ide']:
+                cursor.execute("SELECT value FROM ItemTable WHERE key = ?", (key,))
+                row = cursor.fetchone()
+                if row:
+                    data = json.loads(row[0])
+                    projects = data.get("projects", {})
+                    project = projects.get(project_path)
+                    if project and "customPort" in project:
+                        print("USB port set in VSC:", project["customPort"])
+                        env["UPLOAD_PORT"] = project["customPort"]
+                        break
+            conn.close()


### PR DESCRIPTION
## Description:

pioarduino VSC extension has fixed this bug.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
