### PR TITLE
Fix: TasmotaLEDPusher configuration ignored from user-defines

### DIFF
--- a/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
+++ b/lib/lib_basic/TasmotaLED/src/TasmotaLEDPusher.h
@@ -22,6 +22,9 @@
 
 #include <Arduino.h>
 
+// Include user defines
+#include "tasmota_options.h"
+
 // Below are flags to enable of disable each hardware support: RMT, I2S, SPI
 // By default, only enable RMT support, and SPI is used as fallback if no protocol works
 //


### PR DESCRIPTION
## Description:

The `TasmotaLED` library does not have user-defines include and ignores actual confiuration via `user_config_*.h` files.

Example configuration from documentation is ignored from user-defined config actually:

```cpp
// In your build configuration or before including TasmotaLED
#define TASMOTALED_HARDWARE_RMT 1  // Enable RMT (default: 1)
#define TASMOTALED_HARDWARE_I2S 0  // Enable I2S (default: 0)
#define TASMOTALED_HARDWARE_SPI 0  // Enable SPI (default: 0)
```

Settings can be changed only via `platformio.h` env settings with direct `-DTASMOTALED_HARDWARE_I2S=1` config.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
