### PR TITLE
CI: no wait for safeboot build for tasmota language variant builds

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -187,13 +187,51 @@ jobs:
           path: ./build_output
 
   language-images:
+    runs-on: ubuntu-latest
+    if: github.repository == 'arendst/Tasmota'
+    continue-on-error: true
+    strategy:
+      matrix:
+        language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: development
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: false
+      - name: Install dependencies
+        run: |
+          uv pip install --system pioarduino
+      - name: Add SHA to footer
+        run: |
+          COMMIT_SHA_LONG=$(git rev-parse --short HEAD || echo "")
+          SHA=${COMMIT_SHA_LONG::7}
+          sed -i -e "s/TASMOTA_SHA_SHORT/TASMOTA_SHA_SHORT $SHA-/g" ./tasmota/include/tasmota_version.h
+      - name: Run PlatformIO
+        env:
+          PYTHONIOENCODING: utf-8
+          PYTHONUTF8: '1'
+        run: platformio run -e tasmota-${{ matrix.language }}
+      - name: Upload language firmware artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: tasmota-${{ matrix.language }}
+          path: ./build_output
+
+  language32-images:
     needs: safeboot-images
     runs-on: ubuntu-latest
     if: github.repository == 'arendst/Tasmota'
     continue-on-error: true
     strategy:
       matrix:
-        variant: [ tasmota, tasmota32 ]
         language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
     steps:
       - uses: actions/checkout@v6
@@ -230,15 +268,15 @@ jobs:
         env:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
-        run: platformio run -e ${{ matrix.variant }}-${{ matrix.language }}
+        run: platformio run -e tasmota32-${{ matrix.language }}
       - name: Upload language firmware artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.variant }}-${{ matrix.language }}
+          name: tasmota32-${{ matrix.language }}
           path: ./build_output
 
   Start_final_copy:
-    needs: [base-images, base32-images, language-images]
+    needs: [base-images, base32-images, language-images, language32-images]
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -182,13 +182,49 @@ jobs:
           path: ./build_output
 
   language-images:
+    runs-on: ubuntu-latest
+    if: github.repository == 'arendst/Tasmota'
+    continue-on-error: true
+    strategy:
+      matrix:
+        language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: false
+      - name: Install dependencies
+        run: |
+          uv pip install --system pioarduino
+      - name: Add "release" to footer
+        run: |
+          sed -i -e "s/TASMOTA_SHA_SHORT/TASMOTA_SHA_SHORT release-/g" ./tasmota/include/tasmota_version.h
+      - name: Run PlatformIO
+        env:
+          PYTHONIOENCODING: utf-8
+          PYTHONUTF8: '1'
+        run: platformio run -e tasmota-${{ matrix.language }}
+      - name: Upload language firmware artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: tasmota-${{ matrix.language }}
+          path: ./build_output
+
+  language32-images:
     needs: safeboot-images
     runs-on: ubuntu-latest
     if: github.repository == 'arendst/Tasmota'
     continue-on-error: true
     strategy:
       matrix:
-        variant: [ tasmota, tasmota32 ]
         language: [ AD, AF, BG, BR, CN, CZ, DE, ES, FR, FY, GR, HE, HU, IT, KO, LT, NL, PL, PT, RO, RU, SE, SK, TR, TW, UK, VN ]
     steps:
       - uses: actions/checkout@v6
@@ -223,15 +259,15 @@ jobs:
         env:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: '1'
-        run: platformio run -e ${{ matrix.variant }}-${{ matrix.language }}
+        run: platformio run -e tasmota32-${{ matrix.language }}
       - name: Upload language firmware artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.variant }}-${{ matrix.language }}
+          name: tasmota32-${{ matrix.language }}
           path: ./build_output
 
   Release:
-    needs: [base-images, base32-images, language-images]
+    needs: [base-images, base32-images, language-images, language32-images]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Description:

CI: Decrease build time by splitting build jobs for language variants tasmota-xx and tasmota32-xx
Avoid not needed waiting for compile finish of safeboot build variants. Safeboot is not needed for esp8266 tasmota build env.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
