### PR TITLE
Matter Device non nullable attributes

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
@@ -248,16 +248,16 @@ class Matter_Plugin_Device : Matter_Plugin
     elif cluster == 0x0039             # ========== Bridged Device Basic Information 9.13 p.485 ==========
       import string
 
-      if   attribute == 0x0003          #  ---------- ProductName / string ----------
+      if   attribute == 0x0003          #  ---------- ProductName / string (not nullable) ----------
         if self.BRIDGE
-          var name = self.http_remote.get_info().find("name")
-          return tlv_solo.set_or_nil(0x0C #-TLV.UTF1-#, name)
+          var name = self.http_remote.get_info().find("name", "")
+          return tlv_solo.set(0x0C #-TLV.UTF1-#, name)
         else
           return tlv_solo.set(0x0C #-TLV.UTF1-#, tasmota.cmd("DeviceName", true)['DeviceName'])
         end
       elif attribute == 0x0005          #  ---------- NodeLabel / string ----------
         return tlv_solo.set(0x0C #-TLV.UTF1-#, self.get_name())
-      elif attribute == 0x000A          #  ---------- SoftwareVersionString / string ----------
+      elif attribute == 0x000A          #  ---------- SoftwareVersionString / string (not nullable) ----------
         if self.BRIDGE
           var version_full = self.http_remote.get_info().find("version")
           if version_full
@@ -265,7 +265,7 @@ class Matter_Plugin_Device : Matter_Plugin
             if version_end > 0    version_full = version_full[0..version_end - 1]   end
             return tlv_solo.set(0x0C #-TLV.UTF1-#, version_full)
           else
-            return tlv_solo.set(0x14 #-TLV.NULL-#, nil)
+            return tlv_solo.set(0x0C #-TLV.UTF1-#, "")     # spec is not nullable, return empty until first poll
           end
         else
           var version_full = tasmota.cmd("Status 2", true)['StatusFWR']['Version']
@@ -273,10 +273,10 @@ class Matter_Plugin_Device : Matter_Plugin
           if version_end > 0    version_full = version_full[0..version_end - 1]   end
           return tlv_solo.set(0x0C #-TLV.UTF1-#, version_full)
         end
-      elif attribute == 0x000F || attribute == 0x0012          #  ---------- SerialNumber / string ----------
+      elif attribute == 0x000F || attribute == 0x0012          #  ---------- SerialNumber / UniqueID / string (not nullable) ----------
         if self.BRIDGE
-          var mac = self.http_remote.get_info().find("mac")
-          return tlv_solo.set_or_nil(0x0C #-TLV.UTF1-#, mac)
+          var mac = self.http_remote.get_info().find("mac", "")
+          return tlv_solo.set(0x0C #-TLV.UTF1-#, mac)
         else
           return tlv_solo.set(0x0C #-TLV.UTF1-#, tasmota.wifi().find("mac", ""))
         end


### PR DESCRIPTION
## Description:

Small patch to ensure that non-nullable attributes are never set to nil. It's a tentative to solve a crash of the iOS Google Home app.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
