### PR TITLE
Berry faster compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - ESP8266 platform update from 2026.03.00 to 2026.04.00 (#24635)
 - ESP32 Platform from 2025.03.30 to 2026.04.30, Framework (Arduino Core) from v3.1.10 to v3.1.11 and IDF from v5.3.4.251226 to v5.3.4.260127 (#24635)
 - ESP32-C5/C6/P4 Platform from 2025.03.50 to 2026.04.50, Framework (Arduino Core) from v3.3.7 to v3.3.8 and IDF from v5.5.3+ to v5.5.4.260407 (#24635)
+- Berry faster compilation
 
 ### Fixed
 

--- a/lib/libesp32/berry/tools/coc/bytes_build.py
+++ b/lib/libesp32/berry/tools/coc/bytes_build.py
@@ -24,7 +24,9 @@ class bytes_build:
         ostr = ""
         ostr += "/* binary arrays */\n"
         ostr += "be_define_const_bytes_empty();\n"
-        for k in self.map:
+        # sort to ensure deterministic output so the generated header only
+        # changes when its content actually changes (avoids spurious rebuilds)
+        for k in sorted(self.map):
             ostr += "be_define_const_bytes("
             ostr += k + ", " + ", ".join( [ "0x" + k[i:i+2] for i in range(0, len(k), 2)] )
             ostr += ");\n"
@@ -35,7 +37,7 @@ class bytes_build:
         ostr = ""
         ostr += "/* extern binary arrays */\n"
         ostr += "extern const binstance_arg3 be_const_instance_;\n"
-        for k in self.map:
+        for k in sorted(self.map):
             ostr += "extern const binstance_arg3 be_const_instance_" + k + ";\n"
 
         return ostr


### PR DESCRIPTION
## Description:

Reduce ESP32 re-compilation from 47s to 33s by better caching of Berry precompiled code. It appears that the Berry `coc` precompiler generated different C files at each compilation preventing caching of code.

Before:
```
Building in release mode
Compiling .pio/build/tasmota32s2-custom/src/tasmota.ino.cpp.o
Compiling .pio/build/tasmota32s2-custom/lib4c0/berry_custom/be_custom_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/default/be_re_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_baselib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_byteslib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_debuglib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_gclib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_globallib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_introspectlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_jsonlib.c.o
Archiving .pio/build/tasmota32s2-custom/lib4c0/libberry_custom.a
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_listlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_maplib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_mathlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_oslib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_rangelib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_solidifylib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_strictlib.c.o
Indexing .pio/build/tasmota32s2-custom/lib4c0/libberry_custom.a
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_string.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_strlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_syslib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_timelib.c.o
Compiling .pio/build/tasmota32s2-custom/lib590/berry/be_undefinedlib.c.o
Compiling .pio/build/tasmota32s2-custom/libfdd/berry_mapping/be_cb_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_MI32_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_TFL_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_ULP_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_audio_opus_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_autoconf_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_cam_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_crc32_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_cron_class.cpp.o
Archiving .pio/build/tasmota32s2-custom/lib590/libberry.a
Archiving .pio/build/tasmota32s2-custom/libfdd/libberry_mapping.a
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_crypto_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_ctypes.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_display_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_driverlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_dyn_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_energy_ctypes_definitions.c.o
Indexing .pio/build/tasmota32s2-custom/lib590/libberry.a
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_energylib.c.o
Indexing .pio/build/tasmota32s2-custom/libfdd/libberry_mapping.a
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_extensions_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_flash_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_gpio_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_httpserver_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_hue_bridge_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_hue_lib.cpp.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_i2c_axp192_axp202_axp2102_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_i2c_driverlib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_i2s_audio_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_img_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_leds_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_leds_ntv_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_light_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_light_state_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_lv_tasmota_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_lv_tasmota_widgets_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_matrix_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_md5_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_mdns_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_mqtt_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_mqttclient_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_onewire_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_partition_core_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_path_tasmota_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_persist_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_python_compat.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_serial_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_sortedmap_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tapp_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tasmota_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tasmota_log_reader_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tcpclient_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tcpclientasyc_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_tcpserver_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_trigger_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_udp_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_unishox_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_uuid_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_webclient_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_webfiles_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_webserver_async_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_webserver_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_wire_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_wsserver_lib.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee_zb_coord.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee_zcl_attribute.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee_zcl_attribute_list_ntv.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee_zcl_attribute_ntv.c.o
Compiling .pio/build/tasmota32s2-custom/lib62a/berry_tasmota/be_zigbee_zcl_frame.c.o
Compiling .pio/build/tasmota32s2-custom/lib94a/berry_int64/be_int64_class.c.o
Compiling .pio/build/tasmota32s2-custom/lib28e/lv_haspmota/be_lv_haspmota.c.o
Compiling .pio/build/tasmota32s2-custom/lib376/berry_animation/be_animation.c.o
Compiling .pio/build/tasmota32s2-custom/lib376/berry_animation/be_frame_buffer_ntv.c.o
Compiling .pio/build/tasmota32s2-custom/lib5bd/berry_matter/be_matter_counter.cpp.o
Compiling .pio/build/tasmota32s2-custom/lib5bd/berry_matter/be_matter_misc.cpp.o
Compiling .pio/build/tasmota32s2-custom/lib5bd/berry_matter/be_matter_module.c.o
Compiling .pio/build/tasmota32s2-custom/lib5bd/berry_matter/be_matter_qrcode.c.o
Compiling .pio/build/tasmota32s2-custom/lib5bd/berry_matter/be_matter_verhoeff.cpp.o
Archiving .pio/build/tasmota32s2-custom/lib28e/liblv_haspmota.a
Archiving .pio/build/tasmota32s2-custom/lib94a/libberry_int64.a
Indexing .pio/build/tasmota32s2-custom/lib28e/liblv_haspmota.a
Indexing .pio/build/tasmota32s2-custom/lib94a/libberry_int64.a
Compiling .pio/build/tasmota32s2-custom/libb47/generate/be_lvgl_module.c.o
Archiving .pio/build/tasmota32s2-custom/lib5bd/libberry_matter.a
Archiving .pio/build/tasmota32s2-custom/lib62a/libberry_tasmota.a
Archiving .pio/build/tasmota32s2-custom/lib376/libberry_animation.a
Compiling .pio/build/tasmota32s2-custom/libb47/generate/be_lvgl_widgets_lib.c.o
Compiling .pio/build/tasmota32s2-custom/libb47/lv_binding_berry/be_lv_extra.c.o
Compiling .pio/build/tasmota32s2-custom/libb47/lv_binding_berry/be_lvgl_ctypes_definitions.c.o
Compiling .pio/build/tasmota32s2-custom/libb47/lv_binding_berry/be_lvgl_glob_lib.c.o
Compiling .pio/build/tasmota32s2-custom/libb47/lv_binding_berry/lv_berry.c.o
Indexing .pio/build/tasmota32s2-custom/lib5bd/libberry_matter.a
Indexing .pio/build/tasmota32s2-custom/lib376/libberry_animation.a
Indexing .pio/build/tasmota32s2-custom/lib62a/libberry_tasmota.a
Archiving .pio/build/tasmota32s2-custom/libb47/liblv_binding_berry.a
Indexing .pio/build/tasmota32s2-custom/libb47/liblv_binding_berry.a
Linking .pio/build/tasmota32s2-custom/firmware.elf
```

After:
```
Building in release mode
Compiling .pio/build/tasmota32s2-custom/src/tasmota.ino.cpp.o
Linking .pio/build/tasmota32s2-custom/firmware.elf
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
