### PR TITLE
feat(xsns_126): add Qorvo DW3000 UWB ranging sensor driver

### DIFF
--- a/lib/lib_div/DW3000/DW3000Driver.cpp
+++ b/lib/lib_div/DW3000/DW3000Driver.cpp
@@ -1,0 +1,729 @@
+/*
+ * DW3000Driver.cpp
+ * Low-level HAL for the Qorvo DW3000 UWB chip
+ *
+ * License  : Apache 2.0 (Tasmota compatible)
+ * References:
+ *   - DW3000 User Manual (Qorvo)
+ *   - Fhilb/DW3000_Arduino (reference for chip init sequence)
+ *   - https://gist.github.com/egnor/455d510e11c22deafdec14b09da5bf54
+ *
+ * Note: DW3000_REG_* constants in the header use DW1000-style naming (legacy);
+ * actual DW3000 register banks and offsets are defined locally here.
+ */
+
+#include "DW3000Driver.h"
+#include <SPI.h>
+
+// ─── DW3000 register banks (5-bit base address in SPI header) ────────────────
+#define B_GEN   0x00   // GEN_CFG_AES_LOW  (SYS_STATUS, TX_FCTRL, TX timestamps…)
+#define B_GENH  0x01   // GEN_CFG_AES_HIGH (CHAN_CTRL, EUI, PANADR…)
+#define B_TUNE  0x03   // RX_TUNE / DGC LUT
+#define B_SYNC  0x04   // EXT_SYNC / PGF calibration
+#define B_DRX   0x06   // Digital RX (DTUNE, PAC)
+#define B_RF    0x07   // RF_CONF (TX ctrl, LDO)
+#define B_FS    0x09   // FS_CTRL (PLL, XTAL)
+#define B_AON   0x0A   // Always-On
+#define B_OTP   0x0B   // OTP interface
+#define B_CIA   0x0C   // CIA — RX timestamps, signal quality
+#define B_DIAG  0x0F   // DIG_DIAG / SYS_STATE
+#define B_PMSC  0x11   // Power Management / clock control
+#define B_RXBUF 0x12   // RX buffer 0
+#define B_TXBUF 0x14   // TX buffer
+
+// ─── Offsets in B_GEN (0x00) ──────────────────────────────────────────────────
+#define O_DEV_ID    0x00
+#define O_PANADR    0x0C
+#define O_SYS_CFG   0x10
+#define O_SYS_TIME  0x1C
+#define O_TX_FCTRL  0x24
+#define O_DX_TIME   0x2C
+#define O_RX_FWTO   0x34
+#define O_SYS_EN    0x3C
+#define O_SYS_STAT  0x44   // SYS_STATUS (low 32 bits)
+#define O_RX_FINFO  0x4C   // RX frame info (length…)
+#define O_TX_TIME   0x74   // TX timestamp (5 bytes)
+
+// ─── Offsets in B_GENH (0x01) ─────────────────────────────────────────────────
+#define O_CHAN_CTRL  0x14
+
+// ─── Additional offsets in B_GEN ──────────────────────────────────────────────
+#define O_RX_TIME   0x64   // RX_TIME_0: RX SFD timestamp (5 bytes)
+
+// ─── Offsets in B_CIA (0x0C) ──────────────────────────────────────────────────
+#define O_CIA_DIAG  0x58   // PAC count (for RSSI)
+
+// ─── Offsets in B_PMSC (0x11) ─────────────────────────────────────────────────
+#define O_PMSC_SOFT 0x00
+#define O_PMSC_CLK  0x04
+
+// ─── SYS_STATUS bits for DW3000 (verified against Makerfabs SDK) ─────────────
+#define STS_TXFRS   (1UL << 7)    // TX frame sent
+#define STS_RXPHE   (1UL << 12)   // RX PHY header error
+#define STS_RXDFR   (1UL << 13)   // RX data frame ready (RXFR)
+#define STS_RXFCG   (1UL << 14)   // RX frame CRC good
+#define STS_RXFCE   (1UL << 15)   // RX frame CRC error
+#define STS_RXFTO   (1UL << 17)   // RX frame wait timeout
+#define STS_RXRFTO  (1UL << 21)   // RX RF timeout
+#define STS_RXPTO   (1UL << 22)   // RX preamble timeout
+#define STS_SPIRDY  (1UL << 23)   // SPI ready
+#define STS_RCINIT  (1UL << 24)   // RC init done
+
+// Combined RX error mask
+#define STS_RX_ERR  (STS_RXFCE | STS_RXPHE | 0x04270000UL)
+
+// ─── Fast commands (1 byte: 0x80 | cmd<<1 | 0x01) ───────────────────────────
+#define FCMD(c)     ((uint8_t)(0x81 | ((c) << 1)))
+#define CMD_IDLE     0x00   // Force IDLE (cancel ongoing TX/RX) [TXRXOFF in Qorvo SDK]
+#define CMD_TX       0x01   // Start immediate TX
+#define CMD_RX       0x02   // Start immediate RX
+#define CMD_DTX      0x03   // Deferred TX (via DX_TIME)
+#define CMD_TX_W4R   0x0C   // Immediate TX then auto-RX (Wait-4-Response)
+#define CMD_DTX_W4R  0x0D   // Deferred TX then auto-RX
+
+// ─── Private internal helpers (not declared in header) ───────────────────────
+static uint32_t _otpRead(DW3000Driver* d, uint8_t addr);
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Constructor
+// ═════════════════════════════════════════════════════════════════════════════
+
+DW3000Driver::DW3000Driver(uint8_t csPin, uint8_t rstPin, uint8_t irqPin)
+    : _csPin(csPin), _rstPin(rstPin), _irqPin(irqPin) {}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Lifecycle
+// ═════════════════════════════════════════════════════════════════════════════
+
+void DW3000Driver::begin() {
+    pinMode(_csPin, OUTPUT);
+    digitalWrite(_csPin, HIGH);
+    pinMode(_rstPin, INPUT);    // floating = not in reset
+    pinMode(_irqPin, INPUT);
+    SPI.begin();
+    delay(5);
+}
+
+void DW3000Driver::hardReset() {
+    pinMode(_rstPin, OUTPUT);
+    digitalWrite(_rstPin, LOW);
+    delay(10);
+    pinMode(_rstPin, INPUT);   // release — DW3000 pulls high internally
+    delay(5);
+}
+
+void DW3000Driver::softReset() {
+    // Clear AON config before reset
+    writeReg16(B_AON, 0x0000, 0x00);
+    writeReg8 (B_AON, 0x00,   0x14);
+    writeReg8 (B_AON, 0x00,   0x04);
+    writeReg16(B_AON, 0x0002, 0x04);
+    delay(1);
+
+    // Force clock to FAST_RC/4, reset, restore
+    writeReg32(B_PMSC, 0x00000001UL, O_PMSC_CLK);
+    writeReg16(B_PMSC, 0x0000, O_PMSC_SOFT);
+    delay(20);
+    writeReg16(B_PMSC, 0xFFFF, O_PMSC_SOFT);
+    writeReg8 (B_PMSC, 0x00,   O_PMSC_CLK);
+}
+
+bool DW3000Driver::checkConnection() {
+    uint32_t id = readReg32(B_GEN, O_DEV_ID);
+    return (id == DW3000_DEVICE_ID || id == 0xDECA0312UL);
+}
+
+// ─── Internal IDLE wait ───────────────────────────────────────────────────────
+
+static bool _waitIdle(DW3000Driver* d, uint32_t timeoutMs = 500) {
+    uint32_t t0 = millis();
+    while ((millis() - t0) < timeoutMs) {
+        // PMSC in IDLE (SYS_STATE[17:16] == 0x3)
+        uint32_t sysstate = d->readReg32(B_DIAG, 0x30);
+        if (((sysstate >> 16) & 0x3) == 0x3) return true;
+        // Or SPI_RDY + RCINIT in SYS_STATUS
+        uint32_t stat = d->readReg32(B_GEN, O_SYS_STAT);
+        if ((stat & (STS_SPIRDY | STS_RCINIT)) == (STS_SPIRDY | STS_RCINIT))
+            return true;
+    }
+    return false;
+}
+
+// ─── OTP read ─────────────────────────────────────────────────────────────────
+
+static uint32_t _otpRead(DW3000Driver* d, uint8_t addr) {
+    d->writeReg8 (B_OTP, addr, 0x04);  // OTP_ADDR
+    d->writeReg8 (B_OTP, 0x02, 0x08);  // OTP_CFG : bit OTP_READ
+    return d->readReg32(B_OTP, 0x10);  // OTP_RDATA
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// init() — full DW3000 initialization sequence
+// ═════════════════════════════════════════════════════════════════════════════
+
+bool DW3000Driver::init(const DW3000Config& cfg) {
+    if (!cfg.isValid()) return false;
+    _config = cfg;
+
+    hardReset();
+    begin();
+
+    if (!checkConnection()) return false;
+
+    // Force INIT (SYS_CFG bit 4)
+    uint32_t syscfg = readReg32(B_GEN, O_SYS_CFG);
+    writeReg32(B_GEN, syscfg | (1UL << 4), O_SYS_CFG);
+
+    if (!_waitIdle(this)) return false;
+
+    softReset();
+    delay(200);
+
+    if (!_waitIdle(this)) return false;
+
+    // ── OTP load ─────────────────────────────────────────────────────────────
+    uint32_t ldo_low  = _otpRead(this, 0x04);
+    uint32_t ldo_high = _otpRead(this, 0x05);
+    uint32_t bias_raw = _otpRead(this, 0x0A);
+    uint32_t bias_tune = (bias_raw >> 16) & 0x1F;
+
+    if (ldo_low != 0 && ldo_high != 0 && bias_tune != 0) {
+        writeReg8(B_PMSC, (uint8_t)bias_tune, 0x1F);  // BIAS_CTRL
+        writeReg16(B_OTP, 0x0100, 0x08);               // LDO_KICK
+    }
+
+    uint32_t xtrim = _otpRead(this, 0x1E);
+    if (xtrim == 0) xtrim = 0x2E;
+    writeReg8(B_FS, (uint8_t)xtrim, 0x14);  // XTAL trim
+
+    // ── System config ─────────────────────────────────────────────────────────
+    // SYS_CFG: bit3=DIS_DRXB, bit7=CIA_IPATOV (required for RX_TIME_0 / IP_TOA),
+    //          bit10=RXAUTR (auto re-arm RX after reception)
+    // CIA_STS (bit8) must be 0 in non-STS mode — it was the original bug in 0x188.
+    uint32_t usr_cfg = 0x00000488UL;
+    writeReg32(B_GEN, usr_cfg, O_SYS_CFG);
+
+    // Enable all interrupts
+    writeReg32(B_GEN, 0xFFFFFFFFUL, O_SYS_EN);
+    writeReg16(B_GEN, 0xFFFF, 0x40);
+
+    // AON digital config: auto RX recalibration + GO2IDLE on wake
+    writeReg32(B_AON, 0x000900UL, 0x00);
+
+    // ── DGC (Dynamic Gain Control) — hardcoded values (OTP sometimes absent) ──
+    writeReg32(B_TUNE, 0x10000240UL, 0x1C);  // DGC_CFG0
+    writeReg32(B_TUNE, 0x1B6DA489UL, 0x20);  // DGC_CFG1
+    if (cfg.channel == UWB_CHANNEL_9) {
+        writeReg32(B_TUNE, 0x0002A8FEUL, 0x38);  // DGC_LUT_0 ch9
+        writeReg32(B_TUNE, 0x0002AC36UL, 0x3C);  // DGC_LUT_1 ch9
+        writeReg32(B_TUNE, 0x0002A5FEUL, 0x40);  // DGC_LUT_2 ch9
+        writeReg32(B_TUNE, 0x0002AF3EUL, 0x44);  // DGC_LUT_3 ch9
+        writeReg32(B_TUNE, 0x0002AF7DUL, 0x48);  // DGC_LUT_4 ch9
+        writeReg32(B_TUNE, 0x0002AFB5UL, 0x4C);  // DGC_LUT_5 ch9
+        writeReg32(B_TUNE, 0x0002AFB5UL, 0x50);  // DGC_LUT_6 ch9
+    } else {
+        writeReg32(B_TUNE, 0x0001C0FDUL, 0x38);  // DGC_LUT_0 ch5
+        writeReg32(B_TUNE, 0x0001C43EUL, 0x3C);  // DGC_LUT_1 ch5
+        writeReg32(B_TUNE, 0x0001C6BEUL, 0x40);  // DGC_LUT_2 ch5
+        writeReg32(B_TUNE, 0x0001C77EUL, 0x44);  // DGC_LUT_3 ch5
+        writeReg32(B_TUNE, 0x0001CF36UL, 0x48);  // DGC_LUT_4 ch5
+        writeReg32(B_TUNE, 0x0001CFB5UL, 0x4C);  // DGC_LUT_5 ch5
+        writeReg32(B_TUNE, 0x0001CFF5UL, 0x50);  // DGC_LUT_6 ch5
+    }
+
+    // THR_64 = 0x32 (egnor: "always change")
+    writeReg16(B_TUNE, 0xE5E5, 0x18);
+
+    // PAC size = 8 (recommended) + DTUNE0 clear DT0B4
+    writeReg32(B_DRX, 0x00811018UL, 0x00);
+
+    // OTP: STS_CFG (STS length = 64)
+    writeReg16(B_OTP, 0x1400, 0x08);
+    writeReg8 (B_GEN, 0x00, 0x29);    // clear STS_MODE
+
+    // DTUNE3: recommended default value
+    writeReg32(B_DRX, 0xAF5F584CUL, 0x0C);
+
+    // ── Channel, preamble code, data rate ────────────────────────────────────
+    uint32_t chan_ctrl = readReg32(B_GENH, O_CHAN_CTRL);
+    chan_ctrl &= ~0x1FFFUL;
+    chan_ctrl |= (cfg.channel == UWB_CHANNEL_9) ? 0x01UL : 0x00UL;
+    chan_ctrl |= (uint32_t)(cfg.preambleCode & 0x1F) << 8;   // TX pcode
+    chan_ctrl |= (uint32_t)(cfg.preambleCode & 0x1F) << 3;   // RX pcode
+    // SFD type bits[2:1]: 0b01 = DW proprietary (non-STS); type 2 (4z) requires STS
+    chan_ctrl |= (0x01UL << 1);
+    writeReg32(B_GENH, chan_ctrl, O_CHAN_CTRL);
+
+    // TX_FCTRL: preamble length (TXPSR) + data rate
+    // TXPSR codes: 0x1=64, 0x2=128, 0x3=256, 0x4=512, 0x5=1024 symbols
+    // UWB_PLEN_128=0x14 is a DRX register value, not a TXPSR code
+    static const uint8_t txpsr_lut[] = {
+        /* UWB_PLEN_64=0x04 → */ 1,
+        /* UWB_PLEN_128=0x14 → */ 2,
+        /* UWB_PLEN_1024=0x08 → */ 5
+    };
+    uint8_t txpsr = (cfg.preamble == UWB_PLEN_64)   ? 1 :
+                    (cfg.preamble == UWB_PLEN_1024)  ? 5 : 2;
+    uint32_t fctrl = readReg32(B_GEN, O_TX_FCTRL);
+    fctrl &= ~0x000FC00UL;  // clear TXBR[11:10] and TXPSR[15:12]
+    fctrl |= ((uint32_t)txpsr        << 12);  // TXPSR
+    fctrl |= ((uint32_t)cfg.dataRate << 10);  // TXBR
+    writeReg32(B_GEN, fctrl, O_TX_FCTRL);
+
+    // SFD timeout = 0x8000 (large value, reduces RXSTO frequency with polling approach)
+    writeReg16(B_DRX, 0x8000, 0x02);
+
+    // ── RF config values documented by egnor ────────────────────────────────
+    writeReg8 (B_RF, 0x14,       0x48);  // LDO_RLOAD
+    writeReg8 (B_RF, 0x0E,       0x1A);  // RF_TX_CTRL_1
+    if (cfg.channel == UWB_CHANNEL_9) {
+        writeReg32(B_RF, 0x1C010034UL, 0x1C);  // RF_TX_CTRL_2 ch9
+        writeReg32(B_RF, 0x08B5A833UL, 0x10);  // RF_RX_CTRL_HI ch9
+        writeReg16(B_FS, 0x0F3C,       0x00);  // PLL_CFG ch9
+    } else {
+        writeReg32(B_RF, 0x1C071134UL, 0x1C);  // RF_TX_CTRL_2 ch5
+        writeReg16(B_FS, 0x1F3C,       0x00);  // PLL_CFG ch5
+    }
+    writeReg8(B_FS, 0x81, 0x08);     // PLL_CAL config (PLL_CFG_LD = 0x8)
+
+    // System clock in auto mode
+    writeReg32(B_PMSC, 0x00B40200UL, 0x04);
+    writeReg32(B_PMSC, 0x80030738UL, 0x08);
+
+    // ── PLL lock ──────────────────────────────────────────────────────────────
+    _initPLL();
+
+    // ── DGC KICK via OTP ─────────────────────────────────────────────────────
+    uint32_t otp_val = readReg32(B_OTP, 0x08);
+    otp_val |= 0x40UL;
+    if (cfg.channel == UWB_CHANNEL_9) otp_val |= 0x2000UL;
+    writeReg32(B_OTP, otp_val, 0x08);
+
+    // ── PGF calibration (receiver) ────────────────────────────────────────────
+    writeReg8(B_TUNE, 0xF0, 0x19);  // RX_CTRL_LO reset
+
+    uint32_t ldo_ctrl_save = readReg32(B_RF, 0x48);
+    writeReg32(B_RF, 0x00000105UL, 0x48);  // Enable required LDOs
+
+    writeReg32(B_SYNC, 0x00020000UL, 0x0C);  // RX_CAL: start calibration
+    delay(5);
+    writeReg32(B_SYNC, 0x00000011UL, 0x0C);  // Validate calibration
+
+    // Wait for calibration to complete (max 1 s)
+    uint32_t t0 = millis();
+    while ((millis() - t0) < 1000) {
+        if (readReg32(B_SYNC, 0x20) != 0) break;
+        delay(5);
+    }
+
+    writeReg32(B_SYNC, 0x00000000UL, 0x0C);
+    writeReg8 (B_SYNC, 0x01, 0x20);  // Clear calibration flag
+
+    writeReg32(B_RF, ldo_ctrl_save, 0x48);  // Restore LDO_CTRL
+
+    // Enable full CIA diagnostics (for signal strength) — CIA_CONF bit0
+    writeReg8(B_CIA, 0x01, 0x02);
+
+    // ── Antenna delay ─────────────────────────────────────────────────────────
+    // Stored in EUI / TX antenna delay register (0x01:0x04)
+    writeReg16(B_GENH, (uint16_t)cfg.antennaDelay, 0x04);
+
+    // ── Network address ───────────────────────────────────────────────────────
+    _configurePAN(cfg.panId, cfg.shortAddr);
+
+    // Explicit IDLE + clear all residual status flags
+    {
+        uint8_t idle = FCMD(CMD_IDLE);
+        _spiBeginTransaction(DW3000_SPI_SPEED_INIT);
+        digitalWrite(_csPin, LOW);
+        SPI.transfer(idle);
+        digitalWrite(_csPin, HIGH);
+        _spiEndTransaction();
+    }
+    delay(5);
+    writeReg32(B_GEN, 0xFFFFFFFFUL, O_SYS_STAT);
+
+    _initialized = true;
+    return true;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Register access — public
+// ═════════════════════════════════════════════════════════════════════════════
+
+uint32_t DW3000Driver::readReg32(uint8_t reg, uint16_t offset) {
+    uint8_t buf[4];
+    readBytes(reg, offset, buf, 4);
+    return (uint32_t)buf[0]
+         | ((uint32_t)buf[1] << 8)
+         | ((uint32_t)buf[2] << 16)
+         | ((uint32_t)buf[3] << 24);
+}
+
+uint16_t DW3000Driver::readReg16(uint8_t reg, uint16_t offset) {
+    uint8_t buf[2];
+    readBytes(reg, offset, buf, 2);
+    return (uint16_t)buf[0] | ((uint16_t)buf[1] << 8);
+}
+
+uint8_t DW3000Driver::readReg8(uint8_t reg, uint16_t offset) {
+    uint8_t val;
+    readBytes(reg, offset, &val, 1);
+    return val;
+}
+
+void DW3000Driver::writeReg32(uint8_t reg, uint32_t val, uint16_t offset) {
+    uint8_t buf[4] = {
+        (uint8_t) val,
+        (uint8_t)(val >> 8),
+        (uint8_t)(val >> 16),
+        (uint8_t)(val >> 24)
+    };
+    writeBytes(reg, offset, buf, 4);
+}
+
+void DW3000Driver::writeReg16(uint8_t reg, uint16_t val, uint16_t offset) {
+    uint8_t buf[2] = { (uint8_t)val, (uint8_t)(val >> 8) };
+    writeBytes(reg, offset, buf, 2);
+}
+
+void DW3000Driver::writeReg8(uint8_t reg, uint8_t val, uint16_t offset) {
+    writeBytes(reg, offset, &val, 1);
+}
+
+void DW3000Driver::readBytes(uint8_t reg, uint16_t offset, uint8_t* buf, size_t len) {
+    _spiWrite(reg, offset, false, nullptr, buf, len);
+}
+
+void DW3000Driver::writeBytes(uint8_t reg, uint16_t offset, const uint8_t* buf, size_t len) {
+    _spiWrite(reg, offset, true, buf, nullptr, len);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TX / RX
+// ═════════════════════════════════════════════════════════════════════════════
+
+void DW3000Driver::transmit(const uint8_t* data, size_t len) {
+    writeBytes(B_TXBUF, 0, data, len);
+
+    // Update frame length in TX_FCTRL (+2 for FCS)
+    uint32_t fctrl = readReg32(B_GEN, O_TX_FCTRL);
+    fctrl = (fctrl & 0xFFFFFC00UL) | ((len + 2) & 0x3FFUL);
+    writeReg32(B_GEN, fctrl, O_TX_FCTRL);
+
+    clearSysStatus(STS_TXFRS);
+
+    // Force IDLE — chip may be in RX (RXAUTR re-arms automatically after frame reception)
+    {
+        uint8_t idle = FCMD(CMD_IDLE);
+        _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+        digitalWrite(_csPin, LOW);
+        SPI.transfer(idle);
+        digitalWrite(_csPin, HIGH);
+        _spiEndTransaction();
+    }
+
+    // Fast command TX
+    uint8_t cmd = FCMD(CMD_TX);
+    _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+    digitalWrite(_csPin, LOW);
+    SPI.transfer(cmd);
+    digitalWrite(_csPin, HIGH);
+    _spiEndTransaction();
+}
+
+void DW3000Driver::transmitW4R(const uint8_t* data, size_t len) {
+    writeBytes(B_TXBUF, 0, data, len);
+
+    uint32_t fctrl = readReg32(B_GEN, O_TX_FCTRL);
+    fctrl = (fctrl & 0xFFFFFC00UL) | ((len + 2) & 0x3FFUL);
+    writeReg32(B_GEN, fctrl, O_TX_FCTRL);
+
+    clearSysStatus(STS_TXFRS);
+
+    // Force IDLE first (cancel any auto-re-armed RX from RXAUTR)
+    {
+        uint8_t idle = FCMD(CMD_IDLE);
+        _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+        digitalWrite(_csPin, LOW);
+        SPI.transfer(idle);
+        digitalWrite(_csPin, HIGH);
+        _spiEndTransaction();
+    }
+
+    // CMD_TX_W4R: TX then automatically enable RX (atomic, no software CMD_RX needed)
+    uint8_t cmd = FCMD(CMD_TX_W4R);
+    _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+    digitalWrite(_csPin, LOW);
+    SPI.transfer(cmd);
+    digitalWrite(_csPin, HIGH);
+    _spiEndTransaction();
+}
+
+bool DW3000Driver::transmitAt(const uint8_t* data, size_t len, uint64_t txTime) {
+    writeBytes(B_TXBUF, 0, data, len);
+
+    // Preserve TXPSR and TXBR bits; clear TXFLEN [9:0] AND TXB_OFFSET [25:16]
+    uint32_t fctrl = readReg32(B_GEN, O_TX_FCTRL);
+    fctrl &= 0xFC00FC00UL;  // clear TXFLEN[9:0] and TXB_OFFSET[25:16]
+    fctrl |= ((len + 2) & 0x3FFUL);
+    writeReg32(B_GEN, fctrl, O_TX_FCTRL);
+
+    // DX_TIME[31:0] = bits[39:8] of the 40-bit target TX time
+    uint32_t dx = (uint32_t)(txTime >> 8);
+    writeReg32(B_GEN, dx, O_DX_TIME);
+
+    clearSysStatus(STS_TXFRS);
+
+    // Force IDLE before deferred TX
+    {
+        uint8_t idle = FCMD(CMD_IDLE);
+        _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+        digitalWrite(_csPin, LOW);
+        SPI.transfer(idle);
+        digitalWrite(_csPin, HIGH);
+        _spiEndTransaction();
+    }
+
+    // CMD_DTX_W4R: deferred TX at DX_TIME, then auto-enable RX (for REPORT reception)
+    uint8_t cmd = FCMD(CMD_DTX_W4R);
+    _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+    digitalWrite(_csPin, LOW);
+    SPI.transfer(cmd);
+    digitalWrite(_csPin, HIGH);
+    _spiEndTransaction();
+
+    // HPDWARN (bit 27) set if the planned TX time has already passed
+    uint32_t status = readReg32(B_GEN, O_SYS_STAT);
+    if (status & (1UL << 27)) {
+        return false;  // TX time already passed — increase FINAL_TX_DELAY
+    }
+    return true;
+}
+
+void DW3000Driver::startReceive(uint16_t timeoutMs) {
+    // Force IDLE before enabling RX (command ignored if chip is not in IDLE)
+    {
+        uint8_t idle = FCMD(CMD_IDLE);
+        _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+        digitalWrite(_csPin, LOW);
+        SPI.transfer(idle);
+        digitalWrite(_csPin, HIGH);
+        _spiEndTransaction();
+    }
+
+    clearSysStatus(0xFFFFFFFFUL);
+
+    if (timeoutMs > 0) {
+        // DW3000: RX_FWTO units ~1.026 µs (512 × 2 ns)
+        uint32_t ticks = (uint32_t)timeoutMs * 974UL;  // ≈ 1000 / 1.026
+        writeReg32(B_GEN, ticks, O_RX_FWTO);
+        // RXWTOE = SYS_CFG bit 9 (mask 0x200)
+        uint32_t sc = readReg32(B_GEN, O_SYS_CFG);
+        writeReg32(B_GEN, sc | (1UL << 9), O_SYS_CFG);
+    } else {
+        // Disable timeout
+        uint32_t sc = readReg32(B_GEN, O_SYS_CFG);
+        writeReg32(B_GEN, sc & ~(1UL << 9), O_SYS_CFG);
+    }
+
+    uint8_t cmd = FCMD(CMD_RX);
+    _spiBeginTransaction(DW3000_SPI_SPEED_FAST);
+    digitalWrite(_csPin, LOW);
+    SPI.transfer(cmd);
+    digitalWrite(_csPin, HIGH);
+    _spiEndTransaction();
+}
+
+size_t DW3000Driver::readRxFrame(uint8_t* buf, size_t maxLen) {
+    uint32_t finfo = readReg32(B_GEN, O_RX_FINFO);
+    uint16_t rxLen = finfo & 0x3FF;
+    if (rxLen < 2) return 0;
+    rxLen -= 2;  // strip 2-byte FCS
+    if (rxLen > maxLen) rxLen = maxLen;
+    readBytes(B_RXBUF, 0, buf, rxLen);
+    return rxLen;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Status / Timestamps
+// ═════════════════════════════════════════════════════════════════════════════
+
+uint32_t DW3000Driver::getSysStatus() {
+    return readReg32(B_GEN, O_SYS_STAT);
+}
+
+void DW3000Driver::clearSysStatus(uint32_t mask) {
+    writeReg32(B_GEN, mask, O_SYS_STAT);
+}
+
+uint64_t DW3000Driver::getTxTimestamp() {
+    uint8_t buf[5];
+    readBytes(B_GEN, O_TX_TIME, buf, 5);
+    return (uint64_t)buf[0]
+         | ((uint64_t)buf[1] << 8)
+         | ((uint64_t)buf[2] << 16)
+         | ((uint64_t)buf[3] << 24)
+         | ((uint64_t)buf[4] << 32);
+}
+
+uint64_t DW3000Driver::getRxTimestamp() {
+    uint8_t buf[5] = {0};
+    readBytes(B_GEN, O_RX_TIME, buf, 5);
+    return (uint64_t)buf[0]
+         | ((uint64_t)buf[1] << 8)
+         | ((uint64_t)buf[2] << 16)
+         | ((uint64_t)buf[3] << 24)
+         | ((uint64_t)buf[4] << 32);
+}
+
+uint64_t DW3000Driver::getSysTime() {
+    uint8_t buf[4];
+    readBytes(B_GEN, O_SYS_TIME, buf, 4);
+    return (uint64_t)buf[0]
+         | ((uint64_t)buf[1] << 8)
+         | ((uint64_t)buf[2] << 16)
+         | ((uint64_t)buf[3] << 24);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Diagnostic
+// ═════════════════════════════════════════════════════════════════════════════
+
+float DW3000Driver::getRxPower() {
+    // Formula per DW3000 User Manual §4.7.2 (PRF 64 MHz)
+    uint32_t cir  = readReg32(B_CIA, 0x2C) & 0x1FF;
+    uint32_t pac  = readReg32(B_CIA, O_CIA_DIAG) & 0xFFF;
+    uint32_t dgc  = (readReg32(B_TUNE, 0x60) >> 28) & 0x7;
+    if (pac == 0) return -100.0f;
+    double rssi = 10.0 * log10(((double)cir * (1UL << 21)) / ((double)pac * (double)pac))
+                + 6.0 * dgc - 121.7;
+    return (float)rssi;
+}
+
+void DW3000Driver::dumpStatus() {
+    uint32_t stat = getSysStatus();
+    uint32_t id   = getDeviceId();
+    Serial.print("[DW3000] DevID=0x"); Serial.print(id, HEX);
+    Serial.print(" SYS_STATUS=0x"); Serial.println(stat, HEX);
+    Serial.print("  TX_DONE=");    Serial.println(isTxDone());
+    Serial.print("  RX_DONE=");    Serial.println(isRxDone());
+    Serial.print("  RX_ERR=");     Serial.println(isRxError());
+    Serial.print("  RX_TIMEOUT="); Serial.println(isRxTimeout());
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Low-level SPI — private
+// ═════════════════════════════════════════════════════════════════════════════
+
+/*
+ * DW3000 SPI header (1 or 2 bytes), per DW3000 User Manual §3.2:
+ *
+ * Byte 0: [W/R | EA | A4 | A3 | A2 | A1 | A0 | 0]
+ *   W/R = bit7: 1=write, 0=read
+ *   EA  = bit6: 1=sub-address follows, 0=zero offset
+ *   A[4:0] = base address (5 bits) in bits[5:1]
+ *
+ * Byte 1 (if EA=1): [(S6 | S5 | S4 | S3 | S2 | S1 | S0) << 2 | mode]
+ *   S[6:0] = offset (7 bits) in bits[8:2] of the combined word
+ *   mode[1:0] = 00 (no further extension)
+ */
+void DW3000Driver::_buildHeader(uint8_t reg, uint16_t offset, bool write,
+                                 uint8_t* header, uint8_t& headerLen) {
+    uint32_t hdr = 0;
+    if (write) hdr |= 0x80;
+    hdr |= ((uint32_t)(reg & 0x1F) << 1);
+
+    if (offset == 0) {
+        header[0] = (uint8_t)hdr;
+        headerLen = 1;
+    } else {
+        hdr |= 0x40;   // EA: sub-address follows
+        hdr <<= 8;
+        hdr |= (uint32_t)((offset & 0x7F) << 2);  // S[6:0] dans bits[8:2]
+        header[0] = (uint8_t)(hdr >> 8);
+        header[1] = (uint8_t)(hdr & 0xFF);
+        headerLen = 2;
+    }
+}
+
+void DW3000Driver::_spiBeginTransaction(uint32_t speed) {
+    SPI.beginTransaction(SPISettings(speed, MSBFIRST, SPI_MODE0));
+}
+
+void DW3000Driver::_spiEndTransaction() {
+    SPI.endTransaction();
+}
+
+void DW3000Driver::_spiWrite(uint8_t reg, uint16_t offset, bool write,
+                              const uint8_t* wbuf, uint8_t* rbuf, size_t len) {
+    uint8_t header[2];
+    uint8_t hlen;
+    _buildHeader(reg, offset, write, header, hlen);
+
+    uint32_t speed = _initialized ? DW3000_SPI_SPEED_FAST : DW3000_SPI_SPEED_INIT;
+    _spiBeginTransaction(speed);
+    digitalWrite(_csPin, LOW);
+    for (uint8_t i = 0; i < hlen; i++) SPI.transfer(header[i]);
+    for (size_t i = 0; i < len; i++) {
+        uint8_t out = wbuf ? wbuf[i] : 0x00;
+        uint8_t in  = SPI.transfer(out);
+        if (rbuf) rbuf[i] = in;
+    }
+    digitalWrite(_csPin, HIGH);
+    _spiEndTransaction();
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Internal configuration helpers
+// ═════════════════════════════════════════════════════════════════════════════
+
+void DW3000Driver::_initPLL() {
+    // Clear CP_LOCK flag before polling (write 1 to clear bit 1 of SYS_STATUS)
+    writeReg32(B_GEN, 0x02UL, O_SYS_STAT);
+
+    // Poll CP_LOCK (bit 1 of SYS_STATUS) until PLL locks, max 2 s
+    // AINIT2IDLE was already set in SEQ_CTRL by the preceding writeReg32(B_PMSC, 0x80030738, 0x08)
+    uint32_t t0 = millis();
+    while ((millis() - t0) < 2000) {
+        if (readReg32(B_GEN, O_SYS_STAT) & 0x02UL) return;
+        delay(1);
+    }
+    // Timeout: PLL did not lock — TX/RX will not work
+}
+
+void DW3000Driver::_loadLDECode() {
+    // DW3000: LDE loaded automatically via OTP at startup
+    // (no manual loading required, unlike DW1000)
+}
+
+void DW3000Driver::_configureAGC() {
+    // Handled in init() via hardcoded DGC values
+}
+
+void DW3000Driver::_configureLDE() {
+    // Handled in init() via OTP kick
+}
+
+void DW3000Driver::_configureChannel(DW3000Channel ch, uint8_t preambleCode) {
+    // Handled in init()
+}
+
+void DW3000Driver::_configurePRF(DW3000PRFRate prf) {
+    // Handled in init() via TX_FCTRL
+}
+
+void DW3000Driver::_configureDataRate(DW3000DataRate rate) {
+    // Handled in init() via TX_FCTRL
+}
+
+void DW3000Driver::_configurePAN(uint16_t panId, uint16_t shortAddr) {
+    // PANADR: short address [31:16], PAN ID [15:0]
+    uint32_t panadr = ((uint32_t)shortAddr << 16) | panId;
+    writeReg32(B_GEN, panadr, O_PANADR);
+}
+
+void DW3000Driver::configureAddresses(uint16_t panId, uint16_t shortAddr, float antennaDelay) {
+    _configurePAN(panId, shortAddr);
+    writeReg16(B_GENH, (uint16_t)antennaDelay, 0x04);
+}

--- a/lib/lib_div/DW3000/DW3000Driver.h
+++ b/lib/lib_div/DW3000/DW3000Driver.h
@@ -1,0 +1,222 @@
+#pragma once
+/*
+ * DW3000Driver.h
+ * Low-level HAL for the Qorvo DW3000 UWB chip
+ *
+ * Encapsulates all SPI/register interactions,
+ * independent of Tasmota logic.
+ *
+ * License  : Apache 2.0 (Tasmota compatible)
+ * Reference: DW3000 User Manual (Qorvo)
+ */
+
+#include <SPI.h>
+#include <Arduino.h>
+
+// ─── Default pins (Makerfabs ESP32 UWB DW3000 WROOM) ─────────────────────────
+// Override via Tasmota GPIO template
+#ifndef UWB_PIN_CS
+  #define UWB_PIN_CS   4
+#endif
+#ifndef UWB_PIN_RST
+  #define UWB_PIN_RST  27
+#endif
+#ifndef UWB_PIN_IRQ
+  #define UWB_PIN_IRQ  34
+#endif
+
+// ESP32 default SPI: SCK=18, MISO=19, MOSI=23
+
+// ─── DW3000 constants ────────────────────────────────────────────────────────
+
+// Expected device ID (register 0x00, 4 bytes)
+#define DW3000_DEVICE_ID        0xDECA0302
+
+// SPI speed: slow during init, fast for normal operation
+#define DW3000_SPI_SPEED_INIT   4000000UL
+#define DW3000_SPI_SPEED_FAST   16000000UL
+
+// Register bank addresses (legacy DW1000-style naming kept for readability)
+#define DW3000_REG_DEV_ID       0x00
+#define DW3000_REG_EUI_64       0x01
+#define DW3000_REG_PANADR       0x03
+#define DW3000_REG_SYS_CFG      0x04
+#define DW3000_REG_SYS_TIME     0x06
+#define DW3000_REG_TX_FCTRL     0x08
+#define DW3000_REG_TX_BUFFER    0x09
+#define DW3000_REG_DX_TIME      0x0A
+#define DW3000_REG_RX_FWTO      0x0C
+#define DW3000_REG_SYS_CTRL     0x0D
+#define DW3000_REG_SYS_ENABLE   0x0E
+#define DW3000_REG_SYS_STATUS   0x0F
+#define DW3000_REG_RX_FINFO     0x10
+#define DW3000_REG_RX_BUFFER    0x11
+#define DW3000_REG_RX_TIME      0x15
+#define DW3000_REG_TX_TIME      0x17
+#define DW3000_REG_CHAN_CTRL    0x1F
+#define DW3000_REG_SFD          0x21
+#define DW3000_REG_AGC_CTRL     0x23
+#define DW3000_REG_EXT_SYNC     0x24
+#define DW3000_REG_LDE_CTRL     0x2E
+#define DW3000_REG_DIG_DIAG     0x2F
+#define DW3000_REG_PMSC         0x36
+#define DW3000_REG_PLL_CFG      0x08  // sub-register
+
+// SYS_STATUS bits (DW3000 UM + Makerfabs SDK verified)
+#define DW3000_SYS_STATUS_TXFRS   (1UL << 7)   // TX Frame Sent
+#define DW3000_SYS_STATUS_RXDFR   (1UL << 13)  // RX Frame Ready (RXFR)
+#define DW3000_SYS_STATUS_RXFCG   (1UL << 14)  // RX Frame CRC Good
+#define DW3000_SYS_STATUS_RXFCE   (1UL << 15)  // RX Frame CRC Error
+#define DW3000_SYS_STATUS_RXPHE   (1UL << 12)  // RX PHY Header Error
+#define DW3000_SYS_STATUS_RXRFTO  (1UL << 21)  // RX RF Timeout
+#define DW3000_SYS_STATUS_RXPTO   (1UL << 22)  // RX Preamble Timeout
+#define DW3000_SYS_STATUS_RXSTO   (1UL << 26)  // RX SFD Timeout
+
+// DW3000 time unit: 1 tick ≈ 15.65 ps
+#define DW3000_TIME_UNIT_PS     15.65
+#define SPEED_OF_LIGHT_CM_S     29979245800.0
+
+// ─── Enumerations ─────────────────────────────────────────────────────────────
+
+enum DW3000Channel : uint8_t {
+  UWB_CHANNEL_5 = 5,   // 6.5 GHz
+  UWB_CHANNEL_9 = 9    // 8.0 GHz
+};
+
+enum DW3000DataRate : uint8_t {
+  UWB_RATE_850K  = 0,
+  UWB_RATE_6M8   = 1   // Recommended for ranging
+};
+
+enum DW3000PRFRate : uint8_t {
+  UWB_PRF_16MHz  = 1,
+  UWB_PRF_64MHz  = 2   // Better accuracy
+};
+
+enum DW3000PreambleLen : uint8_t {
+  UWB_PLEN_64   = 0x04,
+  UWB_PLEN_128  = 0x14,
+  UWB_PLEN_1024 = 0x08
+};
+
+// ─── Radio configuration struct ──────────────────────────────────────────────
+
+struct DW3000Config {
+  DW3000Channel   channel    = UWB_CHANNEL_5;
+  DW3000DataRate  dataRate   = UWB_RATE_6M8;
+  DW3000PRFRate   prf        = UWB_PRF_64MHz;
+  DW3000PreambleLen preamble = UWB_PLEN_128;
+  uint8_t         preambleCode = 9;    // Preamble code (channel-dependent)
+  uint16_t        panId      = 0xDECA;
+  uint16_t        shortAddr  = 0x0001;
+  float           antennaDelay = 16384.0; // in DW3000 ticks (calibrate per hardware)
+
+  bool isValid() const {
+    if (channel != UWB_CHANNEL_5 && channel != UWB_CHANNEL_9) return false;
+    if (channel == UWB_CHANNEL_5 && preambleCode > 15) return false;
+    // Channel 9 valid preamble codes: 9-12 (BPRF) and 17-24 (HPRF) per Qorvo SDK
+    if (channel == UWB_CHANNEL_9 && !((preambleCode >= 9 && preambleCode <= 12) || (preambleCode >= 17 && preambleCode <= 24))) return false;
+    return true;
+  }
+};
+
+// ─── DW3000Driver main class ─────────────────────────────────────────────────
+
+class DW3000Driver {
+public:
+  DW3000Driver(uint8_t csPin  = UWB_PIN_CS,
+               uint8_t rstPin = UWB_PIN_RST,
+               uint8_t irqPin = UWB_PIN_IRQ);
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  void begin();       // Initialize SPI bus and GPIO
+  void hardReset();   // Hardware reset via RST pulse
+  void softReset();   // Software reset via PMSC register
+
+  // Configure chip from DW3000Config; returns true on success
+  bool init(const DW3000Config& config = DW3000Config{});
+
+  // Verify connection by reading Device ID
+  bool checkConnection();
+
+  // Update network address and antenna delay without reinitializing chip
+  void configureAddresses(uint16_t panId, uint16_t shortAddr, float antennaDelay = 16384.0f);
+
+  // ── Register access ───────────────────────────────────────────────────────
+
+  uint32_t readReg32(uint8_t reg, uint16_t offset = 0);
+  uint16_t readReg16(uint8_t reg, uint16_t offset = 0);
+  uint8_t  readReg8 (uint8_t reg, uint16_t offset = 0);
+
+  void     writeReg32(uint8_t reg, uint32_t val, uint16_t offset = 0);
+  void     writeReg16(uint8_t reg, uint16_t val, uint16_t offset = 0);
+  void     writeReg8 (uint8_t reg, uint8_t  val, uint16_t offset = 0);
+
+  void     readBytes (uint8_t reg, uint16_t offset, uint8_t* buf, size_t len);
+  void     writeBytes(uint8_t reg, uint16_t offset, const uint8_t* buf, size_t len);
+
+  // ── TX / RX ───────────────────────────────────────────────────────────────
+
+  void transmit(const uint8_t* data, size_t len);
+
+  // Immediate TX then auto-RX (CMD_TX_W4R) — chip enters RX automatically after TX.
+  // Do NOT call startReceive() afterwards.
+  void transmitW4R(const uint8_t* data, size_t len);
+
+  // Delayed TX: schedule transmission at txTime (40-bit DW3000 ticks).
+  // txTime must be at least ~1 ms in the future.
+  // Returns false if chip reports a timing error (HPDWARN).
+  bool transmitAt(const uint8_t* data, size_t len, uint64_t txTime);
+
+  void   startReceive(uint16_t timeoutMs = 0);  // Start RX, 0 = no timeout
+  size_t readRxFrame(uint8_t* buf, size_t maxLen);
+
+  // ── Status / IRQ ─────────────────────────────────────────────────────────
+
+  uint32_t getSysStatus();
+  bool isTxDone()    { return getSysStatus() & DW3000_SYS_STATUS_TXFRS; }
+  bool isRxDone()    { return getSysStatus() & DW3000_SYS_STATUS_RXDFR; }
+  bool isRxError()   { return getSysStatus() & (DW3000_SYS_STATUS_RXFCE | DW3000_SYS_STATUS_RXPHE); }
+  bool isRxTimeout() { return getSysStatus() & (DW3000_SYS_STATUS_RXRFTO | DW3000_SYS_STATUS_RXPTO | DW3000_SYS_STATUS_RXSTO); }
+  void clearSysStatus(uint32_t mask = 0xFFFFFFFF);
+
+  // ── Timestamps ────────────────────────────────────────────────────────────
+
+  uint64_t getTxTimestamp();   // TX timestamp (40-bit DW3000 ticks)
+  uint64_t getRxTimestamp();   // RX timestamp (40-bit DW3000 ticks)
+  uint64_t getSysTime();       // Current system time (40-bit)
+
+  // ── Diagnostics ──────────────────────────────────────────────────────────
+
+  float    getRxPower();       // Approximate RSSI of last received frame (dBm)
+  uint32_t getDeviceId() { return readReg32(DW3000_REG_DEV_ID); }
+  void     dumpStatus();       // Print status summary to Serial (debug)
+
+private:
+  uint8_t _csPin;
+  uint8_t _rstPin;
+  uint8_t _irqPin;
+  DW3000Config _config;
+  bool _initialized = false;
+
+  // ── Low-level SPI ────────────────────────────────────────────────────────
+  void _spiBeginTransaction(uint32_t speed = DW3000_SPI_SPEED_FAST);
+  void _spiEndTransaction();
+  void _spiWrite(uint8_t reg, uint16_t offset, bool write,
+                 const uint8_t* wbuf, uint8_t* rbuf, size_t len);
+
+  // Build DW3000 SPI header (reg + offset + r/w, per DW3000 UM §3.2)
+  void _buildHeader(uint8_t reg, uint16_t offset, bool write,
+                    uint8_t* header, uint8_t& headerLen);
+
+  // ── Internal configuration ────────────────────────────────────────────────
+  void _configureAGC();
+  void _configureLDE();
+  void _configureChannel(DW3000Channel ch, uint8_t preambleCode);
+  void _configurePRF(DW3000PRFRate prf);
+  void _configureDataRate(DW3000DataRate rate);
+  void _configurePAN(uint16_t panId, uint16_t shortAddr);
+  void _loadLDECode();
+  void _initPLL();
+};

--- a/lib/lib_div/DW3000/DW3000Ranging.cpp
+++ b/lib/lib_div/DW3000/DW3000Ranging.cpp
@@ -1,0 +1,579 @@
+/*
+ * DW3000Ranging.cpp
+ * DS-TWR / SS-TWR state machine for DW3000
+ *
+ * DS-TWR (3 exchanges):
+ *   Tag  → Poll     → Anchor
+ *   Tag  ← Response ← Anchor
+ *   Tag  → Final    → Anchor  (carries tPollTx, tRespRx, tFinalTx via deferred TX)
+ *   Tag  ← Report   ← Anchor  (carries computed distance)
+ *
+ * All ToF computation is done on the Anchor side; Tag only receives the result.
+ *
+ * SS-TWR (1 exchange):
+ *   Tag  → Poll     → Anchor
+ *   Tag  ← Response ← Anchor  (carries tRespTx, tPollRx for computation)
+ *   (computation on Tag side)
+ *
+ * License  : Apache 2.0 (Tasmota compatible)
+ * Reference: Fhilb/DW3000_Arduino (inspiration for DS-TWR structure)
+ */
+
+#include "DW3000Ranging.h"
+#include <string.h>
+#include <math.h>
+
+// ─── Internal constants ───────────────────────────────────────────────────────
+
+#define MASK40          0xFFFFFFFFFFULL
+// FINAL TX delay: FINAL_TX_DELAY_MS (defined in .h) converted to DW3000 ticks.
+// DW3000 fires the TX in hardware at the exact scheduled time.
+// FINAL_TX_DELAY_MS must exceed the max Tasmota loop gap (~50 ms).
+// 63898 ticks/µs × 1000 to convert ms to µs.
+#define FINAL_TX_DELAY  (FINAL_TX_DELAY_MS * 1000ULL * 63898ULL)
+// Sequence number encoded as 1 byte in all frames
+static uint8_t s_seqNum = 0;
+
+// ─── Frame format (common header, little-endian) ──────────────────────────────
+// Byte 0  : type (UWB_MSG_*)
+// Byte 1  : seqNum
+// Byte 2-3: dst (little-endian)
+// Byte 4-5: src (little-endian)
+#define FRAME_HDR_LEN   6
+#define FRAME_MAX_LEN   64
+
+// Byte offsets in Final frame (21 bytes) and SS-TWR Response (16 bytes)
+#define FINAL_OFF_TPOLLTX   6    // 5 bytes
+#define FINAL_OFF_TRESRX   11    // 5 bytes
+#define FINAL_OFF_TFINALTX 16    // 5 bytes
+
+#define RESP_SS_OFF_TRESPTX  6   // 5 bytes (SS-TWR: tRespTx in Report)
+#define RESP_SS_OFF_TPOLLRX 11   // 5 bytes
+
+// ─── 40-bit helpers ───────────────────────────────────────────────────────────
+
+static inline uint64_t ts40(uint64_t t)              { return t & MASK40; }
+static inline uint64_t tsdiff(uint64_t a, uint64_t b) { return ts40(a - b); }
+
+static void put40(uint8_t* buf, uint64_t val) {
+    buf[0] = (uint8_t)(val);
+    buf[1] = (uint8_t)(val >> 8);
+    buf[2] = (uint8_t)(val >> 16);
+    buf[3] = (uint8_t)(val >> 24);
+    buf[4] = (uint8_t)(val >> 32);
+}
+
+static uint64_t get40(const uint8_t* buf) {
+    return (uint64_t)buf[0]
+         | ((uint64_t)buf[1] << 8)
+         | ((uint64_t)buf[2] << 16)
+         | ((uint64_t)buf[3] << 24)
+         | ((uint64_t)buf[4] << 32);
+}
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+DW3000Ranging::DW3000Ranging(DW3000Driver& driver) : _drv(driver) {}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+bool DW3000Ranging::begin() {
+    // Driver is already initialized (called after DW3000Driver::init()).
+    // Only update the network address without reinitializing the chip.
+    if (!_drv.checkConnection()) return false;
+    _drv.configureAddresses(0xDECA, _myAddr, _antennaDelay);
+
+    _state        = UWB_STATE_IDLE;
+    _resultReady  = false;
+    _rangingCount = 0;
+    _errorCount   = 0;
+    _lastRangingMs = 0;
+
+    if (_role == UWB_ROLE_ANCHOR) {
+        _enterState(UWB_STATE_LISTEN);
+        _drv.startReceive(0);
+    }
+    return true;
+}
+
+void DW3000Ranging::loop() {
+    switch (_state) {
+    case UWB_STATE_IDLE:
+        if (_role == UWB_ROLE_TAG) {
+            if (millis() - _lastRangingMs >= _intervalMs)
+                _enterState(UWB_STATE_SEND_POLL);
+        }
+        break;
+    case UWB_STATE_SEND_POLL:      _stepSendPoll();      break;
+    case UWB_STATE_WAIT_RESPONSE:  _stepWaitResponse();  break;
+    case UWB_STATE_SEND_FINAL:     _stepSendFinal();     break;
+    case UWB_STATE_WAIT_REPORT:    _stepWaitReport();    break;
+    case UWB_STATE_DONE:
+        _lastRangingMs = millis();
+        if (_anchorCount > 1)
+            _currentAnchorIdx = (_currentAnchorIdx + 1) % _anchorCount;
+        _enterState(UWB_STATE_IDLE);
+        break;
+    case UWB_STATE_LISTEN:         _stepListen();        break;
+    case UWB_STATE_SEND_RESPONSE:  _stepSendResponse();  break;
+    case UWB_STATE_WAIT_FINAL:     _stepWaitFinal();     break;
+    case UWB_STATE_SEND_REPORT:    _stepSendReport();    break;
+    case UWB_STATE_ERROR:
+        _errorCount++;
+        if (_role == UWB_ROLE_TAG) {
+            _lastRangingMs = millis();
+            if (_anchorCount > 1)
+                _currentAnchorIdx = (_currentAnchorIdx + 1) % _anchorCount;
+            _enterState(UWB_STATE_IDLE);
+        } else {
+            _enterState(UWB_STATE_LISTEN);
+            _drv.startReceive(0);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+bool DW3000Ranging::getResult(UWBRangingResult& result) {
+    if (!_resultReady) return false;
+    result = _lastResult;
+    _resultReady = false;
+    return true;
+}
+
+void DW3000Ranging::reset() {
+    _state              = UWB_STATE_IDLE;
+    _resultReady        = false;
+    _finalTxScheduled   = false;
+    _currentAnchorIdx   = 0;
+    _drv.clearSysStatus();
+    if (_role == UWB_ROLE_ANCHOR) {
+        _enterState(UWB_STATE_LISTEN);
+        _drv.startReceive(0);
+    }
+}
+
+void DW3000Ranging::addAnchorAddress(uint16_t addr) {
+    if (_anchorCount < UWB_MAX_ANCHORS)
+        _anchorAddrs[_anchorCount++] = addr;
+}
+
+// ─── TAG state machine ───────────────────────────────────────────────────────
+
+void DW3000Ranging::_stepSendPoll() {
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len;
+    _buildPollFrame(buf, len);
+    // CMD_TX_W4R: atomic TX then auto-start RX
+    _drv.transmitW4R(buf, len);
+
+    uint32_t t0 = millis();
+    while (!_drv.isTxDone()) {
+        if (millis() - t0 > 10) {
+            _enterState(UWB_STATE_ERROR); return;
+        }
+    }
+    _tPollTx = _drv.getTxTimestamp();
+    // Only clear TX bits — chip is already in RX via CMD_TX_W4R
+    _drv.clearSysStatus(DW3000_SYS_STATUS_TXFRS);
+
+    _enterState(UWB_STATE_WAIT_RESPONSE);
+}
+
+void DW3000Ranging::_stepWaitResponse() {
+    uint32_t stat = _drv.getSysStatus();
+    bool rxerr = stat & (DW3000_SYS_STATUS_RXFCE | DW3000_SYS_STATUS_RXPHE);
+    bool rxto  = stat & (DW3000_SYS_STATUS_RXRFTO | DW3000_SYS_STATUS_RXPTO | DW3000_SYS_STATUS_RXSTO);
+    bool rxdone = stat & DW3000_SYS_STATUS_RXDFR;
+    bool fwto   = stat & (1UL << 17);  // RXFTO (frame wait timeout)
+
+    if (rxerr || rxto) {
+        _enterState(UWB_STATE_ERROR); return;
+    }
+    if (!rxdone) {
+        if (fwto) {
+            _drv.clearSysStatus();
+            _enterState(UWB_STATE_ERROR); return;
+        }
+        if (_isTimeout(UWB_TIMEOUT_RESPONSE_MS + 5))
+            _enterState(UWB_STATE_ERROR);
+        return;
+    }
+
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len = _drv.readRxFrame(buf, sizeof(buf));
+    _tRespRx = _drv.getRxTimestamp();
+    _drv.clearSysStatus();
+
+    if (!_useDS) {
+        // SS-TWR: Response contains tRespTx and tPollRx
+        uint64_t tRespTx_anc, tPollRx_anc;
+        if (!_parseResponseFrame(buf, len)) { _enterState(UWB_STATE_ERROR); return; }
+        tRespTx_anc = get40(buf + RESP_SS_OFF_TRESPTX);
+        tPollRx_anc = get40(buf + RESP_SS_OFF_TPOLLRX);
+        float dist = _computeDistanceSS(_tPollTx, _tRespRx, tRespTx_anc, tPollRx_anc);
+        _lastResult.distanceCm = dist;
+        _lastResult.valid      = (dist >= 0.0f && dist < 10000.0f);
+        _lastResult.anchorId   = _currentAnchorIdx;
+        _lastResult.timestamp  = millis();
+        _lastResult.rxPowerDbm = _drv.getRxPower();
+        strncpy(_lastResult.method, "SS-TWR", sizeof(_lastResult.method));
+        _resultReady = true;
+        _rangingCount++;
+        _enterState(UWB_STATE_DONE);
+        return;
+    }
+
+    if (!_parseResponseFrame(buf, len)) { _enterState(UWB_STATE_ERROR); return; }
+    _enterState(UWB_STATE_SEND_FINAL);
+}
+
+void DW3000Ranging::_stepSendFinal() {
+    // Non-blocking: first call schedules the delayed TX, subsequent calls
+    // poll TX done. Avoids blocking the Tasmota loop for FINAL_TX_DELAY_MS.
+    if (!_finalTxScheduled) {
+        uint64_t tFinalTx_sched = ts40(_tRespRx + FINAL_TX_DELAY);
+        // Predict the TX_TIME register value: DW3000 reports (DX_TIME<<8) + antenna_delay.
+        // The lower 8 bits of tFinalTx_sched are lost when written to DX_TIME (32-bit register).
+        uint64_t tFinalTx_frame = (tFinalTx_sched & ~0xFFULL) + (uint64_t)_antennaDelay;
+        uint8_t buf[FRAME_MAX_LEN];
+        size_t  len;
+        _buildFinalFrame(buf, len, _tPollTx, _tRespRx, tFinalTx_frame);
+        if (!_drv.transmitAt(buf, len, tFinalTx_sched)) {
+            _enterState(UWB_STATE_ERROR); return;
+        }
+        _finalTxScheduled = true;
+        return;  // return on next FUNC_LOOP call
+    }
+
+    // TX scheduled — wait for TX done (non-blocking)
+    if (_drv.isTxDone()) {
+        _finalTxScheduled = false;
+        _drv.clearSysStatus(DW3000_SYS_STATUS_TXFRS);
+        _enterState(UWB_STATE_WAIT_REPORT);
+        return;
+    }
+    // Timeout: FINAL_TX_DELAY_MS + 200 ms margin
+    if (_isTimeout(FINAL_TX_DELAY_MS + 200)) {
+        _finalTxScheduled = false;
+        _enterState(UWB_STATE_ERROR);
+    }
+}
+
+void DW3000Ranging::_stepWaitReport() {
+    if (_drv.isRxError() || _drv.isRxTimeout()) {
+        _enterState(UWB_STATE_ERROR); return;
+    }
+    if (!_drv.isRxDone()) {
+        if (_isTimeout(UWB_TIMEOUT_REPORT_MS + 5))
+            _enterState(UWB_STATE_ERROR);
+        return;
+    }
+
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len = _drv.readRxFrame(buf, sizeof(buf));
+    _drv.clearSysStatus();
+
+    float dist;
+    if (!_parseReportFrame(buf, len, dist)) { _enterState(UWB_STATE_ERROR); return; }
+
+    _lastResult.distanceCm = dist;
+    _lastResult.valid      = (dist >= 0.0f && dist < 10000.0f);
+    _lastResult.anchorId   = _currentAnchorIdx;
+    _lastResult.timestamp  = millis();
+    _lastResult.rxPowerDbm = _drv.getRxPower();
+    strncpy(_lastResult.method, "DS-TWR", sizeof(_lastResult.method));
+    _resultReady = true;
+    _rangingCount++;
+    _enterState(UWB_STATE_DONE);
+}
+
+// ─── ANCHOR state machine ────────────────────────────────────────────────────
+
+void DW3000Ranging::_stepListen() {
+    uint32_t stat = _drv.getSysStatus();
+    bool rxdone = stat & DW3000_SYS_STATUS_RXDFR;
+    bool rxerr  = stat & (DW3000_SYS_STATUS_RXFCE | DW3000_SYS_STATUS_RXPHE);
+    bool rxsto  = stat & DW3000_SYS_STATUS_RXSTO;
+    bool rxrfto = stat & (DW3000_SYS_STATUS_RXRFTO | DW3000_SYS_STATUS_RXPTO);
+
+    // RXSTO: DW3000 RXAUTR does NOT re-arm on RXSTO — must restart manually
+    if (rxsto && !rxdone && !rxerr) {
+        _drv.clearSysStatus(DW3000_SYS_STATUS_RXSTO);
+        _drv.startReceive(0);
+        return;
+    }
+    if (rxerr || rxrfto) {
+        _drv.clearSysStatus();
+        _drv.startReceive(0);
+        return;
+    }
+    if (!rxdone) {
+        // Re-arm RX periodically: RXSTO goes to IDLE, RXAUTR does NOT fire on RXSTO.
+        // If RXSTO was cleared before we saw it, chip is silently IDLE.
+        static uint32_t s_rearmMs = 0;
+        uint32_t now = millis();
+        if (now - s_rearmMs > 80) {
+            s_rearmMs = now;
+            _drv.startReceive(0);
+        }
+        return;
+    }
+
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len = _drv.readRxFrame(buf, sizeof(buf));
+    _tPollRx = _drv.getRxTimestamp();
+    _drv.clearSysStatus();
+
+    if (len < FRAME_HDR_LEN || !_parsePollFrame(buf, len)) {
+        _drv.startReceive(0);
+        return;
+    }
+    _enterState(UWB_STATE_SEND_RESPONSE);
+}
+
+void DW3000Ranging::_stepSendResponse() {
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len;
+    _buildResponseFrame(buf, len);
+
+    // CMD_TX_W4R: TX then chip auto-enables RX — no separate startReceive() needed
+    _drv.transmitW4R(buf, len);
+
+    uint32_t t0 = millis();
+    while (!_drv.isTxDone()) {
+        if (millis() - t0 > 10) {
+            _enterState(UWB_STATE_ERROR); return;
+        }
+    }
+    _tRespTx = _drv.getTxTimestamp();
+    // Clear only TX bits — chip is already in RX, do NOT call startReceive()
+    _drv.clearSysStatus(DW3000_SYS_STATUS_TXFRS);
+
+    _enterState(UWB_STATE_WAIT_FINAL);
+}
+
+void DW3000Ranging::_stepWaitFinal() {
+    // Non-blocking: status checked on each FUNC_LOOP call.
+    // FINAL_TX_DELAY = 300 ms → FINAL arrives ~300 ms after the response.
+    // Global timeout: 600 ms.
+    uint32_t stat = _drv.getSysStatus();
+    bool rxdone = stat & DW3000_SYS_STATUS_RXDFR;
+    bool rxerr  = stat & (DW3000_SYS_STATUS_RXFCE | DW3000_SYS_STATUS_RXPHE);
+    bool rxsto  = stat & DW3000_SYS_STATUS_RXSTO;
+    // RXSTO excluded from rxto — sticky bit, handled separately
+    bool rxto   = stat & (DW3000_SYS_STATUS_RXRFTO | DW3000_SYS_STATUS_RXPTO | (1UL << 17));
+
+    // RXSTO: sticky bit — always clear and re-arm (RXAUTR does not)
+    if (rxsto) {
+        _drv.clearSysStatus(DW3000_SYS_STATUS_RXSTO);
+        _drv.startReceive(0);
+    }
+
+    // rxdone takes priority: process FINAL even if RXSTO was also set
+    if (rxdone && !rxerr) {
+        uint8_t buf[FRAME_MAX_LEN];
+        size_t  len = _drv.readRxFrame(buf, sizeof(buf));
+        _tFinalRx = _drv.getRxTimestamp();
+        _drv.clearSysStatus();
+
+        uint64_t tPollTx_tag, tRespRx_tag, tFinalTx_tag;
+        if (!_parseFinalFrame(buf, len, tPollTx_tag, tRespRx_tag, tFinalTx_tag)) {
+            _enterState(UWB_STATE_LISTEN);
+            _drv.startReceive(0);
+            return;
+        }
+        _tPollTx  = tPollTx_tag;
+        _tRespRx  = tRespRx_tag;
+        _tFinalTx = tFinalTx_tag;
+        _enterState(UWB_STATE_SEND_REPORT);
+        return;
+    }
+    if (rxerr) {
+        // CRC error — RXAUTR re-arms automatically, but clear anyway
+        _drv.clearSysStatus();
+        _drv.startReceive(0);
+        return;
+    }
+    if (rxto) {
+        // Preamble/frame timeout: RXAUTR does not re-arm on RXPTO/RXRFTO.
+        // If global timeout has not expired, re-arm RX and wait for FINAL.
+        _drv.clearSysStatus();
+        if (!_isTimeout(600)) {
+            _drv.startReceive(0);  // re-arm, stay in WAIT_FINAL
+            return;
+        }
+        _enterState(UWB_STATE_LISTEN);
+        _drv.startReceive(0);
+        return;
+    }
+    if (_isTimeout(600)) {
+        _drv.clearSysStatus();
+        _enterState(UWB_STATE_LISTEN);
+        _drv.startReceive(0);
+    }
+}
+
+void DW3000Ranging::_stepSendReport() {
+    float dist = _computeDistanceDS(_tPollTx, _tPollRx,
+                                    _tRespTx, _tRespRx,
+                                    _tFinalTx, _tFinalRx);
+
+    _lastResult.distanceCm = dist;
+    _lastResult.valid      = (dist >= 0.0f && dist < 10000.0f);
+    _lastResult.anchorId   = 0;
+    _lastResult.timestamp  = millis();
+    _lastResult.rxPowerDbm = _drv.getRxPower();
+    strncpy(_lastResult.method, "DS-TWR", sizeof(_lastResult.method));
+    _resultReady = true;
+    _rangingCount++;
+
+    uint8_t buf[FRAME_MAX_LEN];
+    size_t  len;
+    _buildReportFrame(buf, len, dist);
+    _drv.transmit(buf, len);
+
+    uint32_t t0 = millis();
+    while (!_drv.isTxDone()) {
+        if (millis() - t0 > 10) break;
+    }
+    _drv.clearSysStatus();
+
+    _enterState(UWB_STATE_LISTEN);
+    _drv.startReceive(0);
+}
+
+// ─── Distance computation ────────────────────────────────────────────────────
+
+float DW3000Ranging::_computeDistanceDS(uint64_t tPollTx, uint64_t tPollRx,
+                                         uint64_t tRespTx, uint64_t tRespRx,
+                                         uint64_t tFinalTx, uint64_t tFinalRx) {
+    // All time intervals are positive modulo 2^40
+    double tRound1 = (double)tsdiff(tRespRx,  tPollTx);
+    double tReply1 = (double)tsdiff(tRespTx,  tPollRx);
+    double tRound2 = (double)tsdiff(tFinalRx, tRespTx);
+    double tReply2 = (double)tsdiff(tFinalTx, tRespRx);
+
+    double denom = tRound1 + tRound2 + tReply1 + tReply2;
+    if (denom < 1.0) return -1.0f;
+
+    double tof = (tRound1 * tRound2 - tReply1 * tReply2) / denom;
+    return _ticksToCm(tof);
+}
+
+float DW3000Ranging::_computeDistanceSS(uint64_t tPollTx, uint64_t tRespRx,
+                                         uint64_t tRespTx, uint64_t tPollRx) {
+    double tRound = (double)tsdiff(tRespRx, tPollTx);
+    double tReply = (double)tsdiff(tRespTx, tPollRx);
+    double tof    = (tRound - tReply) / 2.0;
+    return _ticksToCm(tof);
+}
+
+float DW3000Ranging::_ticksToCm(double ticks) {
+    if (!(ticks > 0.0)) return -1.0f;  // catches NaN, inf, negative, zero
+    float result = (float)(ticks * DW3000_TIME_UNIT_PS * 1e-12 * SPEED_OF_LIGHT_CM_S);
+    if (!(result > 0.0f)) return -1.0f;  // catches NaN/inf in result
+    return result;
+}
+
+// ─── Frame builders ──────────────────────────────────────────────────────────
+
+void DW3000Ranging::_buildPollFrame(uint8_t* buf, size_t& len) {
+    uint16_t ancAddr = _anchorAddrs[_currentAnchorIdx];
+    buf[0] = UWB_MSG_POLL;
+    buf[1] = ++s_seqNum;
+    buf[2] = (uint8_t)(ancAddr);
+    buf[3] = (uint8_t)(ancAddr >> 8);
+    buf[4] = (uint8_t)(_myAddr);
+    buf[5] = (uint8_t)(_myAddr >> 8);
+    len = FRAME_HDR_LEN;
+}
+
+void DW3000Ranging::_buildResponseFrame(uint8_t* buf, size_t& len) {
+    buf[0] = UWB_MSG_RESPONSE;
+    buf[1] = s_seqNum;
+    buf[2] = (uint8_t)(_tagAddr);  // dst = tag
+    buf[3] = (uint8_t)(_tagAddr >> 8);
+    buf[4] = (uint8_t)(_myAddr);   // src = anchor
+    buf[5] = (uint8_t)(_myAddr >> 8);
+
+    if (!_useDS) {
+        // SS-TWR: include tRespTx (placeholder 0 — read after TX) and tPollRx.
+        // The true tRespTx is not known before transmission.
+        // SS-TWR approach: anchor sends tPollRx; tag computes using tRespRx.
+        // tRespTx is not needed with the asymmetric formula.
+        // Send 0 as placeholder for parser consistency.
+        put40(buf + RESP_SS_OFF_TRESPTX, 0);    // placeholder tRespTx
+        put40(buf + RESP_SS_OFF_TPOLLRX, _tPollRx);
+        len = RESP_SS_OFF_TPOLLRX + 5;
+    } else {
+        len = FRAME_HDR_LEN;
+    }
+}
+
+void DW3000Ranging::_buildFinalFrame(uint8_t* buf, size_t& len,
+                                      uint64_t tPollTx, uint64_t tRespRx, uint64_t tFinalTx) {
+    uint16_t ancAddr = _anchorAddrs[_currentAnchorIdx];
+    buf[0] = UWB_MSG_FINAL;
+    buf[1] = s_seqNum;
+    buf[2] = (uint8_t)(ancAddr);
+    buf[3] = (uint8_t)(ancAddr >> 8);
+    buf[4] = (uint8_t)(_myAddr);
+    buf[5] = (uint8_t)(_myAddr >> 8);
+    put40(buf + FINAL_OFF_TPOLLTX,  tPollTx);
+    put40(buf + FINAL_OFF_TRESRX,   tRespRx);
+    put40(buf + FINAL_OFF_TFINALTX, tFinalTx);
+    len = FINAL_OFF_TFINALTX + 5;   // 21 bytes
+}
+
+void DW3000Ranging::_buildReportFrame(uint8_t* buf, size_t& len, float distanceCm) {
+    buf[0] = UWB_MSG_REPORT;
+    buf[1] = s_seqNum;
+    buf[2] = (uint8_t)(_tagAddr);  // dst = tag
+    buf[3] = (uint8_t)(_tagAddr >> 8);
+    buf[4] = (uint8_t)(_myAddr);   // src = anchor
+    buf[5] = (uint8_t)(_myAddr >> 8);
+    memcpy(buf + FRAME_HDR_LEN, &distanceCm, 4);
+    len = FRAME_HDR_LEN + 4;
+}
+
+// ─── Frame parsers ────────────────────────────────────────────────────────────
+
+bool DW3000Ranging::_parsePollFrame(const uint8_t* buf, size_t len) {
+    if (len < FRAME_HDR_LEN || buf[0] != UWB_MSG_POLL) return false;
+    uint16_t dst = (uint16_t)buf[2] | ((uint16_t)buf[3] << 8);
+    if (dst != _myAddr) return false;
+    _tagAddr = (uint16_t)buf[4] | ((uint16_t)buf[5] << 8);
+    return true;
+}
+
+bool DW3000Ranging::_parseResponseFrame(const uint8_t* buf, size_t len) {
+    return (len >= FRAME_HDR_LEN && buf[0] == UWB_MSG_RESPONSE);
+}
+
+bool DW3000Ranging::_parseFinalFrame(const uint8_t* buf, size_t len,
+                                      uint64_t& tPollTx, uint64_t& tRespRx, uint64_t& tFinalTx) {
+    if (len < FINAL_OFF_TFINALTX + 5 || buf[0] != UWB_MSG_FINAL) return false;
+    tPollTx  = get40(buf + FINAL_OFF_TPOLLTX);
+    tRespRx  = get40(buf + FINAL_OFF_TRESRX);
+    tFinalTx = get40(buf + FINAL_OFF_TFINALTX);
+    return true;
+}
+
+bool DW3000Ranging::_parseReportFrame(const uint8_t* buf, size_t len, float& distanceCm) {
+    if (len < FRAME_HDR_LEN + 4 || buf[0] != UWB_MSG_REPORT) return false;
+    memcpy(&distanceCm, buf + FRAME_HDR_LEN, 4);
+    return true;
+}
+
+// ─── State helpers ────────────────────────────────────────────────────────────
+
+void DW3000Ranging::_enterState(UWBRangingState newState) {
+    _state          = newState;
+    _stateEnteredMs = millis();
+}
+
+bool DW3000Ranging::_isTimeout(uint32_t timeoutMs) {
+    return (millis() - _stateEnteredMs) >= timeoutMs;
+}

--- a/lib/lib_div/DW3000/DW3000Ranging.h
+++ b/lib/lib_div/DW3000/DW3000Ranging.h
@@ -1,0 +1,184 @@
+#pragma once
+/*
+ * DW3000Ranging.h
+ * TWR (Two-Way Ranging) state machine for DW3000
+ *
+ * Implements:
+ *  - SS-TWR: Single Sided (1 exchange, faster, less accurate)
+ *  - DS-TWR: Double Sided (3 exchanges, recommended for accuracy)
+ *
+ * Non-blocking: state machine advances in small increments
+ * called from the Tasmota main loop.
+ */
+
+#include "DW3000Driver.h"
+
+// ─── UWB message types (first payload byte) ──────────────────────────────────
+#define UWB_MSG_POLL      0x21  // Initiator → Responder: start ranging
+#define UWB_MSG_RESPONSE  0x50  // Responder → Initiator: acknowledge
+#define UWB_MSG_FINAL     0x23  // Initiator → Responder: final timestamps
+#define UWB_MSG_REPORT    0x58  // Responder → Initiator: computed distance
+
+// ─── Timeouts and delays (ms) ────────────────────────────────────────────────
+// Tasmota/WiFi main loop may have gaps of 50+ ms.
+#define UWB_TIMEOUT_RESPONSE_MS  200
+#define UWB_TIMEOUT_REPORT_MS    300
+#define UWB_RANGING_INTERVAL_MS  200
+// FINAL TX delay must exceed the max Tasmota loop gap (~50 ms).
+// TX is scheduled in advance and triggered by DW3000 hardware timer.
+#define FINAL_TX_DELAY_MS        150UL
+
+// ─── State machine ────────────────────────────────────────────────────────────
+enum UWBRangingState : uint8_t {
+  UWB_STATE_IDLE = 0,
+  // Initiator (tag)
+  UWB_STATE_SEND_POLL,
+  UWB_STATE_WAIT_RESPONSE,
+  UWB_STATE_SEND_FINAL,
+  UWB_STATE_WAIT_REPORT,
+  UWB_STATE_DONE,
+  // Responder (anchor)
+  UWB_STATE_LISTEN,
+  UWB_STATE_SEND_RESPONSE,
+  UWB_STATE_WAIT_FINAL,
+  UWB_STATE_SEND_REPORT,
+  // Error
+  UWB_STATE_ERROR
+};
+
+// ─── Max anchors (multi-anchor round-robin) ───────────────────────────────────
+#define UWB_MAX_ANCHORS 4
+
+// ─── Node role ────────────────────────────────────────────────────────────────
+enum UWBNodeRole : uint8_t {
+  UWB_ROLE_OFF    = 0,
+  UWB_ROLE_TAG    = 1,  // Initiator: computes and publishes distance
+  UWB_ROLE_ANCHOR = 2   // Responder: answers poll frames
+};
+
+// ─── Ranging result ───────────────────────────────────────────────────────────
+struct UWBRangingResult {
+  float    distanceCm  = 0.0f;
+  float    rxPowerDbm  = 0.0f;
+  uint8_t  anchorId    = 0;
+  bool     valid       = false;
+  uint32_t timestamp   = 0;      // millis() at measurement time
+  char     method[8]   = "DS-TWR";
+};
+
+// ─── DW3000Ranging main class ─────────────────────────────────────────────────
+class DW3000Ranging {
+public:
+  DW3000Ranging(DW3000Driver& driver);
+
+  // ── Configuration ─────────────────────────────────────────────────────────
+
+  void setRole(UWBNodeRole role) { _role = role; }
+  void setNodeAddress(uint16_t addr) { _myAddr = addr; }
+  void setAnchorAddress(uint16_t addr) {
+    _anchorAddrs[0] = addr; _anchorCount = 1; _currentAnchorIdx = 0;
+  }
+  void addAnchorAddress(uint16_t addr);
+  void setRangingInterval(uint32_t ms) { _intervalMs = ms; }
+  void setAntennaDelay(float delay) { _antennaDelay = delay; }
+  void useDoubleSided(bool ds) { _useDS = ds; }
+
+  UWBNodeRole     getRole()  const { return _role; }
+  UWBRangingState getState() const { return _state; }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  bool begin();  // Initialize chip and start state machine for the configured role
+  void loop();   // Advance state machine one step — call from FUNC_LOOP, non-blocking
+  bool getResult(UWBRangingResult& result);  // Returns true if a new measurement is ready
+  void reset();
+
+  // ── Statistics ────────────────────────────────────────────────────────────
+  uint32_t getRangingCount()   const { return _rangingCount; }
+  uint32_t getErrorCount()     const { return _errorCount; }
+  float    getLastDistanceCm() const { return _lastResult.distanceCm; }
+
+  // ── Raw DW3000 timestamps (debug / calibration) ───────────────────────────
+  // TAG side  : tPollTx, tRespRx, tFinalTx
+  // ANCHOR side: tPollRx, tRespTx, tFinalRx + TAG's 3 received in FINAL frame
+  uint64_t getTPollTx()  const { return _tPollTx; }
+  uint64_t getTPollRx()  const { return _tPollRx; }
+  uint64_t getTRespTx()  const { return _tRespTx; }
+  uint64_t getTRespRx()  const { return _tRespRx; }
+  uint64_t getTFinalTx() const { return _tFinalTx; }
+  uint64_t getTFinalRx() const { return _tFinalRx; }
+
+private:
+  DW3000Driver& _drv;
+
+  UWBNodeRole     _role        = UWB_ROLE_OFF;
+  UWBRangingState _state       = UWB_STATE_IDLE;
+
+  uint16_t  _myAddr            = 0x0001;
+  uint16_t  _anchorAddrs[UWB_MAX_ANCHORS] = {0x0002};
+  uint8_t   _anchorCount       = 1;
+  uint8_t   _currentAnchorIdx  = 0;
+  uint16_t  _tagAddr           = 0;
+  uint32_t  _intervalMs        = UWB_RANGING_INTERVAL_MS;
+  float     _antennaDelay      = 16384.0f;
+  bool      _useDS             = true;   // DS-TWR by default
+  bool      _finalTxScheduled  = false;  // true between transmitAt() and TX done
+
+  uint32_t  _lastRangingMs     = 0;
+  uint32_t  _stateEnteredMs    = 0;
+
+  uint32_t  _rangingCount      = 0;
+  uint32_t  _errorCount        = 0;
+
+  UWBRangingResult _lastResult;
+  bool             _resultReady = false;
+
+  // DS-TWR timestamps (DW3000 ticks, 40-bit)
+  uint64_t _tPollTx  = 0;
+  uint64_t _tPollRx  = 0;
+  uint64_t _tRespTx  = 0;
+  uint64_t _tRespRx  = 0;
+  uint64_t _tFinalTx = 0;
+  uint64_t _tFinalRx = 0;
+
+  // ── State machine steps (initiator) ──────────────────────────────────────
+  void _stepSendPoll();
+  void _stepWaitResponse();
+  void _stepSendFinal();
+  void _stepWaitReport();
+
+  // ── State machine steps (responder) ──────────────────────────────────────
+  void _stepListen();
+  void _stepSendResponse();
+  void _stepWaitFinal();
+  void _stepSendReport();
+
+  // ── Distance computation ──────────────────────────────────────────────────
+
+  // DS-TWR formula APS013: tof = (tRound1*tRound2 - tReply1*tReply2) /
+  //                               (tRound1+tRound2+tReply1+tReply2)
+  float _computeDistanceDS(uint64_t tPollTx, uint64_t tPollRx,
+                            uint64_t tRespTx, uint64_t tRespRx,
+                            uint64_t tFinalTx, uint64_t tFinalRx);
+
+  float _computeDistanceSS(uint64_t tPollTx, uint64_t tRespRx,
+                            uint64_t tRespTx, uint64_t tPollRx);
+
+  float _ticksToCm(double ticks);
+
+  // ── Frame helpers ─────────────────────────────────────────────────────────
+  void _buildPollFrame    (uint8_t* buf, size_t& len);
+  void _buildResponseFrame(uint8_t* buf, size_t& len);
+  void _buildFinalFrame   (uint8_t* buf, size_t& len,
+                           uint64_t tPollTx, uint64_t tRespRx, uint64_t tFinalTx);
+  void _buildReportFrame  (uint8_t* buf, size_t& len, float distanceCm);
+
+  bool _parsePollFrame    (const uint8_t* buf, size_t len);
+  bool _parseResponseFrame(const uint8_t* buf, size_t len);
+  bool _parseFinalFrame   (const uint8_t* buf, size_t len,
+                           uint64_t& tPollTx, uint64_t& tRespRx, uint64_t& tFinalTx);
+  bool _parseReportFrame  (const uint8_t* buf, size_t len, float& distanceCm);
+
+  void _enterState(UWBRangingState newState);
+  bool _isTimeout(uint32_t timeoutMs);
+};

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -710,6 +710,7 @@
   #define USE_LORA_SX126X                      // Add driver support for LoRa on SX126x based devices like LiliGo T3S3 Lora32 (+16k code)
   #define USE_LORA_SX127X                      // Add driver support for LoRa on SX127x based devices like M5Stack LoRa868, RFM95W (+5k code)
   #define USE_LORAWAN_BRIDGE                   // Add support for LoRaWan bridge (+8k code)
+#define USE_UWB_DW3000                         // Add support for Qorvo DW3000 UWB ranging sensor via SPI (xsns_126) (+~8k code)
 
 #define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
 #define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -238,6 +238,7 @@ enum UserSelectablePins {
   GPIO_VID6608_F, GPIO_VID6608_CW,      // VID6608
   GPIO_MKSKYBLU_TX, GPIO_MKSKYBLU_RX,   // MakeSkyBlue solar charge controller
   GPIO_MBS_RX_ENA,                      // Modbus Bridge Serial Receive Enable
+  GPIO_UWB_CS, GPIO_UWB_RST, GPIO_UWB_IRQ,  // DW3000 UWB SPI interface
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -517,7 +518,8 @@ const char kSensorNames[] PROGMEM =
 #endif
   D_VID6608_F "|" D_VID6608_CW "|"
   D_SENSOR_MKSKYBLU_TX "|" D_SENSOR_MKSKYBLU_RX "|"
-  D_SENSOR_MBS_RX_ENA "|" 
+  D_SENSOR_MBS_RX_ENA "|"
+  D_GPIO_UWB_CS "|" D_GPIO_UWB_RST "|" D_GPIO_UWB_IRQ "|"
 ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -672,6 +674,11 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_LORA_DI4),
   AGPIO(GPIO_LORA_DI5),
 #endif  // USE_SPI_LORA
+#ifdef USE_UWB_DW3000
+  AGPIO(GPIO_UWB_CS),                              // DW3000 UWB SPI Chip Select
+  AGPIO(GPIO_UWB_RST),                             // DW3000 UWB Reset
+  AGPIO(GPIO_UWB_IRQ),                             // DW3000 UWB IRQ
+#endif  // USE_UWB_DW3000
 #endif  // USE_SPI
 
 #if defined(USE_SDCARD) && defined(ESP32)

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -831,7 +831,16 @@ typedef struct {
   uint8_t       weight_change;             // E9F
   uint8_t       web_color2[2][3];          // EA0  Needs to be on integer / 3 distance from web_color
   uint16_t      zcdimmerset[5];            // EA6
-  uint8_t       free_eb0[20];              // EB0  20 bytes
+  uint8_t       free_eb0[20];              // EB0  20 bytes - [0..10] reserved by xsns_126 UWB DW3000
+                                           //   [0] UWB mode autostart (0=off,1=tag,2=anchor)
+                                           //   [1] UWB channel (5 or 9)
+                                           //   [2..3] UWB interval ms (uint16 LE)
+                                           //   [4..5] UWB antenna delay ticks (uint16 LE)
+                                           //   [6] magic 0xAD
+                                           //   [7] flags bit0=mqttRealtime
+                                           //   [8] UWB anchor ID (0-3)
+                                           //   [9] UWB anchor count (1-4)
+                                           //   [10] UWB filter window (1-10)
   uint16_t      light_pixels_height_1 : 15;// EC4  Pixels height minus 1, default 0 (0 means 1 line)
   uint16_t      light_pixels_alternate : 1;// EC4  Indicates alternate lines in Pixels Matrix
   uint8_t       shift595_device_count;     // EC6

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -1343,5 +1343,8 @@
 #define D_SENSOR_V9240_RX "V9240 RX"
 
 #define D_SENSOR_MBS_RX_ENA    "ModBr Rx Ena"
+#define D_GPIO_UWB_CS          "UWB CS"
+#define D_GPIO_UWB_RST         "UWB RST"
+#define D_GPIO_UWB_IRQ         "UWB IRQ"
 
 #endif  // _LANGUAGE_EN_GB_H_

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1006,6 +1006,7 @@
 // -- Low level interface devices -----------------
 #define USE_DHT                                  // Add support for DHT11, AM2301 (DHT21, DHT22, AM2302, AM2321) and SI7021 Temperature and Humidity sensor (1k6 code)
 
+#define USE_UWB_DW3000                           // Add support for Qorvo DW3000 UWB ranging sensor via SPI (xsns_126) (+~8k code)
 //#define USE_MAX31855                             // Add support for MAX31855/MAX6675 K-Type thermocouple sensor using softSPI
 //#define USE_MAX31865                             // Add support for MAX31865 RTD sensors using softSPI
   #define MAX31865_PTD_WIRES  2                  // PTDs come in several flavors, pick yours. Specific settings per sensor possible with MAX31865_PTD_WIRES1..MAX31865_PTD_WIRES6

--- a/tasmota/tasmota_xsns_sensor/xsns_126_uwb_dw3000.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_126_uwb_dw3000.ino
@@ -1,0 +1,613 @@
+/*
+ * xsns_126_uwb_dw3000.ino
+ * Tasmota driver — UWB Ranging via Qorvo DW3000
+ *
+ * Licence : Apache 2.0 (compatible Tasmota)
+ *
+ * Supported hardware:
+ *  - Makerfabs ESP32 UWB DW3000 (WROOM)
+ *  - Any ESP32 + DW3000 module with standard SPI
+ *
+ * Available Tasmota commands:
+ *  UWBMode 0|1|2         → 0=off, 1=tag (initiator), 2=anchor (responder)
+ *  UWBAnchorId 0-3       → ANCHOR: identifies this anchor (address = 0x0002+id)
+ *  UWBAnchorCount 1-4    → TAG: number of anchors to range in round-robin
+ *  UWBInterval <ms>      → Ranging interval (default 200 ms)
+ *  UWBChannel 5|9        → UWB radio channel
+ *  UWBAntennaDelay <tks> → Antenna delay in DW3000 ticks (default 16384)
+ *  UWBFilterWindow 1-10  → Sliding average window size per anchor (default 3)
+ *
+ * JSON MQTT format (TAG, 2 anchors):
+ *  {"UWB":{"Mode":"tag","Channel":5,"Anchor0":234.5,"Anchor1":187.2}}
+ *
+ * JSON MQTT format (TAG, 1 anchor):
+ *  {"UWB":{"Mode":"tag","AnchorId":0,"Distance":234.5,"Unit":"cm","Method":"DS-TWR","Channel":5}}
+ *
+ * JSON MQTT format (ANCHOR):
+ *  {"UWB":{"Mode":"anchor","AnchorId":0,"Distance":234.5,"Unit":"cm","Method":"DS-TWR","Channel":5}}
+ *
+ * Flash persistence:
+ *  Settings->free_eb0[0..10] (reserved block in TSettings)
+ *  [0] autostart mode (0=off 1=tag 2=anchor)
+ *  [1] channel (5 or 9)
+ *  [2..3] intervalMs uint16_t LE
+ *  [4..5] antennaDelay uint16_t LE (ticks)
+ *  [6] magic 0xAD (initialization sentinel)
+ *  [7] flags: bit0 = mqttRealtime
+ *  [8] anchorId (ANCHOR only, 0-3)
+ *  [9] anchorCount (TAG only, 1-4)
+ *  [10] filterWindow (1-10, default 3)
+ */
+
+#ifdef USE_UWB_DW3000
+
+#include "DW3000Driver.h"
+#include "DW3000Ranging.h"
+
+#define XSNS_126  126
+
+#define D_CMND_UWB_MODE        "UWBMode"
+#define D_CMND_UWB_ANCHOR_ID   "UWBAnchorId"
+#define D_CMND_UWB_ANCHOR_CNT  "UWBAnchorCount"
+#define D_CMND_UWB_INTERVAL    "UWBInterval"
+#define D_CMND_UWB_CHANNEL     "UWBChannel"
+#define D_CMND_UWB_ANTENNA_DLY "UWBAntennaDelay"
+#define D_CMND_UWB_FILTER_WIN  "UWBFilterWindow"
+
+#define UWB_SETTINGS_MAGIC  0xAD
+#define UWB_FILTER_MAX_WINDOW 10
+
+// Sliding average per anchor (ring buffer of size UWB_FILTER_MAX_WINDOW)
+struct UwbFilter {
+  float   buf[UWB_FILTER_MAX_WINDOW] = {};
+  uint8_t total = 0;
+  uint8_t head  = 0;
+
+  void reset() { total = 0; head = 0; }
+
+  float push(float v, uint8_t window) {
+    buf[head] = v;
+    head = (head + 1) % UWB_FILTER_MAX_WINDOW;
+    if (total < UWB_FILTER_MAX_WINDOW) total++;
+    uint8_t n = (total < window) ? total : window;
+    float sum = 0;
+    for (uint8_t i = 0; i < n; i++)
+      sum += buf[(head - 1 - i + UWB_FILTER_MAX_WINDOW) % UWB_FILTER_MAX_WINDOW];
+    return sum / n;
+  }
+};
+
+static inline uint8_t* UwbFlash() { return &Settings->free_eb0[0]; }
+
+// ─── Driver globals ───────────────────────────────────────────────────────────
+namespace UwbDW3000 {
+
+  DW3000Driver  driver;
+  DW3000Ranging ranging(driver);
+
+  bool initialized   = false;
+  bool enabled       = false;
+
+  uint8_t  mode         = UWB_ROLE_OFF;
+  uint8_t  anchorId     = 0;    // ANCHOR: identifies this anchor (address = 0x0002+anchorId)
+  uint8_t  anchorCount  = 1;    // TAG: number of anchors to range in round-robin
+  uint32_t intervalMs   = 200;
+  uint8_t  channel      = 5;
+  uint16_t antennaDelay  = 16384;
+  bool     autostart     = false;
+  bool     mqttRealtime  = false;
+  uint8_t  filterWindow  = 3;
+
+  UWBRangingResult lastResults[UWB_MAX_ANCHORS];
+  UwbFilter        filters[UWB_MAX_ANCHORS];
+
+}  // namespace UwbDW3000
+
+// ─── Flash persistence ────────────────────────────────────────────────────────
+
+void UwbDW3000LoadSettings() {
+  using namespace UwbDW3000;
+  uint8_t* f = UwbFlash();
+  if (f[6] != UWB_SETTINGS_MAGIC) return;
+
+  uint8_t savedRole = f[0];
+  if (savedRole <= 2) {
+    mode      = savedRole;
+    autostart = (savedRole != UWB_ROLE_OFF);
+  }
+  uint8_t savedCh = f[1];
+  if (savedCh == 5 || savedCh == 9) channel = savedCh;
+
+  uint16_t savedIv = (uint16_t)f[2] | ((uint16_t)f[3] << 8);
+  if (savedIv >= 50 && savedIv <= 10000) intervalMs = savedIv;
+
+  uint16_t savedAd = (uint16_t)f[4] | ((uint16_t)f[5] << 8);
+  if (savedAd >= 10000 && savedAd <= 32767) antennaDelay = savedAd;
+
+  mqttRealtime = (f[7] & 0x01) != 0;
+
+  uint8_t savedAi = f[8];
+  if (savedAi <= 3) anchorId = savedAi;
+
+  uint8_t savedAc = f[9];
+  if (savedAc >= 1 && savedAc <= UWB_MAX_ANCHORS) anchorCount = savedAc;
+
+  uint8_t savedFw = f[10];
+  if (savedFw >= 1 && savedFw <= UWB_FILTER_MAX_WINDOW) filterWindow = savedFw;
+}
+
+void UwbDW3000SaveSettings() {
+  using namespace UwbDW3000;
+  uint8_t* f = UwbFlash();
+  f[0] = autostart ? mode : (uint8_t)UWB_ROLE_OFF;
+  f[1] = channel;
+  f[2] = (uint8_t)(intervalMs & 0xFF);
+  f[3] = (uint8_t)(intervalMs >> 8);
+  f[4] = (uint8_t)(antennaDelay & 0xFF);
+  f[5] = (uint8_t)(antennaDelay >> 8);
+  f[6] = UWB_SETTINGS_MAGIC;
+  f[7] = mqttRealtime ? 0x01 : 0x00;
+  f[8] = anchorId;
+  f[9] = (uint8_t)anchorCount;
+  f[10] = filterWindow;
+  SettingsSave(0);
+}
+
+// ─── Initialization ───────────────────────────────────────────────────────────
+
+void UwbDW3000HardwareInit() {
+  using namespace UwbDW3000;
+
+  int csPin  = Pin(GPIO_UWB_CS);
+  int rstPin = Pin(GPIO_UWB_RST);
+  int irqPin = Pin(GPIO_UWB_IRQ);
+
+  if (csPin < 0) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR("UWB: CS pin not configured in template"));
+    return;
+  }
+
+  enabled = false;
+  driver = DW3000Driver(csPin, rstPin, irqPin);
+  driver.begin();
+  driver.hardReset();
+  delay(10);
+
+  if (!driver.checkConnection()) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("UWB: DW3000 not found (Device ID mismatch)"));
+    initialized = false;
+    return;
+  }
+
+  DW3000Config cfg;
+  cfg.channel = (channel == 9) ? UWB_CHANNEL_9 : UWB_CHANNEL_5;
+
+  if (!driver.init(cfg)) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("UWB: DW3000 init failed"));
+    initialized = false;
+    return;
+  }
+
+  AddLog(LOG_LEVEL_INFO, PSTR("UWB: DW3000 initialized, channel %d"), channel);
+  initialized = true;
+
+  if (mode != UWB_ROLE_OFF) {
+    UwbDW3000StartRanging();
+  }
+}
+
+void UwbDW3000Init() {
+  UwbDW3000LoadSettings();
+  UwbDW3000HardwareInit();
+}
+
+void UwbDW3000StartRanging() {
+  using namespace UwbDW3000;
+  if (!initialized) return;
+
+  ranging.setRole((UWBNodeRole)mode);
+  ranging.setRangingInterval(intervalMs);
+  ranging.setAntennaDelay((float)antennaDelay);
+  if (mode == UWB_ROLE_TAG) {
+    ranging.setNodeAddress(0x0001);
+    ranging.setAnchorAddress(0x0002);           // reset the anchor list
+    for (uint8_t i = 1; i < anchorCount; i++)
+      ranging.addAnchorAddress(0x0002 + i);     // add anchor 2, 3...
+  } else {
+    ranging.setNodeAddress(0x0002 + anchorId);  // ANCHOR_0=0x0002, ANCHOR_1=0x0003
+    ranging.setAnchorAddress(0x0001);
+  }
+
+  for (uint8_t i = 0; i < UWB_MAX_ANCHORS; i++) filters[i].reset();
+
+  if (ranging.begin()) {
+    enabled = true;
+    AddLog(LOG_LEVEL_INFO, PSTR("UWB: Ranging started, role=%d anchors=%d ad=%d fw=%d"),
+           mode, (mode == UWB_ROLE_TAG) ? (int)anchorCount : 1, (int)antennaDelay, (int)filterWindow);
+  } else {
+    AddLog(LOG_LEVEL_ERROR, PSTR("UWB: Ranging start failed"));
+  }
+}
+
+// ─── Main loop ────────────────────────────────────────────────────────────────
+
+void UwbDW3000Loop() {
+  using namespace UwbDW3000;
+  if (!initialized || !enabled) return;
+
+  UWBRangingState stateBefore = ranging.getState();
+  ranging.loop();
+  UWBRangingState stateAfter  = ranging.getState();
+
+  if (stateAfter != stateBefore) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR("UWB: state %d -> %d"), (int)stateBefore, (int)stateAfter);
+
+    if (stateAfter == UWB_STATE_SEND_REPORT) {
+      uint64_t tPTx = ranging.getTPollTx(),  tPRx = ranging.getTPollRx();
+      uint64_t tRTx = ranging.getTRespTx(),  tRRx = ranging.getTRespRx();
+      uint64_t tFTx = ranging.getTFinalTx(), tFRx = ranging.getTFinalRx();
+      AddLog(LOG_LEVEL_DEBUG, PSTR("UWB TS: tPollTx=%lu|%lu tPollRx=%lu|%lu"),
+             (uint32_t)(tPTx >> 8), (uint32_t)(tPTx & 0xFF),
+             (uint32_t)(tPRx >> 8), (uint32_t)(tPRx & 0xFF));
+      AddLog(LOG_LEVEL_DEBUG, PSTR("UWB TS: tRespTx=%lu|%lu tRespRx=%lu|%lu"),
+             (uint32_t)(tRTx >> 8), (uint32_t)(tRTx & 0xFF),
+             (uint32_t)(tRRx >> 8), (uint32_t)(tRRx & 0xFF));
+      AddLog(LOG_LEVEL_DEBUG, PSTR("UWB TS: tFinalTx=%lu|%lu tFinalRx=%lu|%lu"),
+             (uint32_t)(tFTx >> 8), (uint32_t)(tFTx & 0xFF),
+             (uint32_t)(tFRx >> 8), (uint32_t)(tFRx & 0xFF));
+      uint64_t tRound1 = (tRRx - tPTx) & 0xFFFFFFFFFFULL;
+      uint64_t tReply1 = (tRTx - tPRx) & 0xFFFFFFFFFFULL;
+      uint64_t tRound2 = (tFRx - tRTx) & 0xFFFFFFFFFFULL;
+      uint64_t tReply2 = (tFTx - tRRx) & 0xFFFFFFFFFFULL;
+      AddLog(LOG_LEVEL_DEBUG, PSTR("UWB TS: tRound1=%lu tReply1=%lu tRound2=%lu tReply2=%lu"),
+             (uint32_t)tRound1, (uint32_t)tReply1,
+             (uint32_t)tRound2, (uint32_t)tReply2);
+    }
+  }
+
+  UWBRangingResult result;
+  if (ranging.getResult(result)) {
+    uint8_t aid = result.anchorId;
+    result.distanceCm = filters[aid].push(result.distanceCm, filterWindow);
+    lastResults[aid] = result;
+    AddLog(LOG_LEVEL_DEBUG, PSTR("UWB: dist=%*_f cm (anchor %d)"), 1, &result.distanceCm, aid);
+    if (mqttRealtime) { MqttPublishSensor(); }
+  }
+}
+
+void UwbDW3000Every1s() {
+  using namespace UwbDW3000;
+  if (!initialized || !enabled) return;
+  AddLog(LOG_LEVEL_DEBUG, PSTR("UWB: state=%d errors=%lu"), (int)ranging.getState(), ranging.getErrorCount());
+}
+
+// ─── JSON MQTT publication ────────────────────────────────────────────────────
+
+void UwbDW3000JsonAppend() {
+  using namespace UwbDW3000;
+  if (!initialized) return;
+
+  const char* modeStr = (mode == UWB_ROLE_TAG)   ? "tag"
+                      : (mode == UWB_ROLE_ANCHOR) ? "anchor"
+                      : "off";
+
+  if (mode == UWB_ROLE_TAG && anchorCount > 1) {
+    bool any = false;
+    for (uint8_t i = 0; i < anchorCount; i++) {
+      if (lastResults[i].valid) { any = true; break; }
+    }
+    if (!any) return;
+    ResponseAppend_P(PSTR(",\"UWB\":{\"Mode\":\"tag\",\"Channel\":%d"), channel);
+    for (uint8_t i = 0; i < anchorCount; i++) {
+      if (!lastResults[i].valid) continue;
+      ResponseAppend_P(PSTR(",\"Anchor%d\":%*_f"), i, 1, &lastResults[i].distanceCm);
+    }
+    ResponseAppend_P(PSTR("}"));
+  } else {
+    if (!lastResults[0].valid) return;
+    ResponseAppend_P(PSTR(",\"UWB\":{"
+      "\"Mode\":\"%s\","
+      "\"AnchorId\":%d,"
+      "\"Distance\":%*_f,"
+      "\"Unit\":\"cm\","
+      "\"Method\":\"%s\","
+      "\"Channel\":%d"
+      "}"),
+      modeStr,
+      lastResults[0].anchorId,
+      1, &lastResults[0].distanceCm,
+      lastResults[0].method,
+      channel
+    );
+  }
+}
+
+// ─── WebUI display (main page) ────────────────────────────────────────────────
+
+void UwbDW3000ShowSensor() {
+  using namespace UwbDW3000;
+  if (!initialized) return;
+
+  bool shown = false;
+  for (uint8_t i = 0; i < UWB_MAX_ANCHORS; i++) {
+    if (!lastResults[i].valid) continue;
+    shown = true;
+    WSContentSend_PD(PSTR("{s}UWB Anchor %d{m}%*_f cm{e}"), i, 1, &lastResults[i].distanceCm);
+  }
+  if (shown)
+    WSContentSend_PD(PSTR("{s}UWB Method{m}%s{e}"), lastResults[0].method);
+}
+
+// ─── Tasmota commands ────────────────────────────────────────────────────────
+
+void CmndUwbMode() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t newMode = (uint8_t)XdrvMailbox.payload;
+    if (newMode > 2) { ResponseCmndError(); return; }
+    mode = newMode;
+    autostart = (newMode != UWB_ROLE_OFF);
+    UwbDW3000SaveSettings();
+    if (initialized) {
+      ranging.reset();
+      if (mode != UWB_ROLE_OFF) {
+        UwbDW3000StartRanging();
+      } else {
+        enabled = false;
+      }
+    }
+  }
+  ResponseCmndNumber(mode);
+}
+
+void CmndUwbAnchorId() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t id = (uint8_t)XdrvMailbox.payload;
+    if (id > 3) { ResponseCmndError(); return; }
+    anchorId = id;
+    UwbDW3000SaveSettings();
+    if (initialized && mode != UWB_ROLE_OFF) {
+      ranging.reset();
+      enabled = false;
+      UwbDW3000StartRanging();
+    }
+  }
+  ResponseCmndNumber(anchorId);
+}
+
+void CmndUwbAnchorCount() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t n = (uint8_t)XdrvMailbox.payload;
+    if (n < 1 || n > UWB_MAX_ANCHORS) { ResponseCmndError(); return; }
+    anchorCount = n;
+    UwbDW3000SaveSettings();
+    if (initialized && mode == UWB_ROLE_TAG) {
+      ranging.reset();
+      enabled = false;
+      UwbDW3000StartRanging();
+    }
+  }
+  ResponseCmndNumber(anchorCount);
+}
+
+void CmndUwbInterval() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint32_t ms = (uint32_t)XdrvMailbox.payload;
+    if (ms < 50 || ms > 10000) { ResponseCmndError(); return; }
+    intervalMs = ms;
+    ranging.setRangingInterval(intervalMs);
+  }
+  ResponseCmndNumber(intervalMs);
+}
+
+void CmndUwbChannel() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t ch = (uint8_t)XdrvMailbox.payload;
+    if (ch != 5 && ch != 9) { ResponseCmndError(); return; }
+    channel = ch;
+    if (initialized) { UwbDW3000HardwareInit(); }
+  }
+  ResponseCmndNumber(channel);
+}
+
+void CmndUwbAntennaDelay() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint32_t ad = (uint32_t)XdrvMailbox.payload;
+    if (ad < 10000 || ad > 32767) { ResponseCmndError(); return; }
+    antennaDelay = (uint16_t)ad;
+    ranging.setAntennaDelay((float)antennaDelay);
+  }
+  ResponseCmndNumber(antennaDelay);
+}
+
+void CmndUwbFilterWindow() {
+  using namespace UwbDW3000;
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t fw = (uint8_t)XdrvMailbox.payload;
+    if (fw < 1 || fw > UWB_FILTER_MAX_WINDOW) { ResponseCmndError(); return; }
+    filterWindow = fw;
+    UwbDW3000SaveSettings();
+    for (uint8_t i = 0; i < UWB_MAX_ANCHORS; i++) filters[i].reset();
+  }
+  ResponseCmndNumber(filterWindow);
+}
+
+const char kUwbCommands[] PROGMEM = "UWB|Mode|AnchorId|AnchorCount|Interval|Channel|AntennaDelay|FilterWindow";
+
+void (* const UwbCommand[])(void) PROGMEM = {
+  &CmndUwbMode,
+  &CmndUwbAnchorId,
+  &CmndUwbAnchorCount,
+  &CmndUwbInterval,
+  &CmndUwbChannel,
+  &CmndUwbAntennaDelay,
+  &CmndUwbFilterWindow
+};
+
+// ─── WebUI configuration page ────────────────────────────────────────────────
+
+#ifdef USE_WEBSERVER
+
+#define WEB_HANDLE_UWB "s126"
+
+const char HTTP_BTN_MENU_UWB[] PROGMEM =
+  "<p><form action='" WEB_HANDLE_UWB "' method='get'>"
+  "<button>UWB</button></form></p>";
+
+const char HTTP_FORM_UWB[] PROGMEM =
+  "<form method='post' action='" WEB_HANDLE_UWB "'>"
+  "<fieldset><legend><b>&nbsp;UWB DW3000&nbsp;</b></legend>"
+  "<p><b>Role</b><br>"
+  "<label><input type='radio' name='ro' value='0'%s>&nbsp;Off</label>&emsp;"
+  "<label><input type='radio' name='ro' value='1'%s>&nbsp;Tag</label>&emsp;"
+  "<label><input type='radio' name='ro' value='2'%s>&nbsp;Anchor</label></p>"
+  "<p><b>UWB Channel</b><br>"
+  "<label><input type='radio' name='ch' value='5'%s>&nbsp;Channel&nbsp;5 (6.5&thinsp;GHz)</label>&emsp;"
+  "<label><input type='radio' name='ch' value='9'%s>&nbsp;Channel&nbsp;9 (8.0&thinsp;GHz)</label></p>"
+  "<p><b>Ranging interval (ms)</b><br>"
+  "<input type='number' name='iv' min='50' max='10000' value='%d'></p>"
+  "<p><b>Antenna delay (ticks)</b><br>"
+  "<input type='number' name='ad' min='10000' max='32767' value='%d'></p>"
+  "<p><b>Anchor ID &mdash; ANCHOR only (0&nbsp;&rarr;&nbsp;0x0002, 1&nbsp;&rarr;&nbsp;0x0003&hellip;)</b><br>"
+  "<input type='number' name='ai' min='0' max='3' value='%d'></p>"
+  "<p><b>Anchor count &mdash; TAG only (round-robin)</b><br>"
+  "<input type='number' name='ac' min='1' max='4' value='%d'></p>"
+  "<p><b>Sliding average filter &mdash; window size (per anchor)</b><br>"
+  "<input type='number' name='fw' min='1' max='10' value='%d'></p>"
+  "<p><label><input type='checkbox' name='as' value='1'%s>&nbsp;"
+  "<b>Auto-start on boot</b></label></p>"
+  "<p><label><input type='checkbox' name='mr' value='1'%s>&nbsp;"
+  "<b>Immediate MQTT publish (outside TelePeriod)</b></label></p>"
+  "</fieldset>"
+  "<br><button name='save' type='submit'>Save</button>"
+  "</form>";
+
+void HandleUwbConfiguration(void) {
+  if (!HttpCheckPriviledgedAccess()) { return; }
+
+  if (Webserver->hasArg("save")) {
+    using namespace UwbDW3000;
+    char sval[8];
+
+    WebGetArg("ro", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint8_t m = (uint8_t)atoi(sval);
+      if (m <= 2) mode = m;
+    }
+
+    WebGetArg("ch", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint8_t ch = (uint8_t)atoi(sval);
+      if (ch == 5 || ch == 9) channel = ch;
+    }
+
+    WebGetArg("iv", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint32_t ms = (uint32_t)atol(sval);
+      if (ms >= 50 && ms <= 10000) intervalMs = ms;
+    }
+
+    WebGetArg("ad", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint32_t ad = (uint32_t)atol(sval);
+      if (ad >= 10000 && ad <= 32767) antennaDelay = (uint16_t)ad;
+    }
+
+    WebGetArg("ai", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint8_t ai = (uint8_t)atoi(sval);
+      if (ai <= 3) anchorId = ai;
+    }
+
+    WebGetArg("ac", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint8_t ac = (uint8_t)atoi(sval);
+      if (ac >= 1 && ac <= UWB_MAX_ANCHORS) anchorCount = ac;
+    }
+
+    WebGetArg("fw", sval, sizeof(sval));
+    if (strlen(sval)) {
+      uint8_t fw = (uint8_t)atoi(sval);
+      if (fw >= 1 && fw <= UWB_FILTER_MAX_WINDOW) {
+        filterWindow = fw;
+        for (uint8_t i = 0; i < UWB_MAX_ANCHORS; i++) filters[i].reset();
+      }
+    }
+
+    autostart    = Webserver->hasArg("as");
+    mqttRealtime = Webserver->hasArg("mr");
+
+    UwbDW3000SaveSettings();
+
+    // Full reinit to apply the new channel/mode
+    ranging.reset();
+    enabled = false;
+    UwbDW3000HardwareInit();
+
+    HandleConfiguration();
+    return;
+  }
+
+  using namespace UwbDW3000;
+  WSContentStart_P(PSTR("Configure UWB"));
+  WSContentSendStyle();
+  WSContentSend_P(HTTP_FORM_UWB,
+    (mode == 0) ? " checked" : "", (mode == 1) ? " checked" : "", (mode == 2) ? " checked" : "",
+    (channel == 5) ? " checked" : "", (channel == 9) ? " checked" : "",
+    (int)intervalMs,
+    (int)antennaDelay,
+    (int)anchorId,
+    (int)anchorCount,
+    (int)filterWindow,
+    autostart    ? " checked" : "",
+    mqttRealtime ? " checked" : ""
+  );
+  WSContentSpaceButton(BUTTON_CONFIGURATION);
+  WSContentStop();
+}
+
+#endif  // USE_WEBSERVER
+
+// ─── Tasmota main dispatcher ─────────────────────────────────────────────────
+
+bool Xsns126(uint32_t function) {
+  bool result = false;
+
+  switch (function) {
+    case FUNC_INIT:
+      UwbDW3000Init();
+      break;
+    case FUNC_LOOP:
+      UwbDW3000Loop();
+      break;
+    case FUNC_EVERY_SECOND:
+      UwbDW3000Every1s();
+      break;
+    case FUNC_JSON_APPEND:
+      UwbDW3000JsonAppend();
+      break;
+    case FUNC_COMMAND:
+      result = DecodeCommand(kUwbCommands, UwbCommand);
+      break;
+    case FUNC_WEB_SENSOR:
+      UwbDW3000ShowSensor();
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_ADD_BUTTON:
+      WSContentSend_P(HTTP_BTN_MENU_UWB);
+      break;
+    case FUNC_WEB_ADD_HANDLER:
+      WebServer_on(PSTR("/" WEB_HANDLE_UWB), HandleUwbConfiguration);
+      break;
+#endif
+  }
+
+  return result;
+}
+
+#endif  // USE_UWB_DW3000


