### PR TITLE
disable IPv6 for C2 safeboot

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -81,13 +81,16 @@ lib_ignore              = ${safeboot_flags.lib_ignore}
 extends                 = env:tasmota32_base
 board                   = esp32c2
 board_build.app_partition_name = safeboot
+build_unflags           = ${env:tasmota32_base.build_unflags}
+                          -DUSE_IPV6
+;                          -DUSE_4K_RSA
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_SAFEBOOT
                           -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c2-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              = ${safeboot_flags.lib_ignore}
 custom_sdkconfig        =
-;                          '# CONFIG_LWIP_IPV6 is not set'
+                          '# CONFIG_LWIP_IPV6 is not set'
                           '# CONFIG_LWIP_IPV6_AUTOCONFIG is not set'
                           '# CONFIG_LWIP_PPP_SUPPORT is not set'
                           '# CONFIG_LWIP_IP6_FRAG is not set'
@@ -110,6 +113,8 @@ custom_sdkconfig        =
                           '# CONFIG_ESP_MAC_ADDR_UNIVERSE_BT is not set'
                           '# CONFIG_ESP_MAC_ADDR_UNIVERSE_ETH is not set'
                           '# CONFIG_ETH_ENABLED is not set'
+                          '# CONFIG_VFS_SUPPORT_IO is not set'
+                          '# CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE is not set'
 
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

to shrink firmware size. Needed for C2 2MB special build to keep OTA update possible

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
