### PR TITLE
redirect the floating-point capable vfprintf / vfscanf symbols to picolibc's integer-only variant

### DIFF
--- a/pio-tools/picolibc_flags.py
+++ b/pio-tools/picolibc_flags.py
@@ -1,0 +1,26 @@
+#
+# Picolibc-specific linker flags.
+#
+# When the Arduino ESP32 framework is built against picolibc (detected via
+# `-specs=picolibc.specs`), redirect the floating-point capable vfprintf / vfscanf
+# symbols to picolibc's integer-only variants (__i_vfprintf / __i_vfscanf).
+# This drops the float/double formatting code path from the firmware and saves
+# a noticeable amount of flash.
+#
+
+Import("env")
+
+
+def _picolibc_in_use(env):
+    for var in ("CCFLAGS", "CFLAGS", "CXXFLAGS", "LINKFLAGS"):
+        for flag in env.get(var, []):
+            if "picolibc.specs" in str(flag):
+                return True
+    return False
+
+
+if _picolibc_in_use(env):
+    env.Append(LINKFLAGS=[
+        "-Wl,--defsym=vfprintf=__i_vfprintf",
+        "-Wl,--defsym=vfscanf=__i_vfscanf",
+    ])

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -49,6 +49,7 @@ lib_ignore                  =
                               ArduinoOTA
 extra_scripts               = pre:pio-tools/add_c_flags.py
                               pre:pio-tools/solidify-from-url.py
+                              post:pio-tools/picolibc_flags.py
                               post:pio-tools/dump-defines.py
                               post:pio-tools/gen-berry-defines.py
                               post:pio-tools/gen-berry-structures.py
@@ -103,4 +104,3 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-


### PR DESCRIPTION
which saves around 6-7 kb flash space for all esp32 variants which uses `picolibc`. Only S2 does not use `picolibc` (bug in IDF) 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
