### PR TITLE
Switch to Tasmota Arduino 3.3.8 for all builds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.1.11 / V.3.3.8
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.3.8
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/en/stable/projectconf.html
 
 [platformio]
-; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
+; Store Platformio platform and packages in project directory.
 ;core_dir = .platformio
 ; For unrelated compile errors with Windows it can help to shorten Platformio project path
 ;workspace_dir = c:\.pio
@@ -78,8 +78,6 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 [env:tasmota32_base]
 ; Override settings for esp32, esp32s2, esp32s3, esp32c2 and esp32c3 
 ; *** Uncomment next line ";" to enable development Tasmota Arduino IDF 53 based platform.
-;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53_gcc151
-; *** OR uncomment next line ";" to enable development Tasmota Arduino IDF 55 based platform.
 ;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
 ;platform_packages       = framework-arduinoespressif32 @ 
 ;build_unflags           = ${esp32_defaults.build_unflags}
@@ -108,22 +106,6 @@ lib_extra_dirs           = ${library.lib_extra_dirs}
 ; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
 ;                          lib/libesp32_eink
 
-[env:tasmota32_idf55_base]
-; Override settings for esp32c5, esp32c6 and esp32p4. ONLY IDF 55 based is possible here!!    
-; *** Uncomment next lines ";" to enable development Tasmota Arduino IDF 55 based platform.
-;platform                = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF55_gcc152
-;platform_packages       = framework-arduinoespressif32 @ 
-monitor_speed           = 115200
-;upload_resetmethod      = ${common.upload_resetmethod}
-lib_extra_dirs           = ${library.lib_extra_dirs}
-; *** ESP32 lib. ALWAYS needed for ESP32 !!!
-                          lib/libesp32
-; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
-                          lib/libesp32_lvgl
-; *** uncomment the following line if you use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
-                          lib/libesp32_div
-; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
-;                          lib/libesp32_eink
 
 [library]
 shared_libdeps_dir      = lib
@@ -147,5 +129,3 @@ lib_extra_dirs           =
                            lib/lib_rf
 ; *** Mostly not used functions. Recommended to disable
                            lib/lib_div
-
-

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -97,12 +97,6 @@ custom_component_remove     =
                               espressif/cmake_utilities
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.04.30/platform-espressif32.zip
-platform_packages           =
-build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${esp32_defaults.build_flags}
-
-[core32_IDF55]
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.04.50/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -217,18 +217,18 @@ lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib
 lib_ignore                  = Micro-RTSP
 
 [env:tasmota32c5-mi32]
-extends                     = env:tasmota32_idf55_base
+extends                     = env:tasmota32_base
 board                       = esp32c5
-build_flags                 = ${env:tasmota32_idf55_base.build_flags}
+build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DCONFIG_BT_NIMBLE_NVS_PERSIST=y
                               -DOTA_URL='""'
 
 [env:tasmota32c6-mi32]
-extends                     = env:tasmota32_idf55_base
+extends                     = env:tasmota32_base
 board                       = esp32c6
-build_flags                 = ${env:tasmota32_idf55_base.build_flags}
+build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_BERRY_ULP

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -26,33 +26,6 @@ lib_ignore              = ${esp32_defaults.lib_ignore}
 ; tasmota/berry/modules/Partition_Manager.tapp
 custom_files_upload     = no_files
 
-[env:tasmota32_idf55_base]
-framework               = ${common.framework}
-platform                = ${core32_IDF55.platform}
-platform_packages       = ${core32_IDF55.platform_packages}
-board_build.filesystem  = ${common.board_build.filesystem}
-custom_unpack_dir       = ${common.custom_unpack_dir}
-board_build.variants_dir = ${common.board_build.variants_dir}
-board                   = esp32
-monitor_speed           = ${common.monitor_speed}
-monitor_echo            = ${common.monitor_echo}
-upload_resetmethod      = ${common.upload_resetmethod}
-check_skip_packages     = ${common.check_skip_packages}
-extra_scripts           = ${esp32_defaults.extra_scripts}
-monitor_filters         = ${esp32_defaults.monitor_filters}
-build_unflags           = ${core32_IDF55.build_unflags}
-build_flags             = ${core32_IDF55.build_flags}
-lib_ldf_mode            = ${common.lib_ldf_mode}
-lib_compat_mode         = ${common.lib_compat_mode}
-lib_extra_dirs          = ${common.lib_extra_dirs}
-                          lib/libesp32
-                          lib/libesp32_lvgl
-lib_ignore              = ${esp32_defaults.lib_ignore}
-; Add files to Filesystem for all env (global). Remove no files entry and add a line with the file to include
-; Example for adding the Partition Manager
-; custom_files_upload =
-; tasmota/berry/modules/Partition_Manager.tapp
-custom_files_upload     = no_files
 
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
@@ -169,10 +142,10 @@ lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32c5-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c5
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -194,10 +167,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c5ser-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c5ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -219,10 +192,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c6
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -244,10 +217,10 @@ custom_sdkconfig        =
 custom_component_remove = ${safeboot_flags.custom_component_remove}
 
 [env:tasmota32c6ser-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c6ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -279,40 +252,40 @@ lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4r3-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4r3
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4ser-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 
 [env:tasmota32p4r3ser-safeboot]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4r3ser
 board_build.app_partition_name = safeboot
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3ser-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
@@ -375,38 +348,38 @@ build_flags             = ${env:tasmota32_base.build_flags}
 lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 [env:tasmota32c5]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c5
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c5.bin"'
-lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 [env:tasmota32c6]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32c6
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c6.bin"'
-lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32p4]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4.bin"'
-lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32p4r3]
-extends                 = env:tasmota32_idf55_base
+extends                 = env:tasmota32_base
 board                   = esp32p4r3
-build_flags             = ${env:tasmota32_idf55_base.build_flags}
+build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_TASMOTA32
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32p4r3.bin"'
-lib_ignore              = ${env:tasmota32_idf55_base.lib_ignore}
+lib_ignore              = ${env:tasmota32_base.lib_ignore}
                           Micro-RTSP
 
 [env:tasmota32s3]


### PR DESCRIPTION
## Description:

so all esp32x Tasmota variants use the same IDF 5.5.4 version

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
