### PR TITLE
CI: remove solidify / update actions version

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -162,7 +162,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/upload-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: tasmota32*
           path: ./temp
@@ -213,7 +213,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/upload-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: tasmota32*
           path: ./temp

--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -162,7 +162,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -213,7 +213,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp

--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -15,72 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  be_solidify:
-    runs-on: ubuntu-latest
-    if: github.repository == 'arendst/Tasmota' && github.ref_name == 'development'
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - name: Make Berry and Solidify code
-        run: |
-          cd lib/libesp32/berry
-          make
-          cd ../berry_tasmota
-          ../berry/berry -s -g solidify_all.be
-          cd ../berry_matter
-          ../berry/berry -s -g solidify_all.be
-          cd ../berry_animation
-          ../berry/berry -s -g solidify_all.be
-          cd ../../libesp32_lvgl/lv_binding_berry
-          ../../libesp32/berry/berry -s -g solidify_all.be
-          cd ../lv_haspmota
-          ../../libesp32/berry/berry -s -g solidify_all.be
-      - uses: actions/upload-artifact@v4
-        with:
-          name: berry
-          path: |
-            ./lib/libesp32/berry_tasmota/src/solidify
-            ./lib/libesp32/berry_matter/src/solidify
-            ./lib/libesp32/berry_animation/src/solidify
-            ./lib/libesp32_lvgl/lv_binding_berry/src/solidify
-            ./lib/libesp32_lvgl/lv_haspmota/src/solidify
-            ./lib/libesp32/berry/generate
-
-  push_solidified:
-    needs: be_solidify
-    runs-on: ubuntu-latest
-    if: github.repository == 'arendst/Tasmota' && github.ref_name == 'development'
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: berry
-          path: berry
-      - name: Move solidified Berry files back
-        run: |
-          ls -R ./berry
-          mv berry/berry/libesp32/berry_tasmota/src/solidify/* ./lib/libesp32/berry_tasmota/src/solidify
-          mv berry/berry/libesp32/berry_matter/src/solidify/* ./lib/libesp32/berry_matter/src/solidify
-          mv berry/berry/libesp32/berry_animation/src/solidify/* ./lib/libesp32/berry_animation/src/solidify
-          mv berry/berry/libesp32_lvgl/lv_binding_berry/src/solidify/* ./lib/libesp32_lvgl/lv_binding_berry/src/solidify
-          mv berry/berry/libesp32_lvgl/lv_haspmota/src/solidify/* ./lib/libesp32_lvgl/lv_haspmota/src/solidify
-          mv berry/berry/libesp32/berry/generate/* ./lib/libesp32/berry/generate
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Solidified Code updated
-
   safeboot-images:
-    needs: push_solidified
     runs-on: ubuntu-latest
     if: github.repository == 'arendst/Tasmota'
     continue-on-error: true
@@ -130,13 +65,12 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }} 
       - name: Upload safeboot firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
 
   base-images:
-    needs: push_solidified
     runs-on: ubuntu-latest
     if: github.repository == 'arendst/Tasmota'
     continue-on-error: true
@@ -180,7 +114,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -228,7 +162,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -247,7 +181,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -279,7 +213,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -298,7 +232,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}-${{ matrix.language }}
       - name: Upload language firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}-${{ matrix.language }}
           path: ./build_output

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -159,7 +159,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -208,7 +208,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Download all Tasmota artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         pattern: tasmota*
         path: ./temp

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -159,7 +159,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/upload-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: tasmota32*
           path: ./temp
@@ -208,7 +208,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/upload-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: tasmota32*
           path: ./temp
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Download all Tasmota artifacts
-      uses: actions/upload-artifact@v8
+      uses: actions/download-artifact@v7
       with:
         pattern: tasmota*
         path: ./temp

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -63,7 +63,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload safeboot firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -111,7 +111,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -159,7 +159,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -176,7 +176,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -208,7 +208,7 @@ jobs:
           uv pip install --system pioarduino
           cp ./platformio_override_sample.ini ./platformio_override.ini
       - name: Download safeboot firmwares
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact@v8
         with:
           pattern: tasmota32*
           path: ./temp
@@ -225,7 +225,7 @@ jobs:
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}-${{ matrix.language }}
       - name: Upload language firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}-${{ matrix.language }}
           path: ./build_output
@@ -237,7 +237,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Download all Tasmota artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/upload-artifact@v8
       with:
         pattern: tasmota*
         path: ./temp

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -45,7 +45,7 @@ jobs:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -77,7 +77,7 @@ jobs:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -144,7 +144,7 @@ jobs:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}
           path: ./build_output
@@ -176,7 +176,7 @@ jobs:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
         run: platformio run -e ${{ matrix.variant }}-${{ matrix.language }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.variant }}-${{ matrix.language }}
           path: ./build_output


### PR DESCRIPTION
## Description:

follow up of #24664
Update gh actions to silence warnings

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
