### PR TITLE
Clarify dns_save4 handling in IPv6 only case

### DIFF
--- a/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
+++ b/lib/default/WiFiHelper/src/WiFiHelper_ESP32.cpp
@@ -109,10 +109,12 @@ void WiFiHelper::scrubDNS(void) {
 
   // Step 2. scrub addresses not supported
 #ifdef USE_IPV6
-  if (!has_v4 && has_v6) {            // v6 only
-    dns_save4[0] = *IP4_ADDR_ANY;
-    dns_save4[1] = *IP4_ADDR_ANY;
-  }
+  // Note: do NOT clear dns_save4 when !has_v4 && has_v6.
+  // IPv4 may be temporarily unavailable during WiFi reconnect while IPv6 RA
+  // completes before DHCP. Clearing dns_save4 here would lose the saved IPv4
+  // DNS server, causing all subsequent DNS lookups to fail until DHCP restores
+  // it. Step 3 already uses dns_save6 exclusively when !has_v4 && has_v6,
+  // so clearing dns_save4 here is both harmful and redundant.
   if (!has_v6) {
     dns_save6[0] = *IP_ADDR_ANY;
     dns_save6[1] = *IP_ADDR_ANY;


### PR DESCRIPTION
## Description:

Flow:

1. WiFi disconnects briefly and reconnects
2. IPv6 auto-configuration (RA) completes quickly → has_v6=true
3. DHCP for IPv4 not yet complete → has_v4=false
4. During this brief window, MQTT retry → hostByName → scrubDNS
5. Step 2: !has_v4 && has_v6 → dns_save4 is reset to 0!
6. Step 3 sets DNS server to dns_save6 (0 if applicable) → no DNS configuration
7. DNS lookup fails → rc -5

fix Race Condition in scrubDNS which can happen in networks with global IPv6 (Dual-Stack ISP).
The PR ensures DNS resolve in boot phase, so the mqtt name resolve is always working

@s-hadinger please review

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
