### PR TITLE
I2S: fix mkv muxing for files

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.cc
+++ b/lib/lib_audio/ESP8266Audio/src/libwebm/mkvmuxer/mkvwriter.cc
@@ -70,7 +70,7 @@ int32 MkvWriter::Position(int64 position) {
   if (!file_ || use_write_cb_)
     return -1;
 
-  return file_->seek(position);
+  return file_->seek(position) ? 0 : -1;
 
 // #ifdef _MSC_VER
 //   return _fseeki64(file_, position, SEEK_SET);

--- a/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_42_1_i2s_mp3mic_idf51.ino
@@ -185,7 +185,7 @@ class AudioEncoderOpusWebm : public AudioEncoder
       if (len > 2) // ignore packets shorter than or equal to 2 bytes.
       {
         if(!muxerSegment.AddFrame(outFrame, len, trackNumber, timeCode, true)){
-          return -1;
+          return -2;
         }
       }
       timeCode += 20000 * 1000; // 20 ms in nanoseconds
@@ -316,7 +316,7 @@ void I2sMicTask(void *arg){
 
     if (audio_i2s.Settings->sys.full_duplex) { // if we initiated with 2 channels for TX!! TODO: make it bullteproof for any duplex configuration
       i2s_channel_read(audio_i2s.in->getRxHandle(), (void*)stereo_buf,
-                      mic_enc->byteSize * 2, &bytes_read, pdMS_TO_TICKS(1));
+                      mic_enc->byteSize * 2, &bytes_read, pdMS_TO_TICKS(timeForOneRead));
       // decimate: extract left channel into encoder's mono buffer
       for (size_t i = 0; i < mic_enc->samplesPerPass; i++) {
         mic_enc->inBuffer[i] = stereo_buf[(i * 2)];
@@ -324,7 +324,7 @@ void I2sMicTask(void *arg){
       bytes_read /= 2;
     } else {
       i2s_channel_read(audio_i2s.in->getRxHandle(), (void*)mic_enc->inBuffer,
-                      mic_enc->byteSize, &bytes_read, pdMS_TO_TICKS(1));
+                      mic_enc->byteSize, &bytes_read, pdMS_TO_TICKS(timeForOneRead));
     }
 
     if (gain > 1) {
@@ -350,7 +350,7 @@ void I2sMicTask(void *arg){
     }
 
     audio_i2s_mp3.recdur = TasmotaGlobal.uptime - ctime;
-    vTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS(timeForOneRead));
+    xTaskDelayUntil( &xLastWakeTime, pdMS_TO_TICKS(timeForOneRead));
   }
 
   written = mic_enc->stop();
@@ -435,7 +435,7 @@ int32_t I2sRecord(char *path, uint32_t encoder_type) {
   audio_i2s.in->SetRxRate(rec_rate);
 
   audio_i2s.in->startRx();
-  err = xTaskCreatePinnedToCore(I2sMicTask, "MIC", stack, NULL, 3, &audio_i2s_mp3.mic_task_handle, 1);
+  err = xTaskCreatePinnedToCore(I2sMicTask, "MIC", stack, NULL, 20, &audio_i2s_mp3.mic_task_handle, 1);
   return err;
 }
 


### PR DESCRIPTION
## Description:

File recording — seekable, cluster finalization works, but Position(int64) uses file_->seek() which returns a bool from the Arduino File API, not 0 on success. The libwebm code expects 0 on success, non-zero on failure — but File::seek() returns true on success. This means every seekback was treated as a failure due to incompatible return values.

Besides something must have changed in between regarding task callback timings in the IDF, where I encountered packet losses on audio read due to delay drift or something like that. Thus it is the simplest solution to allow i2s_read to block up to the time for one frame read to (pretty much) guarantee a full frame, which will now silently happen from time to time. This removed noise in OPUS recordings in my tests.

Some small refactoring for better error report in debug and calling xTaskDelayUntil directly and not through a macro.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
