### PR TITLE
Berry `format()` now uses internal `ext_snprintf_P()` for floating point formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - ESP32 Platform from 2026.04.50 to 2026.05.50, Framework (Arduino Core) from v3.3.8 to v3.3.8.260506 and IDF v5.5.4.260407 (#24718)
+- Berry `format()` now uses internal `ext_snprintf_P()` for floating point formatting
 
 ### Fixed
 

--- a/lib/default/Ext-printf/src/ext_printf.h
+++ b/lib/default/Ext-printf/src/ext_printf.h
@@ -20,14 +20,28 @@
 #ifndef EXT_PRINTF_H
 #define EXT_PRINTF_H
 
+#ifdef __cplusplus
 #include <cstddef>
 #include <cstdint>
 #include <cstdarg>
+#else
+#include <stddef.h>
+#include <stdint.h>
+#include <stdarg.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int32_t ext_vsnprintf_P(char * buf, size_t buf_len, const char * fmt_P, va_list va);
 int32_t ext_snprintf_P(char * buf, size_t buf_len, const char * fmt, ...);
 char * ext_snprintf_malloc_P(const char * fmt, ...);
 char * ext_vsnprintf_malloc_P(const char * fmt_P, va_list va);
+
+#ifdef __cplusplus
+}
+#endif
 
 char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween);
 

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -20,6 +20,40 @@
 #include <float.h>
 #include <math.h>
 
+#ifdef TASMOTA
+/* In Tasmota builds linked against picolibc's integer-only vfprintf
+ * (see `pio-tools/picolibc_flags.py`), the standard snprintf family
+ * cannot format floating point values anymore and outputs `*float*`
+ * placeholders instead. We route Berry's float formatting through
+ * Tasmota's ext_snprintf_P helper which performs its own float
+ * conversion via dtostrf and does not rely on vfprintf for floats.
+ */
+#include "ext_printf.h"
+
+/* Format a breal using ext_snprintf_P (dtostrf-based) and delegate
+ * width/alignment to snprintf via `%s`. Precision after '.' is honored;
+ * 'g'/'G' strip trailing zeros; 'e'/'E' fall back to fixed notation.
+ */
+static int be_snprintf_real(char *buf, size_t buf_len, const char *mode, breal val)
+{
+    const char *dot = strchr(mode, '.');
+    int prec = dot ? (int)strtol(dot + 1, NULL, 10) : 6;
+    char spec = mode[strlen(mode) - 1];
+    if (spec == 'g' || spec == 'G') { prec = -prec; }  /* trim trailing zeros */
+    float fval = (float)val;
+    char num[32];
+    ext_snprintf_P(num, sizeof(num), "%*_f", prec, &fval);
+    /* Rewrite "%[flags][width][.prec]<spec>" as "%[flags][width]s" */
+    char fmt[24];
+    size_t keep = dot ? (size_t)(dot - mode) : strlen(mode) - 1;
+    if (keep >= sizeof(fmt) - 1) { keep = sizeof(fmt) - 2; }
+    memcpy(fmt, mode, keep);
+    fmt[keep] = 's';
+    fmt[keep + 1] = '\0';
+    return snprintf(buf, buf_len, fmt, num);
+}
+#endif /* TASMOTA */
+
 #if BE_INTGER_TYPE == 0 /* int */
     #define M_IMAX    INT_MAX
     #define M_IMIN    INT_MIN
@@ -135,7 +169,11 @@ bstring* be_num2str(bvm *vm, bvalue *v)
     if (var_isint(v)) {
         snprintf(buf, sizeof(buf),BE_INT_FORMAT, var_toint(v));
     } else if (var_isreal(v)) {
+#ifdef TASMOTA
+        be_snprintf_real(buf, sizeof(buf), "%g", var_toreal(v));
+#else
         snprintf(buf, sizeof(buf), "%g", var_toreal(v));
+#endif
     } else {
         snprintf(buf, sizeof(buf), "(nan)");
     }
@@ -167,7 +205,11 @@ static bstring* sim2str(bvm *vm, bvalue *v)
         snprintf(sbuf, sizeof(sbuf), BE_INT_FORMAT, var_toint(v));
         break;
     case BE_REAL:
+#ifdef TASMOTA
+        be_snprintf_real(sbuf, sizeof(sbuf), "%g", var_toreal(v));
+#else
         snprintf(sbuf, sizeof(sbuf), "%g", var_toreal(v));
+#endif
         break;
     case BE_CLOSURE: case BE_NTVCLOS: case BE_NTVFUNC: case BE_CTYPE_FUNC:
         snprintf(sbuf, sizeof(sbuf), "<function: %p>", var_toobj(v));
@@ -777,7 +819,11 @@ int be_str_format(bvm *vm)
             {
                 breal val;
                 if (convert_to_real(vm, index, &val)) {
+#ifdef TASMOTA
+                    be_snprintf_real(buf, sizeof(buf), mode, val);
+#else
                     snprintf(buf, sizeof(buf), mode, val);
+#endif
                 }
                 be_pushstring(vm, buf);
                 break;


### PR DESCRIPTION
## Description:

Add specific code in Berry `format()` function that used to rely on `snprintf()` for all formatting. This PR prepares for `stdio` without floating point format #24720 like on ESP8266. Now floating point formatting is redirected to Tasmota specific `ext_snprintf_P()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
