### PR TITLE
S2 fixed framework

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -100,6 +100,7 @@ custom_component_remove     =
 
 [core32]
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2026.04.50/platform-espressif32.zip
-platform_packages           =
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/0405-1702-5.5/framework-arduinoespressif32-release_v5.5-f2a3fa2b.tar.xz
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+


### PR DESCRIPTION
## Description:

Quick fix for crashing ESP32-S2 development builds. Will be removed with Tasmota May Platform build
Fix for https://github.com/espressif/arduino-esp32/issues/12570  

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
