### PR TITLE
LVGL splash screen uses default Montserrat-14 instead of Montserrat-20 on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Platform from 2026.04.50 to 2026.05.50, Framework (Arduino Core) from v3.3.8 to v3.3.8.260506 and IDF v5.5.4.260407 (#24718)
 - Berry `format()` now uses internal `ext_snprintf_P()` for floating point formatting (#24725)
 - ESP8266 wrap printf and replace with stubs reducing flash size by 6k (#24714)
+- LVGL splash screen uses default Montserrat-14 instead of Montserrat-20 on small screens
 
 ### Fixed
 - NeoPool possible overflow/div-zero errors and Hydrolysis module detection (#24724)

--- a/lib/libesp32/berry_tasmota/src/embedded/lv_tasmota.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/lv_tasmota.be
@@ -109,7 +109,6 @@ def splash()
 
   var bg = lv.obj(lv.scr_act())     # create a parent object for splash screen
   var f28 = lv.montserrat_font(28)  # load embedded Montserrat 28
-  var f20 = lv.montserrat_font(20)  # load embedded Montserrat 20
   var white = lv.color(lv.COLOR_WHITE)
 
   bg.set_style_bg_color(lv.color(0x000066), 0) # lv.PART_MAIN | lv.STATE_DEFAULT
@@ -132,8 +131,6 @@ def splash()
   tas.set_text("TASMOTA")
   if lv.get_hor_res() >= 200
     if f28 != nil tas.set_style_text_font(f28, 0) end
-  else
-    if f20 != nil tas.set_style_text_font(f20, 0) end
   end
   tas.set_align(lv.ALIGN_LEFT_MID)
   tas.set_x(42)


### PR DESCRIPTION
## Description:

LVGL splash screen uses default Montserrat-14 instead of Montserrat-20 on small screens.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
