### PR TITLE
`USE_UNIVERSAL_TOUCH` no more forced when `USE_UNIVERSAL_DISPLAY` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 - Seesaw encoder position tracking in light control mode (#24730)
 
 ### Removed
-
+- `USE_UNIVERSAL_TOUCH` no more forced when `USE_UNIVERSAL_DISPLAY` is enabled
 
 ## [15.4.0.1] 20260507
 ### Added

--- a/lib/lib_display/UDisplay/include/uDisplay_config.h
+++ b/lib/lib_display/UDisplay/include/uDisplay_config.h
@@ -19,11 +19,6 @@ extern float CharToFloat(const char *str);
 extern SPIClass *SpiBegin(uint32_t bus);
 #endif  // _TASMOTA_H_
 
-// Enable universal touch support
-#ifndef USE_UNIVERSAL_TOUCH
-#define USE_UNIVERSAL_TOUCH
-#endif
-
 enum uColorType { uCOLOR_BW, uCOLOR_COLOR };
 
 // Color definitions


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #24740

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
