### PR TITLE
Berry fix compilation of webfiles

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_webfiles_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webfiles_lib.c
@@ -326,7 +326,9 @@ static int w_webfiles_serve(bvm *vm) {
             .uri      = registered_uri_pattern, // Use the static buffer
             .method   = HTTP_GET,
             .handler  = webfiles_handler,
+#if CONFIG_HTTPD_WS_SUPPORT
             .is_websocket = false,
+#endif // CONFIG_HTTPD_WS_SUPPORT
             .user_ctx = NULL
         };
 


### PR DESCRIPTION
## Description:

Fix compilation of webfiles when `#define USE_BERRY_WEBFILES`

See https://github.com/arendst/Tasmota/pull/23206#issuecomment-4322462424

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
