### PR TITLE
Move autoconf repository to `ota.tasmota.com`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Berry `format()` now uses internal `ext_snprintf_P()` for floating point formatting (#24725)
 - ESP8266 wrap printf and replace with stubs reducing flash size by 6k (#24714)
 - LVGL splash screen uses default Montserrat-14 instead of Montserrat-20 on small screens (#24735)
+- Move autoconf repository to `ota.tasmota.com`
 
 ### Fixed
 - NeoPool possible overflow/div-zero errors and Hydrolysis module detection (#24724)

--- a/lib/libesp32/berry_tasmota/src/embedded/autoconf_module.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/autoconf_module.be
@@ -90,7 +90,7 @@ autoconf_module.init = def (m)
     def load_templates()
       import json
       try 
-        var url = format("https://raw.githubusercontent.com/tasmota/autoconf/main/%s_manifest.json", tasmota.arch())
+        var url = format("https://ota.tasmota.com/autoconf/%s_manifest.json", tasmota.arch())
         tasmota.log(format("CFG: loading '%s'", url), 3)
         # load the template
         var cl = webclient()


### PR DESCRIPTION
## Description:

Move autoconf repository from `raw.githubusercontent.com` to `ota.tasmota.com` to have better control on TLS ciphers.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
