### PR TITLE
Remove -DUSE_SHA_ROM flag for esp32s3 due to issues

### DIFF
--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -19,3 +19,10 @@ if mcu in ("esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
     build_flags.pop(build_flags.index("-mtarget-align"))
   except:
     pass
+
+# Remove -DUSE_SHA_ROM for esp32s3 (currently not working on this chip)
+if mcu in ("esp32s3"):
+  try:
+    build_flags.pop(build_flags.index("-DUSE_SHA_ROM"))
+  except:
+    pass


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
