### PR TITLE
VsCode: disable auto-trim whitespaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,5 +74,6 @@
         "commands": "platformio-ide.rebuildProjectIndex"
       }
     ],
-    "C_Cpp.dimInactiveRegions": false
+    "C_Cpp.dimInactiveRegions": false,
+    "editor.trimAutoWhitespace": false
   }


### PR DESCRIPTION
## Description:

Saving some files (source code, ini config) generates extremely annoying garbage diff with whitespace changes. Example of such commit: [2a94354](https://github.com/arendst/Tasmota/commit/2a9435449de7ae8939a2a4d57813936b5a38c22d#diff-14b190596cf1e1a8a1688aa4946790e3147e976e1b1a3d3d10d52a44d51b7227).

<img width="1832" height="843" alt="image" src="https://github.com/user-attachments/assets/1f42cd6a-5768-4b4c-817c-89ce2ee41032" />

This PR disables such behavior for VsCode IDE.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
