### PR TITLE
Berry solidification: use build env folder for dummy sdkconfig.h

### DIFF
--- a/pio-tools/dump-defines.py
+++ b/pio-tools/dump-defines.py
@@ -35,7 +35,7 @@ def _run_dump():
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Working dir for the sdkconfig.h stub.
-    stub_parent = project_dir / "build_output"
+    stub_parent = pathlib.Path(env.subst("$BUILD_DIR"))
     stub_parent.mkdir(parents=True, exist_ok=True)
 
     cxx = env.subst("$CXX")


### PR DESCRIPTION
## Description:

in pio script `pio-tools/dump-defines.py`
Should fix CI fail. 

@s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
