### PR TITLE
Build ESP32-P4-rev3 Tasmota variant

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -140,6 +140,7 @@ jobs:
           - tasmota32c5
           - tasmota32c6
           - tasmota32p4
+          - tasmota32p4r3
           - tasmota32s2
           - tasmota32s2cdc
           - tasmota32s3

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -137,6 +137,7 @@ jobs:
           - tasmota32c5
           - tasmota32c6
           - tasmota32p4
+          - tasmota32p4r3
           - tasmota32s2
           - tasmota32s2cdc
           - tasmota32s3


### PR DESCRIPTION
## Description:

Since the ESP32-P4-rev3 (seen under the name ESP32-P4X too) is available now. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
