### PR TITLE
Add explicit error message when compiling for WebSockets

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_wsserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_wsserver_lib.c
@@ -18,6 +18,9 @@
 */
 
 #ifdef USE_BERRY_WSSERVER
+#if !defined(CONFIG_HTTPD_WS_SUPPORT) || !CONFIG_HTTPD_WS_SUPPORT
+  #error "You need to compile with option 'custom_sdkconfig = CONFIG_HTTPD_WS_SUPPORT=y'"
+#endif
 
 #ifndef LOG_LOCAL_LEVEL
 #define LOG_LOCAL_LEVEL ESP_LOG_INFO


### PR DESCRIPTION
## Description:

Add explicit error message when trying to compile WebSockets and `CONFIG_HTTPD_WS_SUPPORT=y` is not set.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
