### PR TITLE
Berry force type to 8 bit enum

### DIFF
--- a/lib/libesp32/berry/src/be_parser.h
+++ b/lib/libesp32/berry/src/be_parser.h
@@ -45,7 +45,7 @@ typedef struct {
     int t; /* patch list of 'exit when true' */
     int f; /* patch list of 'exit when false' */
     bbyte not; /* not mark */
-    bbyte type;
+    exptype_t type : 8;
 } bexpdesc;
 
 typedef struct bblockinfo {


### PR DESCRIPTION
## Description:

Berry, define `type` as  8-bit enum instead of `bbyte` which improves debugger support and aligns with upstream.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
