### PR TITLE
Create tasmota_defines_for_berry.be stub before solidification if absent

### DIFF
--- a/pio-tools/solidify-from-url.py
+++ b/pio-tools/solidify-from-url.py
@@ -142,6 +142,12 @@ else:
     if env.IsCleanTarget() == False:
         os.chdir(BERRY_SOLIDIFY_DIR)
 
+        # tasmota_defines_for_berry.be is generated post-compilation; create an empty
+        # stub if it doesn't exist yet so solidify_all_python.be can import it safely.
+        defines_file = join(env.subst("$PROJECT_DIR"), "tasmota", "tasmota_defines_for_berry.be")
+        if not os.path.exists(defines_file):
+            open(defines_file, 'w').close()
+
         if prepareBerryFiles(files.splitlines()):
             BERRY_GEN_DIR = join(env.subst("$PROJECT_DIR"), "lib", "libesp32", "berry")
             solidify_env = os.environ.copy()


### PR DESCRIPTION
## Description:
Create tasmota_defines_for_berry.be stub before solidification if absent

- solidify_all_python.be imports tasmota_defines during solidification, but the actual file is generated post-compilation by gen-berry-defines.py. If it doesn't exist yet, solidification fails. Create an empty stub before calling prepareBerryFiles so the import succeeds regardless of build order.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
