### PR TITLE
Fix URL detection and path handling in esp32_build_filesystem

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -140,9 +140,15 @@ def esp32_build_filesystem(fs_size):
         print(Fore.GREEN + "Will create filesystem with the following file(s):")
         print()
     for file in files:
+        # Remove leading and trailing whitespace, ignore empty lines
+        file = file.strip()
+        if not file:
+            continue
+
         if "no_files" in file:
             continue
-        if "http" and "://" in file:
+        # Remote URL
+        if file.startswith(("http://", "https://")):
             response = requests.get(file.split(" ")[0])
             if response.ok:
                 target = os.path.normpath(join(filesystem_dir, file.split(os.path.sep)[-1]))
@@ -155,6 +161,8 @@ def esp32_build_filesystem(fs_size):
             else:
                 print(Fore.RED + "Failed to download: ",file)
             continue
+        # Local path (relative to PROJECT_DIR or absolute)
+        file = file if os.path.isabs(file) else os.path.normpath(join(env.subst("$PROJECT_DIR"), file))
         if os.path.isdir(file):
             print(f"{file}/ (directory)")
             shutil.copytree(file, filesystem_dir, dirs_exist_ok=True)


### PR DESCRIPTION
## Description:
Fix URL detection and path handling in esp32_build_filesystem

- Replace broken "http" and "://" in file condition with file.startswith(("http://", "https://")) — the original always evaluated "http" as truthy and only tested for "://".
- Strip whitespace and skip blank lines from custom_files_upload entries, matching the pattern in solidify-from-url.py.
- Resolve relative local paths against $PROJECT_DIR rather than the build-time CWD.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
