### PR TITLE
Berry Matter improve async HTTP error handling

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_HTTP_remote.be
@@ -306,7 +306,7 @@ class Matter_HTTP_remote : Matter_HTTP_async
     var ret = super(self).begin_sync(cmd_url, timeout)
     var payload_short = (ret) ? ret : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    log(format("MTR: HTTP sync-resp  in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    log(f"MTR: HTTP {'sync'}-resp in {tasmota.millis() - self.time_start} ms from {self.addr}: [{size(self.payload)}] '{payload_short}'", 3)
     return ret
   end
 
@@ -314,17 +314,17 @@ class Matter_HTTP_remote : Matter_HTTP_async
     if self.current_cmd == nil    return  end       # do nothing if sync request
     var payload_short = (self.payload != nil) ? self.payload : 'nil'
     if size(payload_short) > 30   payload_short = payload_short[0..29] + '...'   end
-    log(format("MTR: HTTP async-resp in %i ms from %s: [%i] '%s'", tasmota.millis() - self.time_start, self.addr, size(self.payload), payload_short), 3)
+    log(f"MTR: HTTP {'async'}-resp in {tasmota.millis() - self.time_start} ms from {self.addr}: [{size(self.payload)}] '{payload_short}'", 3)
     self.dispatch_cb(self.http_status, self.payload)
   end
   def event_http_failed()
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    log("MTR: HTTP failed", 3)
+    log(f"MTR: HTTP failed in={tasmota.millis() - self.time_start} ms from {self.addr}", 3)
     self.dispatch_cb(self.http_status, nil)
   end
   def event_http_timeout()
     if self.current_cmd == nil    return  end       # do nothing if sync request
-    log(format("MTR: HTTP timeout http_status=%i phase=%i tcp_status=%i size_payload=%i", self.http_status, self.phase, self.status, size(self.payload)), 3)
+    log(f"MTR: HTTP timeout in={tasmota.millis() - self.time_start} ms from {self.addr}", 3)
     self.dispatch_cb(self.http_status, nil)
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TCP_async.be
@@ -147,17 +147,15 @@ class Matter_TCP_async
         self.event_refused()
         self.close()
         return
-      elif (tasmota.millis() - self.time_start) > self.timeout
-        # connection timeout
-        self.status = -3
-        self.tcp_connected = false        # force to false
-        self.event_timeout()
       end
+      # if still not connected, fall through to the timeout check below
     end
 
     if (tasmota.millis() - self.time_start) > self.timeout
+      # connection timeout (either while connecting or after established)
       self.close()
       self.status = -3
+      self.tcp_connected = false        # force to false
       self.event_timeout()
       return
     end

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpclientasync.ino
@@ -151,14 +151,14 @@ public:
       res = getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &sockerr, &len);
 
       if (res < 0) {
-        AddLog(LOG_LEVEL_DEBUG, "BRY: getsockopt on fd %d, errno: %d, \"%s\"", sockfd, errno, strerror(errno));
+        AddLog(LOG_LEVEL_DEBUG_MORE, "BRY: getsockopt on fd %d, errno: %d, \"%s\"", sockfd, errno, strerror(errno));
         stop();
         state = AsyncTCPState::REFUSED;
         return;
       }
 
       if (sockerr != 0) {
-        AddLog(LOG_LEVEL_DEBUG, "BRY: socket error on fd %d, errno: %d, \"%s\"", sockfd, sockerr, strerror(sockerr));
+        AddLog(LOG_LEVEL_DEBUG_MORE, "BRY: socket error on fd %d, errno: %d, \"%s\"", sockfd, sockerr, strerror(sockerr));
         stop();
         state = AsyncTCPState::REFUSED;
         return;


### PR DESCRIPTION
## Description:

Berry Matter improve async HTTP error handling.

Now logs look like this in case of errors:
```

22:24:06.230 MTR: HTTP async-resp in 406 ms from 192.168.2.63: [435] '{"StatusSTS":{"Time":"2026-05-...'
22:24:10.568 MTR: HTTP timeout in=1740 ms from 192.168.2.63
22:24:12.097 MTR: HTTP failed in=22 ms from 192.168.2.63
22:24:15.567 MTR: HTTP async-resp in 484 ms from 192.168.2.63: [434] '{"StatusSTS":{"Time":"2026-05-...'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
