### PR TITLE
BearSSL: update SHA functions for breaking change of IDF 5.5

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/hash/_sha_hal_idf5x.c
@@ -54,7 +54,7 @@
 #define HAVE_HAL_SHA512  (SOC_SHA_SUPPORT_SHA512)
 
 static portMUX_TYPE s_sha_mux = portMUX_INITIALIZER_UNLOCKED;
-#define SHA_ENTER()  {portENTER_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(true); sha_ll_reset_register();}
+#define SHA_ENTER()  {portENTER_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(true); sha_ll_reset_register(); sha_ll_set_mode(mode);}
 #define SHA_EXIT()   {portEXIT_CRITICAL(&s_sha_mux); int __DECLARE_RCC_ATOMIC_ENV; sha_ll_enable_bus_clock(false);}
 #define SHA_WAIT()   {while (sha_ll_busy()) { } }
 
@@ -65,24 +65,21 @@ static portMUX_TYPE s_sha_mux = portMUX_INITIALIZER_UNLOCKED;
 
 static void __attribute__((noinline))
 sha_hal_process_block(void *state_buf, const void *blk,
-                      esp_sha_type type, size_t digest_words,
+                      esp_sha_type mode, size_t digest_words,
                       size_t block_words, bool first)
 {
     SHA_ENTER();
-#if defined(CONFIG_IDF_TARGET_ESP32P4) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
-    sha_ll_set_mode(type); // required on P4 in IDF 5.5+
-#endif 
     if (!first) {
-        sha_ll_write_digest(type, state_buf, digest_words);
+        sha_ll_write_digest(mode, state_buf, digest_words);
     }
     sha_ll_fill_text_block(blk, block_words);
     if (first) {
-        sha_ll_start_block(type);
+        sha_ll_start_block(mode);
     } else {
-        sha_ll_continue_block(type);
+        sha_ll_continue_block(mode);
     }
     SHA_WAIT();
-    sha_ll_read_digest(type, state_buf, digest_words);
+    sha_ll_read_digest(mode, state_buf, digest_words);
     SHA_EXIT();
 }
 
@@ -290,7 +287,7 @@ void br_sha224_update(br_sha224_context *cc, const void *data, size_t len)
     if (!len) return;
 
     /* Embedded mode selection by vtable pointer (no desc, no tags) */
-    const int mode = (cc->vtable == &br_sha256_vtable) ? SHA2_256 : SHA2_224;
+    const esp_sha_type mode = (cc->vtable == &br_sha256_vtable) ? SHA2_256 : SHA2_224;
 
     const uint8_t *data_ptr = (const uint8_t *)data;
     const uint8_t *orig_ptr = data_ptr;
@@ -346,7 +343,7 @@ void br_sha224_update(br_sha224_context *cc, const void *data, size_t len)
                 sha_ll_write_digest(mode, midstate_words2, 8);
             }
 
