### PR TITLE
Berry fix invalid format in string.format

### DIFF
--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -664,16 +664,22 @@ static const char* get_mode(const char *str, char *buf, size_t buf_len)
     }
     p = skip2dig(p); /* skip width (2 digits at most) */
     if (*p == '.') {
-        p = skip2dig(++p); /* skip width (2 digits at most) */
+        p = skip2dig(++p); /* skip precision (2 digits at most) */
     }
     *(buf++) = '%';
     size_t mode_size = p - str + 1;
     /* Leave 2 bytes for the leading % and the trailing '\0' */
-    if (mode_size > buf_len - 2) { 
-        mode_size = buf_len - 2;
+    /* Also ensure the format specifier character is always included */
+    if (mode_size > buf_len - 2) {
+        /* truncate flags/width but always keep the conversion specifier */
+        size_t max = buf_len - 2;
+        strncpy(buf, str, max - 1);
+        buf[max - 1] = p[0]; /* conversion specifier */
+        buf[max] = '\0';
+    } else {
+        strncpy(buf, str, mode_size);
+        buf[mode_size] = '\0';
     }
-    strncpy(buf, str, mode_size);
-    buf[mode_size] = '\0';
     return p;
 }
 

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -150,7 +150,7 @@ assert(string.format("%s", false) == 'false')
 assert(string.format("%q", "\ntest") == '\'\\ntest\'')
 
 # corrupt format string should not crash the VM
-string.format("%0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f", 3.5)
+assert(string.format("%0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f", 3.5) == '3.500000')
 
 # format is now synonym to string.format
 assert(format == string.format)


### PR DESCRIPTION
## Description:

Berry `be_strlib.c`: get_mode truncated long format specifiers (e.g. %0000...0f) by dropping the trailing conversion character, producing an invalid format string passed to snprintf. Preserve the conversion specifier when truncating.

Application of upstream change https://github.com/berry-lang/berry/pull/511

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