### PR DESCRIPTION
## Description:

Adds xsns_126, a new sensor driver for the Qorvo DW3000 Ultra-Wideband
ranging chip, tested on the Makerfabs ESP32 UWB DW3000 (WROOM) board.

**Capabilities:**
- DS-TWR (Double-Sided Two-Way Ranging) and SS-TWR ranging
- Multi-anchor round-robin ranging (up to 4 anchors, 1 tag)
- Per-anchor sliding average filter (UWBFilterWindow 1\E2\80\9310)
- Immediate MQTT publish on each ranging result (optional, outside TelePeriod)
- Full web UI configuration page with flash persistence
- Tasmota commands: UWBMode, UWBAnchorId, UWBAnchorCount, UWBInterval,
UWBChannel, UWBAntennaDelay, UWBFilterWindow

**JSON MQTT output (TAG, 2 anchors):**
```json
{"UWB":{"Mode":"tag","Channel":5,"Anchor0":234.5,"Anchor1":187.2}}

New files:
- lib/lib_div/DW3000/DW3000Driver.h/.cpp \E2\80\94 Low-level SPI HAL for DW3000
- lib/lib_div/DW3000/DW3000Ranging.h/.cpp \E2\80\94 DS/SS-TWR non-blocking state machine
- tasmota/tasmota_xsns_sensor/xsns_126_uwb_dw3000.ino \E2\80\94 Tasmota sensor driver

Modified files:
- tasmota/include/tasmota_template.h \E2\80\94 GPIO entries for UWB CS/RST/IRQ
- tasmota/include/tasmota_types.h \E2\80\94 Document free_eb0[0..10] reservation
- tasmota/include/tasmota_configurations_ESP32.h \E2\80\94 Enable by default on ESP32
- tasmota/my_user_config.h \E2\80\94 Add USE_UWB_DW3000 flag (commented out) 
- tasmota/language/en_GB.h \E2\80\94 GPIO string definitions

ESP32-only (requires SPI). Not enabled for ESP8266.

Checklist:

- The pull request is done against the latest development branch
- Only relevant files were touched
- Only one feature/fix was added per PR and the code change compiles without warnings
- The code change is tested and works with Tasmota core ESP8266 V.2.7.8
(N/A \E2\80\94 DW3000 requires SPI + ESP32, not applicable to ESP8266)
- The code change is tested and works with Tasmota core ESP32 V.3.3.8
- I accept the CLA.