-#if defined(CONFIG_IDF_TARGET_ARCH_RISCV)  /* RISC-V: enforce 8-block (512B) window with checkpointing */
+#if defined(CONFIG_IDF_TARGET_ARCH_RISCV)  /* RISC-V: enforce 8-block (512B) window with checkpointing to prevent hardware overrun.*/
             while (len >= 64) {
                 sha_ll_fill_text_block(data_ptr, 16);
                 sha_ll_continue_block(mode);
@@ -402,7 +399,7 @@ void br_sha256_out(const br_sha256_context *cc, void *out)
     memcpy(saved_state, cc->val, 32);
 
     uint8_t partial_len = (uint8_t)(saved_count & 63U);
-    const int mode = (cc->vtable == &br_sha256_vtable) ? SHA2_256 : SHA2_224;
+    const esp_sha_type mode = (cc->vtable == &br_sha256_vtable) ? SHA2_256 : SHA2_224;
 
     bool midstate_is_iv = (memcmp(saved_state, S256_IV_BYTES, 32) == 0);
     bool no_full_blocks_done = (saved_count < 64);
@@ -528,6 +525,7 @@ void br_sha384_init(br_sha384_context *cc) {
 
 void br_sha384_update(br_sha384_context *cc, const void *data, size_t len) {
     if (!len) return;
+    const esp_sha_type mode = SHA2_512;
     const uint8_t *src = (const uint8_t *)data;
     size_t used = (size_t)(cc->count & 127U);
     uint64_t prior_count = cc->count;
@@ -589,6 +587,7 @@ void br_sha384_update(br_sha384_context *cc, const void *data, size_t len) {
 }
 
 void br_sha384_out(const br_sha384_context *cc, void *out) {
+    const esp_sha_type mode = SHA2_512;
     br_sha384_context ctx = *cc;
     size_t used = (size_t)(ctx.count & 127U);
     uint64_t bit_hi = (uint64_t)(ctx.count >> 61);
@@ -689,6 +688,7 @@ void br_sha512_init(br_sha512_context *cc) {
 }
 
 void br_sha512_out(const br_sha512_context *cc, void *out) {
+    const esp_sha_type mode = SHA2_512;
     br_sha512_context ctx = *cc;
     size_t used = (size_t)(ctx.count & 127U);
     uint64_t bit_hi = (uint64_t)(ctx.count >> 61);

--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -19,10 +19,3 @@ if mcu in ("esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
     build_flags.pop(build_flags.index("-mtarget-align"))
   except:
     pass
-
-# Remove -DUSE_SHA_ROM for esp32s3 (currently not working on this chip)
-if mcu in ("esp32s3"):
-  try:
-    build_flags.pop(build_flags.index("-DUSE_SHA_ROM"))
-  except:
-    pass

--- a/pio-tools/add_c_flags.py
+++ b/pio-tools/add_c_flags.py
@@ -1,7 +1,19 @@
 Import("env")
 
+import json
+from pathlib import Path
+
 build_flags = env['BUILD_FLAGS']
 mcu = env.get("BOARD_MCU").lower()
+framework_dir = env.PioPlatform().get_package_dir("framework-arduinoespressif32")
+
+# Determine IDF version
+idf_major = idf_minor = idf_patch = 0
+pkg_json = Path(framework_dir) / "tools" / "esp32-arduino-libs" / "package.json"
+with pkg_json.open() as f:
+    version_str = json.load(f)["version"].split("+")[0]  # e.g. "5.5.4"
+idf_major, idf_minor, idf_patch = (int(x) for x in version_str.split("."))
+# print(f"IDF version: {idf_major}.{idf_minor}.{idf_patch}")
 
 # General options that are passed to the C++ compiler
 env.Append(CXXFLAGS=["-Wno-volatile"])
@@ -10,12 +22,21 @@ env.Append(CXXFLAGS=["-Wno-volatile"])
 env.Append(CFLAGS=["-Wno-discarded-qualifiers", "-Wno-implicit-function-declaration", "-Wno-incompatible-pointer-types"])
 
 # Remove build flags which are not valid for risc-v
-if mcu in ("esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
+if mcu not in ("esp32", "esp32s2", "esp32s3"):
   try:
     build_flags.pop(build_flags.index("-mno-target-align"))
   except:
     pass
   try:
     build_flags.pop(build_flags.index("-mtarget-align"))
+  except:
+    pass
+
+# Remove -DUSE_SHA_ROM when building with IDF versions earlier than v5.5.4, 
+# as it is not supported in Tasmota code.
+if (idf_major, idf_minor, idf_patch) < (5, 5, 4):
+  try:
+    build_flags.pop(build_flags.index("-DUSE_SHA_ROM"))
+    print("Removed -DUSE_SHA_ROM from build flags for compatibility with IDF versions earlier than v5.5.4")
   except:
     pass

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -30,8 +30,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Dsint16_t=int16_t
                               -Dmemcpy_P=memcpy
                               -Dmemcmp_P=memcmp
-                              ; disable ROM routines, use causes issues with TLS
-                              ;-DUSE_SHA_ROM
+                              ; use of ROM SHA routines is automatically disabled for IDF version earlier v5.5.4
+                              -DUSE_SHA_ROM
                               ;for TLS we can afford compiling for 4K RSA keys
                               -DUSE_4K_RSA
                               -I$PROJECT_DIR/include


### PR DESCRIPTION
## Description:

Related to:
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/5.5/security.html

After doing a similar patch for SHA1 on the ESP32-P4 only, I simply forgot to update the rest of the hw accelerated SHA functions with the update of our frameworks to ESP-IDF >= 5.5.

 In my tests this works on at least S2, S3, C6 and C3 (did not test more), where as I could not really reproduce the error on the C types (although I have seen it once on the C3). The S types had been 100% broken.

I removed the little S3 specific patch from one script, but left the global flag 'DUSE_SHA_ROM' disabled by default, waiting for confirmation of the fix by other testers.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
