### PR TITLE
MI32 legacy: unify BLE connection task

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -70,8 +70,7 @@ BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[ii]");
 extern void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
 BE_FUNC_CTYPE_DECLARE(be_BLE_set_characteristic, "", "@s");
 
-extern void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1);
-BE_FUNC_CTYPE_DECLARE(be_BLE_run, "", "@i[bi]");
+extern void be_BLE_run(struct bvm *vm);
 
 extern void be_BLE_store(uint8_t *buf, size_t size);
 BE_FUNC_CTYPE_DECLARE(be_BLE_store, "", "(bytes)~");
@@ -92,7 +91,7 @@ module BLE (scope: global) {
   info,       func(be_BLE_info)
   conn_cb,    ctype_func(be_BLE_reg_conn_cb)
   set_svc,    ctype_func(be_BLE_set_service)
-  run,        ctype_func(be_BLE_run)
+  run,        func(be_BLE_run)
   store,      ctype_func(be_BLE_store)
   set_chr,    ctype_func(be_BLE_set_characteristic)
   adv_cb,     ctype_func(be_BLE_reg_adv_cb)

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -172,7 +172,14 @@ struct MI32connectionContextBerry_t{
   NimBLEUUID charUUID;
   uint16_t returnCharUUID;
   uint16_t handle;
+  uint16_t itvl_min;
+  uint16_t itvl_max;
   uint8_t * buffer;
+  // Reverse-role client (peripheral side). Singleton owned by NimBLEServer
+  // (do NOT pass to NimBLEDevice::deleteClient). Use only for server-side
+  // ACNS-style queries toward the connected central. Set in
+  // MI32ServerCallbacks::onConnect, cleared (not freed) in onDisconnect.
+  NimBLEClient * serverPeer = nullptr;
   uint8_t MAC[6];
   uint8_t operation;
   uint8_t addrType;
@@ -188,7 +195,6 @@ struct {
   // uint32_t period;             // set manually in addition to TELE-period, is set to TELE-period after start
   TaskHandle_t ScanTask = nullptr;
   TaskHandle_t ConnTask = nullptr;
-  TaskHandle_t ServerTask = nullptr;
   MI32connectionContextBerry_t *conCtx = nullptr;
   uint16_t connID;
   union {
@@ -214,14 +220,11 @@ struct {
 
       uint32_t triggerBerryAdvCB:1;
       uint32_t triggerBerryConnCB:1;
-      uint32_t triggerNextConnJob:1;
-      uint32_t readyForNextConnJob:1;
+      uint32_t triggerNextJob:1;
+      uint32_t readyForNextJob:1;
       uint32_t discoverAttributes:1;
 
-      uint32_t triggerNextServerJob:1;
-      uint32_t readyForNextServerJob:1;
-      uint32_t triggerBerryServerCB:1;
-      uint32_t deleteServerTask:1;
+      uint32_t deleteConnectionTask:1; // request server-task teardown (renamed from deleteServerTask)
     };
     uint32_t all = 0;
   } mode;
@@ -245,10 +248,9 @@ struct {
 
   void *beConnCB;
   void *beAdvCB;
-  void *beServerCB;
   uint8_t *beAdvBuf;
   uint8_t infoMsg = 0;
-  uint8_t role = 0;
+  uint8_t role = 0; // bitfield of MI32Role values (concurrently active roles)
 } MI32;
 
 struct mi_sensor_t{
@@ -419,8 +421,6 @@ enum MI32_Commands {          // commands useable in console or rules
 
 enum MI32_TASK {
   MI32_TASK_SCAN = 0,
-  MI32_TASK_CONN = 1,
-  MI32_TASK_SERV = 2,
 };
 
 enum BLE_CLIENT_OP {
@@ -461,6 +461,15 @@ enum MI32_ConnErrorMsg {
   MI32_CONN_CAN_NOT_WRITE,
   MI32_CONN_DID_NOT_WRITE,
   MI32_CONN_NOTIFY_TIMEOUT
+};
+
+// MI32.role bit layout (concurrently-active roles, not mutually exclusive)
+enum MI32Role : uint8_t {
+  MI32_ROLE_NONE       = 0x00,
+  MI32_ROLE_SCAN       = 0x01,
+  MI32_ROLE_CLIENT     = 0x02,
+  MI32_ROLE_SERVER     = 0x04,
+  MI32_ROLE_ADVERTISER = 0x08,
 };
 
 enum MI32_BLEInfoMsg {
@@ -511,8 +520,8 @@ const char HTTP_MI32_POWER_WIDGET[] PROGMEM =
   "<div class='box' id='box%u'>"
    "<h2 style='margin-top:0em;'>Energy"
   "</h2>"
-  "<p>" D_VOLTAGE ": %.1f " D_UNIT_VOLT "</p>"
-  "<p>" D_CURRENT ": %.3f " D_UNIT_AMPERE "</p>";
+  "<p>" D_VOLTAGE ": %s " D_UNIT_VOLT "</p>"
+  "<p>" D_CURRENT ": %s " D_UNIT_AMPERE "</p>";
 #endif //USE_MI_ESP32_ENERGY
 
 /*

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -805,9 +805,6 @@ bool HttpCheckPriviledgedAccess(bool autorequestauth = true) {
     AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_HTTP "Referer '%s' denied. Use 'SO128 1' for HTTP API commands. 'Webpassword' is recommended."), referer.c_str());
     return false;
   } else {
-#if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
-    MI32suspendScanTask();
-#endif // defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
     return true;
   }
 }
@@ -1212,9 +1209,6 @@ void WSContentEnd(void) {
   }
 
   Webserver->client().stop();
-#if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
-  MI32resumeScanTask();
-#endif // defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
 }
 
 /*-------------------------------------------------------------------------------------------*/

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -107,7 +107,7 @@ extern "C" {
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
   extern void MI32setBerryServerCB(void* function, uint8_t *buffer);
-  extern bool MI32runBerryConnection(uint8_t operation, bbool response, int32_t *arg1);
+  extern bool MI32runBerryConnection(uint8_t operation, bbool response, bbool hasArg1, int32_t arg1);
   extern bool MI32setBerryCtxSvc(const char *Svc, bbool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
   extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type, uint32_t pin);
@@ -196,22 +196,36 @@ extern "C" {
     be_raisef(vm, "ble_error", "BLE: could not set characteristic");
   }
 
-  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1);
-  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response, int32_t arg1){
-    int32_t argc = be_top(vm); // Get the number of arguments
-    bool _response = false;
-    if(response){
-      _response = response;
-    }
-    int32_t *ptr_arg1 = nullptr;
-    int32_t _arg1 = arg1;
-    if(argc == 3){
-      ptr_arg1 = &_arg1;
-    }
-    if (MI32runBerryConnection(operation, _response, ptr_arg1)) return;
+int be_BLE_run(bvm *vm);
+int be_BLE_run(bvm *vm) {
+  int argc = be_top(vm);
 
-    be_raisef(vm, "ble_error", "BLE: could not run operation");
+  if (argc < 1 || !be_isint(vm, 1)) {
+    be_raise(vm, "value_error", "BLE.run: wrong arguments");
+    be_return_nil(vm);
   }
+
+  uint8_t operation = (uint8_t) be_toint(vm, 1);
+
+  bool response = false;
+  if (argc >= 2) {
+    response = be_tobool(vm, 2);
+  }
+
+  int32_t arg1 = 0;
+  bool hasArg1 = false;
+  if (argc >= 3) {
+      arg1 = (int32_t) be_toint(vm, 3);
+      hasArg1 = true;
+  }
+
+  if (MI32runBerryConnection(operation, response, hasArg1, arg1)) {
+    be_return_nil(vm);
+  }
+
+  be_raisef(vm, "ble_error", "BLE: could not run operation");
+  be_return_nil(vm);
+}
 
   void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
   void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){
@@ -278,7 +292,7 @@ extern "C" {
 // #else
 //     be_map_insert_nil(vm, "bonds");
 // #endif
-    if(MI32.mode.connected == 1 || MI32.ServerTask != nullptr){
+    if(MI32.mode.connected == 1 || (MI32.role & MI32_ROLE_SERVER)){
       NimBLEClient* _device = nullptr;
       if(MI32.mode.connected == 1){
         _device = NimBLEDevice::getClientByHandle(MI32.connID);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -17,36 +17,6 @@
 
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
-  --------------------------------------------------------------------------------------------
-  Version yyyymmdd  Action    Description
-  --------------------------------------------------------------------------------------------
-  0.9.5.6 20221006  changed - remove old HASS code, allow adding unknown sensors, prepare YLAI003
-  -------
-  0.9.5.5 20220326  changed - refactored connection task for asynchronous op, add response option,
-                              fixed MI32Key command
-  -------
-  0.9.5.4 20220325  changed - add Berry adv_watch and adv_block to BLE class
-  -------
-  0.9.5.3 20220315  changed - reworked Berry part, active scanning and holding active connections possible, new format of advertisement buffer
-  -------
-  0.9.5.1 20220209  changed - rename YEERC to YLYK01, add dimmer YLKG08 (incl. YLKG07), change button report scheme
-  -------
-  0.9.5.0 20211016  changed - major rewrite, added mi32cfg (file and command), Homekit-Bridge,
-                              extended GUI,
-                              removed BLOCK, PERIOD, TIME, UNIT, BATTERY and PAGE -> replaced via Berry-Support
-  -------
-  0.9.1.7 20201116  changed - small bugfixes, add BLOCK and OPTION command, send BLE scan via MQTT
-  -------
-  0.9.1.0 20200712  changed - add lights and YLYK01, add pure passive mode with decryption,
-                              lots of refactoring
-  -------
-  0.9.0.1 20200706  changed - adapt to new NimBLE-API, tweak scan process
-  -------
-  0.9.0.0 20200413  started - initial development by Christian Baars
-                    forked  - from arendst/tasmota            - https://github.com/arendst/Tasmota
-
 */
 #ifndef USE_BLE_ESP32
 #ifdef ESP32                       // ESP32 only. Use define USE_HM10 for ESP8266 support
@@ -79,6 +49,11 @@ void MI32notifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* pD
 void MI32AddKey(mi_bindKey_t keyMAC);
 void MI32HandleEveryDevice(const NimBLEAdvertisedDevice* advertisedDevice, uint8_t addr[6], int RSSI);
 void MI32parseBTHomePacket(char * _buf, uint32_t length, uint8_t addr[6], int RSSI, std::string_view optionalName);
+void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servicesToStart, bool &shallStartServices);
+void MI32ServerSetCharacteristic(NimBLEServer *pServer, std::vector<NimBLEService*>& servicesToStart, bool &shallStartServices);
+void MI32ConnectionTask(void *pvParameters);
+static void MI32EnsureServerInstance(NimBLEServer *&pServer);
+static void MI32RunClientOp();
 
 std::vector<mi_sensor_t> MIBLEsensors;
 RingbufHandle_t BLERingBufferQueue = nullptr;
@@ -92,7 +67,10 @@ static NimBLEClient* MI32Client;
 
 class MI32SensorCallback : public NimBLEClientCallbacks {
   void onConnect(NimBLEClient* pclient) {
-    // AddLog(LOG_LEVEL_DEBUG,PSTR("connected %s"), MI32getDeviceName(MI32.conCtx->slot));
+    if (MI32.role & MI32_ROLE_SERVER) { // accepted-link bridge: don't hijack client-mode dispatch
+      MI32.connID = pclient->getConnHandle();
+      return;
+    }
     MI32.infoMsg = MI32_DID_CONNECT;
     MI32.mode.willConnect = 0;
     MI32.mode.connected = 1;
@@ -100,12 +78,15 @@ class MI32SensorCallback : public NimBLEClientCallbacks {
     pclient->updateConnParams(8,16,0,1000);
   }
   void onDisconnect(NimBLEClient* pclient, int reason) {
+    if (MI32.role & MI32_ROLE_SERVER) { // accepted-link bridge: server owns the connection lifecycle
+      return;
+    }
     MI32.mode.connected = 0;
+    MI32.role &= ~MI32_ROLE_CLIENT;
     MI32.infoMsg = MI32_DID_DISCONNECT;
     MI32.conCtx->error = reason;
     MI32.conCtx->operation = 5; //set for all disconnects that come from the remote device or connection loss
     MI32.mode.triggerBerryConnCB = 1;
-    //AddLog(LOG_LEVEL_DEBUG,PSTR("disconnected"));
   }
   void onPassKeyEntry(NimBLEConnInfo& connInfo) {
     NimBLEDevice::injectPassKey(connInfo, MI32.conCtx->pin);
@@ -120,10 +101,6 @@ class MI32AdvCallbacks: public NimBLEScanCallbacks {
   }
 
   void IRAM_ATTR onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
-    static bool _mutex = false;
-    if(_mutex) return;
-    _mutex = true;
-
     const int RSSI = advertisedDevice->getRSSI();
     alignas(4) uint8_t addr[6];
     memcpy(addr,advertisedDevice->getAddress().getVal(),6);
@@ -145,7 +122,6 @@ class MI32AdvCallbacks: public NimBLEScanCallbacks {
       if(MI32.option.handleEveryDevice == 1) {
         MI32HandleEveryDevice(advertisedDevice, addr, RSSI);
       }
-      _mutex = false;
       return;
     }
 
@@ -167,7 +143,6 @@ class MI32AdvCallbacks: public NimBLEScanCallbacks {
     else if(MI32.option.handleEveryDevice == 1) {
         MI32HandleEveryDevice(advertisedDevice, addr, RSSI);
     }
-  _mutex = false;
   };
 };
 
@@ -182,6 +157,11 @@ class MI32ServerCallbacks: public NimBLEServerCallbacks {
         memcpy(item.buffer,connInfo.getAddress().getVal(),6);
         xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + 6 , pdMS_TO_TICKS(1));
         MI32.infoMsg = MI32_SERV_CLIENT_CONNECTED;
+        if(MI32.conCtx == nullptr) return;
+        MI32.conCtx->serverPeer = pServer->getClient(connInfo); // Singleton - do NOT delete via NimBLEDevice::deleteClient.
+        if(MI32.conCtx->itvl_min != 0 && MI32.conCtx->itvl_max != 0){
+          pServer->updateConnParams(connInfo.getConnHandle(), MI32.conCtx->itvl_min >> 1, MI32.conCtx->itvl_max >> 1, 0, 400);
+        }
     };
     void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
         struct{
@@ -189,9 +169,13 @@ class MI32ServerCallbacks: public NimBLEServerCallbacks {
         } item;
         item.header.length = 0;
         item.header.type = BLE_OP_ON_DISCONNECT;
-        memset(MI32.conCtx->MAC,0,6);
         xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t), pdMS_TO_TICKS(1));
         MI32.infoMsg = MI32_SERV_CLIENT_DISCONNECTED;
+        if(MI32.conCtx == nullptr) return;
+        memset(MI32.conCtx->MAC,0,6);
+        // Reverse-role client cleanup: pServer owns the singleton, just drop our
+        // borrowed pointer. Never call NimBLEDevice::deleteClient on it.
+        MI32.conCtx->serverPeer = nullptr;
 #ifdef CONFIG_BT_NIMBLE_EXT_ADV
         NimBLEDevice::startAdvertising(0);
 #else
@@ -199,16 +183,30 @@ class MI32ServerCallbacks: public NimBLEServerCallbacks {
 #endif
     };
     void onAuthenticationComplete(NimBLEConnInfo& connInfo) {
+      constexpr size_t security_record_size = sizeof(ble_store_value_sec);
       struct{
         BLERingBufferItem_t header;
-        uint8_t buffer[sizeof(ble_store_value_sec)];
+        uint8_t buffer[2 * security_record_size];
       } item;
-      item.header.length = sizeof(ble_store_value_sec);
+      ble_store_value_sec our_security_record;
+      ble_store_value_sec peer_security_record;
+      memset(&our_security_record, 0, security_record_size);
+      memset(&peer_security_record, 0, security_record_size);
+      ble_gap_conn_desc connection_desc;
+      if (ble_gap_conn_find(connInfo.getConnHandle(), &connection_desc) != 0) {
+        MI32.infoMsg = MI32_SERV_CLIENT_AUTHENTICATED;
+        return;
+      }
+      ble_store_key_sec security_key;
+      memset(&security_key, 0, sizeof(security_key));
+      security_key.peer_addr = connection_desc.peer_id_addr;
+      ble_store_read_our_sec(&security_key, &our_security_record);
+      ble_store_read_peer_sec(&security_key, &peer_security_record);
+      memcpy(item.buffer, &our_security_record, security_record_size);
+      memcpy(item.buffer + security_record_size, &peer_security_record, security_record_size);
+      item.header.length = 2 * security_record_size;
       item.header.type = BLE_OP_ON_AUTHENTICATED;
-      ble_store_value_sec value_sec;
-      ble_sm_read_bond(connInfo.getConnHandle(), &value_sec);
-      memcpy(item.buffer,(uint8_t*)&value_sec,sizeof(ble_store_value_sec));
-      xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t), pdMS_TO_TICKS(1));
+      xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + item.header.length, pdMS_TO_TICKS(1));
       MI32.infoMsg = MI32_SERV_CLIENT_AUTHENTICATED;
     }
 };
@@ -230,11 +228,15 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
           BLERingBufferItem_t header;
           uint8_t buffer[255];
         } item;
-        item.header.length = pCharacteristic->getValue().size();
+        // Negotiated MTU can be > default 23, so cap to buffer size to prevent
+        // stack overflow on peers that write a large value at once.
+        size_t valSize = pCharacteristic->getValue().size();
+        if(valSize > sizeof(item.buffer)) valSize = sizeof(item.buffer);
+        item.header.length = valSize;
         item.header.type = BLE_OP_ON_WRITE;
         item.header.returnCharUUID = *reinterpret_cast<const uint16_t*>(pCharacteristic->getUUID().getValue() + 12);
         item.header.handle = pCharacteristic->getHandle();
-        memcpy(item.buffer,pCharacteristic->getValue().data(),pCharacteristic->getValue().size());
+        memcpy(item.buffer,pCharacteristic->getValue().data(),valSize);
         xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + item.header.length , pdMS_TO_TICKS(1));
     };
 
@@ -259,7 +261,9 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
           BLERingBufferItem_t header;
         } item;
         item.header.length = 0;
-        item.header.type = BLE_OP_ON_UNSUBSCRIBE + subValue;;
+        // op = BLE_OP_ON_UNSUBSCRIBE + CCCD subValue: 224 = unsubscribe (0),
+        // 225 = notify (1), 226 = indicate (2). Berry receives the raw op number.
+        item.header.type = BLE_OP_ON_UNSUBSCRIBE + subValue;
         item.header.returnCharUUID = *reinterpret_cast<const uint16_t*>(pCharacteristic->getUUID().getValue() + 12);
         item.header.handle = pCharacteristic->getHandle();
         xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t), pdMS_TO_TICKS(1));
@@ -268,13 +272,17 @@ class MI32CharacteristicCallbacks: public NimBLECharacteristicCallbacks {
 
 
 void MI32notifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify){
+  AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: notifyCB uuid=%04x handle=%u len=%u isNotify=%u"),
+    *reinterpret_cast<const uint16_t*>(pRemoteCharacteristic->getUUID().getValue() + 12),
+    pRemoteCharacteristic->getHandle(), (unsigned)length, (unsigned)isNotify);
   if(isNotify){
     struct{
       BLERingBufferItem_t header;
       uint8_t buffer[255];
     } item;
+    if(length > sizeof(item.buffer)) length = sizeof(item.buffer); // Cap notification payload 
     item.header.length = length;
-    // item.header.type = 103;  does not matter for now
+    item.header.type = 103; // notification op for serv_cb dispatch in bridge mode (role==3)
     memcpy(item.buffer,pData,length);
     item.header.returnCharUUID = *reinterpret_cast<const uint16_t*>(pRemoteCharacteristic->getUUID().getValue() + 12);
     item.header.handle = pRemoteCharacteristic->getHandle();
@@ -717,7 +725,7 @@ void MI32Init(void) {
     const std::string name(TasmotaGlobal.hostname);
     NimBLEDevice::init(name);
     #ifdef CONFIG_BT_NIMBLE_NVS_PERSIST
-      NimBLEDevice::setSecurityAuth(true, true, true);
+      NimBLEDevice::setSecurityAuth(true, false, true); // with BLE_HS_IO_NO_INPUT_OUTPUT
     #else
       NimBLEDevice::setSecurityAuth(false, true, true);
       NimBLEDevice::setSecurityIOCap(BLE_HS_IO_KEYBOARD_DISPLAY);
@@ -725,7 +733,7 @@ void MI32Init(void) {
 
     AddLog(LOG_LEVEL_INFO,PSTR("M32: Init BLE device: %s"),TasmotaGlobal.hostname);
     MI32.mode.init = 1;
-    MI32.mode.readyForNextConnJob = 1;
+    MI32.mode.readyForNextJob = 1;
     MI32StartTask(MI32_TASK_SCAN); // Let's get started !!
   }
 
@@ -746,11 +754,15 @@ extern "C" {
   }
 
   void MI32setBerryStoreRec(uint8_t *buffer, size_t size){
-    constexpr size_t sec_size = sizeof(ble_store_value_sec);
-    if(sec_size == size){
-      ble_store_write_peer_sec((const struct ble_store_value_sec*)&buffer);
-      AddLog(LOG_LEVEL_INFO,PSTR("BLE: write peer"));
+    constexpr size_t security_record_size = sizeof(ble_store_value_sec);
+    if(size != 2 * security_record_size){
+      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: bond blob size %u unexpected"), (unsigned)size);
+      return;
     }
+    // Layout matches onAuthenticationComplete: [our_sec][peer_sec].
+    int our_result = ble_store_write_our_sec((const struct ble_store_value_sec*)buffer);
+    int peer_result = ble_store_write_peer_sec((const struct ble_store_value_sec*)(buffer + security_record_size));
+    AddLog(LOG_LEVEL_INFO,PSTR("BLE: restore bond our=%d peer=%d"), our_result, peer_result);
   }
 
   bool MI32runBerryConfig(uint16_t operation){
@@ -776,12 +788,12 @@ extern "C" {
       case 232: // set adv params via bytes() descriptor of size 5,
         #ifndef CONFIG_BT_NIMBLE_EXT_ADV
         if(MI32.conCtx->buffer[0] == 5){
-          uint16_t itvl_min = MI32.conCtx->buffer[2] + (MI32.conCtx->buffer[3] << 8);
-          uint16_t itvl_max = MI32.conCtx->buffer[4] + (MI32.conCtx->buffer[5] << 8);
+          MI32.conCtx->itvl_min = MI32.conCtx->buffer[2] + (MI32.conCtx->buffer[3] << 8);
+          MI32.conCtx->itvl_max = MI32.conCtx->buffer[4] + (MI32.conCtx->buffer[5] << 8);
           pAdvertising->setConnectableMode(MI32.conCtx->buffer[1]);
-          pAdvertising->setMinInterval(itvl_min);
-          pAdvertising->setMaxInterval(itvl_max);
-          AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: adv params: type: %u, min: %u, max: %u"),MI32.conCtx->buffer[1], (uint16_t)(itvl_min * 0.625), (uint16_t)(itvl_max * 0.625)) ;
+          pAdvertising->setMinInterval(MI32.conCtx->itvl_min);
+          pAdvertising->setMaxInterval(MI32.conCtx->itvl_max);
+          AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: adv params: type: %u, min: %u, max: %u"),MI32.conCtx->buffer[1], (uint16_t)(MI32.conCtx->itvl_min * 0.625), (uint16_t)(MI32.conCtx->itvl_max * 0.625)) ;
           success = true;
         }
         #endif //CONFIG_BT_NIMBLE_EXT_ADV
@@ -795,82 +807,92 @@ extern "C" {
     return success;
   }
 
-  bool MI32runBerryServer(uint16_t operation){
-    if(operation > 230){
-      return MI32runBerryConfig(operation);
-    }
-    MI32.conCtx->operation = operation;
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Berry server op: %d, response: %u"),MI32.conCtx->operation, MI32.conCtx->response);
-    if(MI32.mode.readyForNextServerJob == 0){
-      MI32.mode.triggerNextServerJob = 0;
-      AddLog(LOG_LEVEL_DEBUG,PSTR("M32: old server job not finished yet!!"));
-      return false;
-    }
-    MI32.mode.triggerNextServerJob = 1;
-    return true;
-  }
-
-  bool MI32runBerryConnection(uint8_t operation, bool response, int32_t* arg1){
-    if(MI32.conCtx != nullptr){
-      if(arg1 != nullptr){
-        MI32.conCtx->arg1 = *arg1;
-        MI32.conCtx->hasArg1 = true;
-        AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: arg1: %u"),MI32.conCtx->arg1);
-      }
-      else{
-        MI32.conCtx->hasArg1 = false;
-      }
-      MI32.conCtx->response = response;
-      if(operation > 200){
-        return MI32runBerryServer(operation);
-      }
-      MI32.conCtx->oneOp = (operation > 9);
-      MI32.conCtx->operation = operation%10;
-      AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Berry connection op: %d, addrType: %d, oneOp: %u, response: %u"),MI32.conCtx->operation, MI32.conCtx->addrType, MI32.conCtx->oneOp, MI32.conCtx->response);
-      if(MI32.conCtx->oneOp){
-        MI32StartConnectionTask();
-      }
-      else{
-        if(MI32.mode.connected){
-          AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: continue connection job"));
-          MI32.mode.triggerNextConnJob = 1;
-          if(!MI32.mode.readyForNextConnJob){
-            AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: old connection job not finished yet!!"));
-          }
-        }
-        else{
-          MI32StartConnectionTask(); //first job of many or unexpected disconnect
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  void MI32setBerryConnCB(void* function, uint8_t *buffer){
-    if(MI32.conCtx == nullptr){
-      MI32.conCtx = new MI32connectionContextBerry_t;
-    }
-    MI32.conCtx->buffer = buffer;
-    MI32.beConnCB = function;
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: Connection Ctx created"));
-  }
-
-  void MI32setBerryServerCB(void* function, uint8_t *buffer){
-    if(function == nullptr || buffer == nullptr)
-    {
-      MI32.mode.deleteServerTask = 1;
-      MI32.beServerCB = nullptr;
-      AddLog(LOG_LEVEL_INFO,PSTR("BLE: Server session stopping"));
-      return;
-    }
+  // Shared conCtx allocation/buffer-update for both Berry CB setters.
+  static void MI32ensureConCtx(uint8_t *buffer){
     if(MI32.conCtx == nullptr){
       MI32.conCtx = new MI32connectionContextBerry_t{};
     }
     MI32.conCtx->buffer = buffer;
-    MI32.beServerCB = function;
-    MI32StartTask(MI32_TASK_SERV);
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: Server Ctx created"));
+  }
+
+  // Single Berry entry point for both client- and server-side BLE ops.
+  // The unified MI32ConnectionTask is launched once at conn_cb registration;
+  // here we only stage conCtx fields and signal triggerNextJob.
+  bool MI32runBerryConnection(uint8_t operation, bool response, bool hasArg1, int32_t arg1){
+    if(MI32.conCtx == nullptr){
+      return false;
+    }
+    MI32.conCtx->arg1 = arg1;
+    MI32.conCtx->hasArg1 = hasArg1;
+    MI32.conCtx->response = response;
+    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: arg1: %u"),MI32.conCtx->arg1);
+
+    if(operation > 230){ // 231..233: runtime config helpers, executed inline
+      return MI32runBerryConfig(operation);
+    }
+    if(operation > 200){ // server op (SET_ADV / SCAN_RESP / SET_CHARACTERISTIC)
+      MI32.conCtx->operation = operation;
+      MI32.conCtx->oneOp = false;
+    }
+    else{
+      MI32.conCtx->oneOp = (operation > 9);
+      MI32.conCtx->operation = operation%10;
+      if(MI32.role & MI32_ROLE_SERVER){
+        // accepted-link bridge: never tear down on oneOp completion
+        MI32.conCtx->oneOp = false;
+      }
+    }
+    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Berry op: %d, addrType: %d, oneOp: %u, response: %u"),
+           MI32.conCtx->operation, MI32.conCtx->addrType, MI32.conCtx->oneOp, MI32.conCtx->response);
+
+    if(MI32.ConnTask == nullptr){
+      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: connection task not running - register conn_cb first"));
+      return false;
+    }
+    if(MI32.mode.readyForNextJob == 0){
+      AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: previous job not finished yet"));
+    }
+    MI32.mode.triggerNextJob = 1;
+    return true;
+  }
+
+  void MI32setBerryConnCB(void* function, uint8_t *buffer){
+    if(function == nullptr || buffer == nullptr){
+      MI32.mode.deleteConnectionTask = 1; // request task teardown if alive
+      MI32.beConnCB = nullptr;
+      AddLog(LOG_LEVEL_INFO,PSTR("BLE: Connection callback cleared"));
+      return;
+    }
+    MI32ensureConCtx(buffer);
+    MI32.beConnCB = function;
+    if(MI32.ConnTask != nullptr){
+      // re-registration: keep the running task, just refresh cb/buffer
+      AddLog(LOG_LEVEL_INFO,PSTR("BLE: Connection callback re-registered"));
+      return;
+    }
+    if(BLERingBufferQueue == nullptr){
+      BLERingBufferQueue = xRingbufferCreate(4096, RINGBUF_TYPE_NOSPLIT);
+      if(!BLERingBufferQueue){
+        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed to create ringbuffer queue"));
+        return;
+      }
+    }
+    MI32.mode.readyForNextJob   = 0; // task will set to 1 on entry
+    MI32.mode.triggerNextJob    = 0;
+    MI32.mode.deleteConnectionTask = 0;
+    xTaskCreatePinnedToCore(
+      MI32ConnectionTask,    /* Function to implement the task */
+      "MI32ConnectionTask",  /* Name of the task */
+      8192,                  /* Stack size in words */
+      NULL,                  /* Task input parameter */
+      2,                     /* Priority */
+      &MI32.ConnTask,        /* Task handle */
+      0);                    /* Core */
+    AddLog(LOG_LEVEL_INFO,PSTR("BLE: Connection task started"));
+  }
+
+  void MI32setBerryServerCB(void* function, uint8_t *buffer){ //deprecated!
+    MI32setBerryConnCB(function, buffer);
   }
 
   bool MI32setBerryCtxSvc(const char *Svc, bool discoverAttributes){
@@ -935,21 +957,21 @@ extern "C" {
   }
 
   void MI32setBatteryForSlot(uint32_t slot, uint8_t value){
-    if(slot>MIBLEsensors.size()-1) return;
+    if(slot >= MIBLEsensors.size()) return;
     if(MIBLEsensors[slot].feature.bat){
       MIBLEsensors[slot].bat = value;
     }
   }
 
   void MI32setHumidityForSlot(uint32_t slot, float value){
-    if(slot>MIBLEsensors.size()-1) return;
+    if(slot >= MIBLEsensors.size()) return;
     if(MIBLEsensors[slot].feature.hum){
       MIBLEsensors[slot].hum = value;
     }
   }
 
   void MI32setTemperatureForSlot(uint32_t slot, float value){
-    if(slot>MIBLEsensors.size()-1) return;
+    if(slot >= MIBLEsensors.size()) return;
     if(MIBLEsensors[slot].feature.temp){
       MIBLEsensors[slot].temp = value;
     }
@@ -960,20 +982,21 @@ extern "C" {
   }
 
   uint8_t * MI32getDeviceMAC(uint32_t slot){
-    if(slot>MIBLEsensors.size()-1) return NULL;
+    if(slot >= MIBLEsensors.size()) return NULL;
     return MIBLEsensors[slot].MAC;
   }
 
   char * MI32getDeviceName(uint32_t slot){
+    if(slot >= MIBLEsensors.size()) return (char*)"";
     if(MIBLEsensors[slot].name != nullptr){
       return MIBLEsensors[slot].name;
     }
-    static char _name[12];
+    thread_local char _name[12];
     if( MIBLEsensors[slot].type == UNKNOWN_MI){
       if(MIBLEsensors[slot].PID == 0){
-        snprintf_P(_name,8,PSTR("BLE_%02u"),slot);
+        snprintf_P(_name,sizeof(_name),PSTR("BLE_%02u"),slot);
       } else {
-        snprintf_P(_name,8,PSTR("MI_%04X"),MIBLEsensors[slot].PID);
+        snprintf_P(_name,sizeof(_name),PSTR("MI_%04X"),MIBLEsensors[slot].PID);
       }
     }
     else{
@@ -1033,7 +1056,7 @@ void MI32loadCfg(){
       JsonParserArray arr = root.getArray();
       if (!arr) {AddLog(LOG_LEVEL_INFO,PSTR("M32: invalid array object"));; }
       bool _error;
-      int32_t _numberOfDevices;
+      int32_t _numberOfDevices = -1; // slot of the last successfully parsed MAC/PID; -1 = none yet
       for (auto _dev  : arr) {
           AddLog(LOG_LEVEL_INFO,PSTR("M32: found device in config file"));
           JsonParserObject _device = _dev.getObject();
@@ -1066,6 +1089,8 @@ void MI32loadCfg(){
                 _error = false;
               }
           }
+          // Subsequent fields only valid if MAC+PID parsed successfully above.
+          if(_numberOfDevices < 0) continue;
           _val = _device[PSTR("key")];
           if (_val) {
             char *_keyStr = (char *)_val.getStr();
@@ -1148,30 +1173,12 @@ void MI32saveConfig(){
  * Task section
 \*********************************************************************************************/
 
-void MI32suspendScanTask(void){
-  if (MI32.ScanTask != nullptr && MI32.mode.runningScan == 1) vTaskSuspend(MI32.ScanTask);
-}
-
-void MI32resumeScanTask(void){
-  if (MI32.ScanTask != nullptr && MI32.mode.runningScan == 1) vTaskResume(MI32.ScanTask);
-}
-
 void MI32StartTask(uint32_t task){
   if (MI32.mode.willConnect == 1) return; // we are in the middle of connecting to something ... do not interrupt this.
-  MI32.role = 0;
   switch(task){
     case MI32_TASK_SCAN:
       if (MI32.mode.connected == 1) return;
       MI32StartScanTask();
-      break;
-    case MI32_TASK_CONN:
-      if (MI32.mode.canConnect == 0) return;
-      MI32.mode.deleteScanTask = 1;
-      MI32StartConnectionTask();
-      break;
-    case MI32_TASK_SERV:
-      MI32.mode.deleteScanTask = 1;
-      MI32StartServerTask();
       break;
     default:
       break;
@@ -1182,10 +1189,18 @@ void MI32StartTask(uint32_t task){
 
 void MI32StartScanTask(){
     if (MI32.mode.connected == 1) return;
-    if(MI32.ScanTask!=nullptr) vTaskDelete(MI32.ScanTask);
+    if(MI32.ScanTask != nullptr){
+      MI32.mode.deleteScanTask = 1;
+      uint32_t _waitMs = 0;
+      while(MI32.ScanTask != nullptr && _waitMs < 1000){
+        vTaskDelay(20 / portTICK_PERIOD_MS);
+        _waitMs += 20;
+      }
+      if(MI32.ScanTask != nullptr) return; // bail rather than hard-kill
+    }
     MI32.mode.runningScan = 1;
     MI32.mode.deleteScanTask = 0;
-    MI32.role = 1;
+    MI32.role |= MI32_ROLE_SCAN;
     xTaskCreatePinnedToCore(
     MI32ScanTask,    /* Function to implement the task */
     "MI32ScanTask",  /* Name of the task */
@@ -1236,48 +1251,11 @@ void MI32ScanTask(void *pvParameters){
     }
   }
   MI32.mode.deleteScanTask = 0;
+  MI32.role &= ~MI32_ROLE_SCAN;
   vTaskDelete( NULL );
 }
 
 // connection task section
-
-bool MI32ConnectActiveSensor(){ // only use inside a task !!
-  if(MI32.conCtx->operation == 5) {
-    return false;
-  }
-  NimBLEAddress _address = NimBLEAddress(MI32.conCtx->MAC, MI32.conCtx->addrType);
-  if(MI32Client != nullptr){
-    if(MI32Client->isConnected() && MI32.mode.connected == 1){ //we only accept a "clean" state without obvious packet losses
-      if(MI32.conCtx->operation == 5){ //5 is the disconnect operation
-        NimBLEDevice::deleteClient(MI32Client); // disconnect the old
-        return false; // request disconnect
-      }
-      if(MI32Client->getPeerAddress() == _address){
-        MI32.infoMsg = MI32_STILL_CONNECTED;
-        return true; // still connected -> keep it
-      }
-      else{
-        // AddLog(LOG_LEVEL_ERROR,PSTR("M32: disconnect %s"),MI32Client->getPeerAddress().toString().c_str());
-        NimBLEDevice::deleteClient(MI32Client); // disconnect the old and connect the new
-      }
-    }
-  }
-
-  MI32Client = nullptr;
-  if(NimBLEDevice::getCreatedClientCount() > 0) {
-    MI32Client = NimBLEDevice::getClientByPeerAddress(_address);
-  }
-  if (!MI32Client){
-    MI32Client = NimBLEDevice::createClient(_address);
-    MI32Client->setClientCallbacks(&MI32SensorCB , false);
-  }
-  if (!MI32Client->connect(false)) {
-      NimBLEDevice::deleteClient(MI32Client);
-      // AddLog(LOG_LEVEL_ERROR,PSTR("M32: did not connect client"));
-      return false;
-  }
-  return true;
-}
 
 /**
  * @brief Retrieves all services of the connected BLE device and stores the result into the transfer buffer of Berry's BLE module
@@ -1338,239 +1316,333 @@ void MI32ConnectionGetCharacteristics(NimBLERemoteService* pSvc){
   MI32.conCtx->buffer[0] = i;
 }
 
-bool MI32StartConnectionTask(){
-    if(MI32.conCtx == nullptr) return false;
-    if(MI32.conCtx->buffer == nullptr) return false;
-    MI32.mode.willConnect = 1;
-    MI32Scan->stop();
-    MI32suspendScanTask();
-    MI32.role = 2;
-    xTaskCreatePinnedToCore(
-      MI32ConnectionTask,    /* Function to implement the task */
-      "MI32ConnectionTask",  /* Name of the task */
-      4096,             /* Stack size in words */
-      NULL,             /* Task input parameter */
-      2,                /* Priority of the task */
-      &MI32.ConnTask,   /* Task handle. */
-      0);               /* Core where the task should run */
-    return true;
-}
-
-void MI32ConnectionTask(void *pvParameters){
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) || !defined(CONFIG_IDF_TARGET_ESP32C5) || !defined(CONFIG_IDF_TARGET_ESP32C6) //needs more testing ...
-    // NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM,false); //seems to be important for i.e. xbox controller, hopefully not breaking other things
-#endif //CONFIG_IDF_TARGET_ESP32C3
-    MI32.conCtx->error = MI32_CONN_NO_ERROR;
-    if (MI32ConnectActiveSensor()){
-      if (BLERingBufferQueue == nullptr){
-        BLERingBufferQueue = xRingbufferCreate(2048, RINGBUF_TYPE_NOSPLIT);
-      }
-      MI32.mode.readingDone = 0;
-      uint32_t timer = 0;
-      while (MI32.mode.connected == 0){
-        if (timer>1000){
-          MI32Client->disconnect();
-          NimBLEDevice::deleteClient(MI32Client);
-          MI32.mode.willConnect = 0;
-          MI32.mode.triggerBerryConnCB = 1;
-          MI32.conCtx->error = MI32_CONN_NO_CONNECT; // not connected
-          MI32StartTask(MI32_TASK_SCAN);
-          vTaskDelay(100/ portTICK_PERIOD_MS);
-          vTaskDelete( NULL );
-        }
-        timer++;
-        vTaskDelay(10/ portTICK_PERIOD_MS);
-      }
-      if(MI32.mode.discoverAttributes || MI32.conCtx->hasArg1){ // explicit or in the first run with selection by handle
-        MI32Client->discoverAttributes(); // solves connection problems on i.e. yeelight dimmer
-      }
-      NimBLERemoteService* pSvc = nullptr;
-      NimBLERemoteCharacteristic* pChr = nullptr;
-      std::vector<NimBLERemoteCharacteristic*>charvector;
-
-      // AddLog(LOG_LEVEL_INFO,PSTR("M32: start connection loop"));
-      bool keepConnectionAlive = true;
-      MI32.mode.triggerNextConnJob = 1;
-      while(keepConnectionAlive){
-        while(MI32.mode.triggerNextConnJob == 0){
-          vTaskDelay(50/ portTICK_PERIOD_MS);
-          if(MI32.mode.connected == 0){
-              MI32StartTask(MI32_TASK_SCAN);
-              vTaskDelete( NULL );
-          }
-          // AddLog(LOG_LEVEL_INFO,PSTR("M32: wait ..."));
-        }
-
-        MI32.mode.triggerNextConnJob = 0;
-        MI32.mode.readyForNextConnJob = 0;
-        if(MI32.conCtx->operation == 5){
-          MI32Client->disconnect();
-          break;
-        }
-
-        if(MI32.conCtx->operation == 6){ // get remote services to Berry
-          MI32ConnectionGetServices();
-        }
-        else{
-          if(MI32.conCtx->hasArg1){
-            pSvc = nullptr; // invalidate possible dangling service from last operation
-          }
-          else{
-            pSvc = MI32Client->getService(MI32.conCtx->serviceUUID);
-          }
-        }
-
-        if(pSvc) {
-          if(MI32.conCtx->operation == 7){ // get remote characteristics to Berry
-            MI32ConnectionGetCharacteristics(pSvc);
-          }
-          else{
-          pChr = pSvc->getCharacteristic(MI32.conCtx->charUUID);
-          }
-        }
-        else if(MI32.conCtx->hasArg1){
-          pChr = MI32Client->getCharacteristic(MI32.conCtx->arg1); // get by handle, overriding svc and chr values
-        }
-        else{
-          if(MI32.conCtx->operation != 6){
-            MI32.conCtx->error = MI32_CONN_NO_SERVICE;
-          }
-        }
-        if (pChr){
-          switch(MI32.conCtx->operation){
-            case 1:
-              if(pChr->canRead()) {
-                NimBLEAttValue _val = pChr->readValue();
-                MI32.conCtx->buffer[0] = _val.size();
-                memcpy( MI32.conCtx->buffer + 1,_val.data(),MI32.conCtx->buffer[0]);
-                MI32.conCtx->handle = pChr->getHandle();
-              }
-              else{
-                MI32.conCtx->error = MI32_CONN_CAN_NOT_READ;
-              }
-              break;
-            case 2:
-              if(pChr->canWrite() || pChr->canWriteNoResponse()) {
-                uint8_t len = MI32.conCtx->buffer[0];
-                if(pChr->writeValue(MI32.conCtx->buffer + 1,len,MI32.conCtx->response & !pChr->canWriteNoResponse())) { // falls always back to "no response" if server provides both options
-                  // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: write op done"));
-                  MI32.conCtx->handle = pChr->getHandle();
-                }
-                else{
-                MI32.conCtx->error = MI32_CONN_DID_NOT_WRITE;
-                }
-              }
-              else{
-                MI32.conCtx->error = MI32_CONN_CAN_NOT_WRITE;
-              }
-              MI32.mode.readingDone = 1;
-              break;
-            case 3:
-              if(!BLERingBufferQueue) {
-                MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
-                break;
-              }
-              if(MI32.conCtx->hasArg1){ // characteristic selected by handle
-                if (pChr->canNotify()) {
-                  if(!pChr->subscribe(true, MI32notifyCB, MI32.conCtx->response)) {
-                    MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY; // will return the last result only ATM, maybe check differently
-                  }
-                }
-              }
-              else { //  characteristic selected by UUID
-                charvector = pSvc->getCharacteristics(true); // always try to subscribe to all characteristics with the same UUID
-                uint32_t position = 1;
-                for (auto &it: charvector) {
-                  if (it->getUUID() == MI32.conCtx->charUUID) {
-                    if (it->canNotify()) {
-                      if(!it->subscribe(true, MI32notifyCB, MI32.conCtx->response)) {
-                        MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY; // will return the last result only ATM, maybe check differently
-                      }
-                      else{
-                        MI32.conCtx->buffer[position++] = it->getHandle() >> 8;
-                        MI32.conCtx->buffer[position++] = it->getHandle() & 0xff;
-                        MI32.conCtx->handle = it->getHandle();
-                      }
-                    }
-                  }
-                }
-                MI32.conCtx->buffer[0] = position - 1;
-              }
-              break;
-          default:
-              break;
-          }
-        }
-        else{
-            if(MI32.conCtx->operation < 5){ // no characteristics are fine for ops, that are not read, write or subscribe
-              MI32.conCtx->error = MI32_CONN_NO_CHARACTERISTIC;
-            }
-        }
-        timer = 0;
-
-        if(MI32.conCtx->error == MI32_CONN_NO_ERROR){
-          while (timer<150){
-            if (MI32.mode.readingDone || !MI32.conCtx->oneOp){
-              break;
-            }
-            else if (timer>148){
-              if (MI32.conCtx->operation==3 && MI32.conCtx->oneOp) {
-                MI32.conCtx->error = MI32_CONN_NOTIFY_TIMEOUT; //did not read on notify - timeout only for one-shot op
-              }
-            }
-            timer++;
-            vTaskDelay(100/ portTICK_PERIOD_MS);
-          }
-        }
-      MI32.mode.readingDone = 0;
-      if(MI32.conCtx->oneOp){
-        MI32Client->disconnect();
-        keepConnectionAlive = false;
-      }
-      else{
-        MI32.mode.readyForNextConnJob = 1;
-        MI32.mode.triggerBerryConnCB = 1;
-      }
+/**
+ * @brief Lazy server bring-up. Runs INSIDE MI32ConnectionTask on the first server op.
+ *        Tears down the scan task to avoid a race with ble_gatts_start(), then creates
+ *        the singleton NimBLEServer and sets MI32_ROLE_SERVER.
+ */
+static void MI32EnsureServerInstance(NimBLEServer *&pServer){
+  if(pServer != nullptr) return;
+  if(MI32.ScanTask != nullptr && MI32.mode.runningScan == 1){
+    MI32.mode.deleteScanTask = 1;
+    uint32_t _waitMs = 0;
+    while(MI32.mode.runningScan == 1 && _waitMs < 1000){
+      vTaskDelay(20 / portTICK_PERIOD_MS);
+      _waitMs += 20;
     }
   }
-  else{
-    MI32.mode.willConnect = 0;
-    MI32.conCtx->error = MI32_CONN_NO_CONNECT; // could not connect (including op:5 in not connected state)
+  pServer = NimBLEDevice::createServer();
+  pServer->setCallbacks(new MI32ServerCallbacks(), true);
+  MI32.role |= MI32_ROLE_SERVER;
+  AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: server instance created (lazy)"));
+}
+
+/**
+ * @brief Single client GATT op handler. Replaces both MI32BridgeRunClientOp and the
+ *        legacy in-task client switch. Behaviour differs in two minor ways depending
+ *        on whether MI32_ROLE_SERVER is set ("bridge") or not ("legacy"):
+ *          - legacy: stops scan, sets willConnect, polls mode.connected (≤1s)
+ *          - bridge: server callback owns the link; just reuse/createClient(addr) +
+ *            connect(false) without the mode.connected handshake.
+ *        Sets MI32_ROLE_CLIENT on successful (re)use of MI32Client; clears it on op==5.
+ */
+static void MI32RunClientOp(){
+  if(MI32.conCtx == nullptr) return;
+  const bool bridge = (MI32.role & MI32_ROLE_SERVER) != 0;
+  // Reverse-role borrowed singleton (bridge with an accepted central). When set,
+  // we ride the existing accepted link instead of creating an outbound client.
+  // Lifetime owned by NimBLEServer; never deleted here.
+  NimBLEClient * const acceptedCentralClient = bridge ? MI32.conCtx->serverPeer : nullptr;
+  NimBLEAddress _address = NimBLEAddress(MI32.conCtx->MAC, MI32.conCtx->addrType);
+
+  // op==5: tear everything down. In bridge-active mode this also drops the
+  // central link via the server-owned client; the actual freeing of serverPeer
+  // happens in MI32ServerCallbacks::onDisconnect (we never free the singleton).
+  if(MI32.conCtx->operation == 5){
+    if(acceptedCentralClient != nullptr && acceptedCentralClient->isConnected()){
+      acceptedCentralClient->disconnect();
+    }
+    if(MI32Client != nullptr){
+      if(MI32Client->isConnected()){
+        MI32Client->disconnect();
+      }
+      NimBLEDevice::deleteClient(MI32Client);
+      MI32Client = nullptr;
+    }
+    MI32.mode.connected = 0;
+    MI32.role &= ~MI32_ROLE_CLIENT;
+    return;
   }
-  MI32.mode.connected = 0;
-  MI32.mode.triggerBerryConnCB = 1;
-  if (BLERingBufferQueue != nullptr){
+
+  // Pick the working client: bridge-active uses the accepted central link
+  // (already connected, server owns lifecycle); otherwise use/allocate the
+  // outbound MI32Client.
+  NimBLEClient * activeClient = acceptedCentralClient;
+  if(acceptedCentralClient == nullptr){
+    // (re)acquire outbound client
+    if(MI32Client != nullptr && !MI32Client->isConnected()){
+      NimBLEDevice::deleteClient(MI32Client);
+      MI32Client = nullptr;
+    }
+    if(MI32Client == nullptr){
+      if(NimBLEDevice::getCreatedClientCount() > 0){
+        MI32Client = NimBLEDevice::getClientByPeerAddress(_address);
+      }
+      if(MI32Client == nullptr){
+        MI32Client = NimBLEDevice::createClient(_address);
+        MI32Client->setClientCallbacks(&MI32SensorCB, false);
+      }
+    }
+    if(!MI32Client->isConnected()){
+      if(!bridge){
+        if(MI32Scan) MI32Scan->stop();
+        MI32.mode.willConnect = 1;
+      }
+      if(!MI32Client->connect(false)){
+        NimBLEDevice::deleteClient(MI32Client);
+        MI32Client = nullptr;
+        MI32.mode.willConnect = 0;
+        MI32.conCtx->error = MI32_CONN_NO_CONNECT;
+        return;
+      }
+      if(!bridge){
+        uint32_t timer = 0;
+        while(MI32.mode.connected == 0){
+          if(timer > 100){ // 100 * 10ms = 1s
+            MI32Client->disconnect();
+            NimBLEDevice::deleteClient(MI32Client);
+            MI32Client = nullptr;
+            MI32.mode.willConnect = 0;
+            MI32.conCtx->error = MI32_CONN_NO_CONNECT;
+            return;
+          }
+          timer++;
+          vTaskDelay(10 / portTICK_PERIOD_MS);
+        }
+      }
+    }
+    activeClient = MI32Client;
+    MI32.role |= MI32_ROLE_CLIENT; // tracks outbound MI32Client only
+  }
+
+  // discoverAttributes() drops cached services + their notify callbacks
+  // (CCCD stays on, but notifies get silently dropped). Only rediscover
+  // when cache is empty or caller asked via hasArg1.
+  if(MI32.conCtx->hasArg1){
+    activeClient->discoverAttributes();
+  } else if(MI32.mode.discoverAttributes && activeClient->getServices(false).empty()){
+    activeClient->discoverAttributes();
+  }
+
+  if(MI32.conCtx->operation == 6){ // get remote services
+    MI32ConnectionGetServices();
+    return;
+  }
+
+  NimBLERemoteService* pSvc = nullptr;
+  NimBLERemoteCharacteristic* pChr = nullptr;
+  std::vector<NimBLERemoteCharacteristic*> charvector;
+
+  if(MI32.conCtx->hasArg1){
+    pSvc = nullptr;
+  } else {
+    pSvc = activeClient->getService(MI32.conCtx->serviceUUID);
+  }
+  if(pSvc){
+    if(MI32.conCtx->operation == 7){ // get remote characteristics
+      MI32ConnectionGetCharacteristics(pSvc);
+      return;
+    }
+    pChr = pSvc->getCharacteristic(MI32.conCtx->charUUID);
+  } else if(MI32.conCtx->hasArg1){
+    pChr = activeClient->getCharacteristic(MI32.conCtx->arg1); // by handle
+  } else {
+    MI32.conCtx->error = MI32_CONN_NO_SERVICE;
+  }
+
+  if(pChr){
+    switch(MI32.conCtx->operation){
+      case 1: // read
+        if(pChr->canRead()){
+          NimBLEAttValue _val = pChr->readValue();
+          MI32.conCtx->buffer[0] = _val.size();
+          memcpy(MI32.conCtx->buffer + 1, _val.data(), MI32.conCtx->buffer[0]);
+          MI32.conCtx->handle = pChr->getHandle();
+        } else {
+          MI32.conCtx->error = MI32_CONN_CAN_NOT_READ;
+        }
+        break;
+      case 2: // write
+        if(pChr->canWrite() || pChr->canWriteNoResponse()){
+          uint8_t len = MI32.conCtx->buffer[0];
+          if(pChr->writeValue(MI32.conCtx->buffer + 1, len,
+                              MI32.conCtx->response && !pChr->canWriteNoResponse())){
+            MI32.conCtx->handle = pChr->getHandle();
+          } else {
+            MI32.conCtx->error = MI32_CONN_DID_NOT_WRITE;
+          }
+        } else {
+          MI32.conCtx->error = MI32_CONN_CAN_NOT_WRITE;
+        }
+        MI32.mode.readingDone = 1;
+        break;
+      case 3: // subscribe
+        if(!BLERingBufferQueue){
+          MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
+          break;
+        }
+        if(MI32.conCtx->hasArg1){
+          if(pChr->canNotify()){
+            if(!pChr->subscribe(true, MI32notifyCB, MI32.conCtx->response)){
+              MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
+            } else {
+              // Mirror the UUID-subscribe path's bookkeeping so Berry receives the
+              // resolved handle (1-handle payload, big-endian then little-endian
+              // pair as expected by the existing decoder).
+              MI32.conCtx->handle = pChr->getHandle();
+              MI32.conCtx->buffer[0] = 2;
+              MI32.conCtx->buffer[1] = pChr->getHandle() >> 8;
+              MI32.conCtx->buffer[2] = pChr->getHandle() & 0xff;
+            }
+          }
+        } else {
+          // refresh=false: getCharacteristics(true) would wipe m_vChars and
+          // kill prior subscribe callbacks (CCCD stays on, notifies drop).
+          // Cache is already populated by getCharacteristic(...) above.
+          charvector = pSvc->getCharacteristics(false);
+          uint32_t position = 1;
+          for(auto &it: charvector){
+            if(it->getUUID() == MI32.conCtx->charUUID){
+              if(it->canNotify()){
+                if(!it->subscribe(true, MI32notifyCB, MI32.conCtx->response)){
+                  MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
+                } else {
+                  MI32.conCtx->buffer[position++] = it->getHandle() >> 8;
+                  MI32.conCtx->buffer[position++] = it->getHandle() & 0xff;
+                  MI32.conCtx->handle = it->getHandle();
+                }
+              }
+            }
+          }
+          MI32.conCtx->buffer[0] = position - 1;
+        }
+        break;
+      default:
+        break;
+    }
+  } else if(MI32.conCtx->operation < 5){
+    MI32.conCtx->error = MI32_CONN_NO_CHARACTERISTIC;
+  }
+
+  // legacy oneOp: optionally wait for notification then disconnect
+  if(MI32.conCtx->oneOp && !bridge){
+    if(MI32.conCtx->error == MI32_CONN_NO_ERROR){
+      uint32_t timer = 0;
+      while(timer < 150){
+        if(MI32.mode.readingDone) break;
+        if(timer > 148 && MI32.conCtx->operation == 3){
+          MI32.conCtx->error = MI32_CONN_NOTIFY_TIMEOUT;
+        }
+        timer++;
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+      }
+    }
+    MI32.mode.readingDone = 0;
+    if(MI32Client != nullptr && MI32Client->isConnected()){
+      MI32Client->disconnect();
+    }
+    MI32.role &= ~MI32_ROLE_CLIENT; // defensive; onDisconnect also clears it
+  } else {
+    MI32.mode.readingDone = 0;
+  }
+}
+
+/**
+ * @brief Unified BLE worker task. Launched once from MI32setBerryConnCB and survives
+ *        until conn_cb is cleared (function==nullptr -> deleteConnectionTask=1).
+ *        Handles both client (BLE_OP 1..7) and server (BLE_OP_SET_*) ops in the same
+ *        loop. MI32.role is set lazily by op dispatch:
+ *          - server bits flip in MI32EnsureServerInstance on first SET_ADV/CHARACTERISTIC
+ *          - client bits flip in MI32RunClientOp on successful connect, cleared on op==5
+ */
+void MI32ConnectionTask(void *pvParameters){
+  NimBLEServer *pServer = nullptr;
+  std::vector<NimBLEService*> servicesToStart;
+  bool shallStartServices = true;
+
+  MI32.mode.readyForNextJob = 1;
+  MI32.mode.deleteConnectionTask = 0;
+  if(MI32.conCtx) MI32.conCtx->error = MI32_CONN_NO_ERROR;
+
+  for(;;){
+    while(MI32.mode.triggerNextJob == 0){
+      if(MI32.mode.deleteConnectionTask == 1){
+        goto cleanup;
+      }
+      vTaskDelay(50 / portTICK_PERIOD_MS);
+    }
+    MI32.mode.triggerNextJob  = 0;
+    MI32.mode.readyForNextJob = 0;
+
+    if(MI32.conCtx == nullptr){
+      MI32.mode.readyForNextJob = 1;
+      continue;
+    }
+    MI32.conCtx->error = MI32_CONN_NO_ERROR;
+
+    switch(MI32.conCtx->operation){
+      case BLE_OP_SET_ADV:
+      case BLE_OP_SET_SCAN_RESP:
+        MI32EnsureServerInstance(pServer);
+        MI32ServerSetAdv(pServer, servicesToStart, shallStartServices);
+        break;
+      case BLE_OP_SET_CHARACTERISTIC:
+        MI32EnsureServerInstance(pServer);
+        MI32ServerSetCharacteristic(pServer, servicesToStart, shallStartServices);
+        break;
+      case 1: case 2: case 3: case 5: case 6: case 7: // client op
+        MI32RunClientOp();
+        MI32.mode.triggerBerryConnCB = 1;
+        break;
+      default:
+        AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: unhandled op %u"), MI32.conCtx->operation);
+        break;
+    }
+
+    MI32.mode.readyForNextJob = 1;
+  }
+
+cleanup:
+  if(pServer != nullptr){
+    pServer->stopAdvertising();
+  }
+  if(MI32Client != nullptr){
+    if(MI32Client->isConnected()){
+      MI32Client->disconnect();
+    }
+    NimBLEDevice::deleteClient(MI32Client);
+    MI32Client = nullptr;
+  }
+  if(MI32.conCtx != nullptr){
+    delete MI32.conCtx;
+    MI32.conCtx = nullptr;
+  }
+  if(BLERingBufferQueue != nullptr){
     vRingbufferDelete(BLERingBufferQueue);
     BLERingBufferQueue = nullptr;
   }
+  MI32.role &= ~(MI32_ROLE_SERVER | MI32_ROLE_CLIENT | MI32_ROLE_ADVERTISER);
+  MI32.mode.connected            = 0;
+  MI32.mode.willConnect          = 0;
+  MI32.mode.deleteConnectionTask = 0;
+  MI32.mode.triggerBerryConnCB   = 1;
+  MI32.ConnTask = nullptr;
   MI32StartTask(MI32_TASK_SCAN);
-  vTaskDelete( NULL );
+  vTaskDelete(NULL);
 }
 
 // server task section
 
-bool MI32StartServerTask(){
-  AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Server task ... start"));
-  if (BLERingBufferQueue == nullptr){
-    BLERingBufferQueue = xRingbufferCreate(4096, RINGBUF_TYPE_NOSPLIT);
-    if(!BLERingBufferQueue) {
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed to create ringbuffer queue"));
-      return false;
-    }
-  }
-  MI32.role = 3;
-  xTaskCreatePinnedToCore(
-    MI32ServerTask,    /* Function to implement the task */
-    "MI32ServerTask",  /* Name of the task */
-    8192,             /* Stack size in words */
-    NULL,             /* Task input parameter */
-    2,                /* Priority of the task */
-    &MI32.ServerTask,   /* Task handle. */
-    0);               /* Core where the task should run */
-  return true;
-}
-
-void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servicesToStart, bool &shallStartServices);
 /**
  * @brief Sets the advertisement message from the data of the context, could be regular advertisement or scan response
  *
@@ -1594,9 +1666,7 @@ void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servic
     //TODO
 #else
     pAdvertising->setConnectableMode(MI32.conCtx->arg1);
-    // AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: AdvertisementType: %u"),MI32.conCtx->arg1);
 #endif
-    // AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: AdvertisementType: %u"),MI32.conCtx->arg1);
   }
   struct{
     BLERingBufferItem_t header;
@@ -1615,6 +1685,7 @@ void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servic
         std::vector<NimBLECharacteristic *> characteristics = pService->getCharacteristics();
         for (auto & pCharacteristic : characteristics) {
           uint16_t handle = pCharacteristic->getHandle(); // now we have handles, so pass them to Berry
+          //AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic started %s"),pCharacteristic->toString().c_str());
           item.buffer[idx] = (uint8_t)handle>>8;
           item.buffer[idx+1] = (uint8_t)handle&0xff;
           if (idx > 254) break; // limit to 127 characteristics
@@ -1632,7 +1703,6 @@ void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servic
   pAdvertising->setInstanceData(0,adv); // instance id 0
   if(MI32.conCtx->operation == BLE_OP_SET_ADV){
     if(pAdvertising->isAdvertising() == false && !shallStartServices){ // first advertisement
-      vTaskDelay(1000/ portTICK_PERIOD_MS);   // work around to prevent crash on start
       pAdvertising->start(0);
     }
   } else
@@ -1645,7 +1715,6 @@ void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servic
   if(MI32.conCtx->operation == BLE_OP_SET_ADV){
     pAdvertising->setAdvertisementData(adv); // replace whole advertisement with our custom data from the Berry side
     if(pAdvertising->isAdvertising() == false && !shallStartServices){ // first advertisement
-      vTaskDelay(1000/ portTICK_PERIOD_MS);   // work around to prevent crash on start
       pAdvertising->start();
     }
   } else
@@ -1662,7 +1731,6 @@ void MI32ServerSetAdv(NimBLEServer *pServer, std::vector<NimBLEService*>& servic
   xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t) + item.header.length, pdMS_TO_TICKS(20));
 }
 
-void MI32ServerSetCharacteristic(NimBLEServer *pServer, std::vector<NimBLEService*>& servicesToStart, bool &shallStartServices);
 /**
  * @brief Create a characteristic or modify its value with data of the context
  *
@@ -1693,10 +1761,10 @@ void MI32ServerSetCharacteristic(NimBLEServer *pServer, std::vector<NimBLEServic
                          NIMBLE_PROPERTY::INDICATE; // default to "all"
     if(MI32.conCtx->hasArg1){
       _property = MI32.conCtx->arg1;    // override with optional argument
-      // AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: _property: %u"),_property);
     }
+    // AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: createCharacteristic %s _property=0x%02X shallStartServices=%u"), MI32.conCtx->charUUID.toString().c_str(), _property, shallStartServices);
     pCharacteristic = pService->createCharacteristic(MI32.conCtx->charUUID,
-                                                    _property);  //... or create characteristic.
+                                                     _property);  //... or create characteristic.
     if(pCharacteristic == nullptr){
       MI32.conCtx->error = MI32_CONN_NO_CHARACTERISTIC;
       return;
@@ -1714,46 +1782,6 @@ void MI32ServerSetCharacteristic(NimBLEServer *pServer, std::vector<NimBLEServic
   item.header.returnCharUUID = *reinterpret_cast<const uint16_t*>(pCharacteristic->getUUID().getValue() + 12);
   item.header.handle = pCharacteristic->getHandle();
   xRingbufferSend(BLERingBufferQueue, (const void*)&item, sizeof(BLERingBufferItem_t), pdMS_TO_TICKS(1));
-}
-
-void MI32ServerTask(void *pvParameters){
-  MI32.conCtx->error = MI32_CONN_NO_ERROR;
-  NimBLEServer *pServer = NimBLEDevice::createServer();
-  auto _srvCB = new MI32ServerCallbacks();  
-  pServer->setCallbacks(_srvCB,true);
-
-  MI32.mode.readyForNextServerJob = 1;
-  MI32.mode.deleteServerTask = 0;
-  std::vector<NimBLEService*> servicesToStart;
-  bool shallStartServices = true; //will start service at the first call MI32ServerSetAdv()
-
-  for(;;){
-    while(MI32.mode.triggerNextServerJob == 0){
-      if(MI32.mode.deleteServerTask == 1){
-        delete MI32.conCtx;
-        pServer->stopAdvertising();
-        MI32StartTask(MI32_TASK_SCAN);
-        vRingbufferDelete(BLERingBufferQueue);
-        BLERingBufferQueue = nullptr;
-        MI32.conCtx = nullptr;
-        vTaskDelete( NULL );
-      }
-      vTaskDelay(50/ portTICK_PERIOD_MS);
-    }
-    MI32.mode.readyForNextServerJob = 0;
-    switch(MI32.conCtx->operation){
-      case BLE_OP_SET_ADV: case BLE_OP_SET_SCAN_RESP:
-        MI32ServerSetAdv(pServer, servicesToStart, shallStartServices);
-        break;
-      case BLE_OP_SET_CHARACTERISTIC:
-        MI32ServerSetCharacteristic(pServer, servicesToStart, shallStartServices);
-        break;
-    }
-
-    MI32.mode.triggerNextServerJob = 0;
-    MI32.mode.readyForNextServerJob = 1;
-    MI32.mode.triggerBerryServerCB = 1;
-  }
 }
 
 /*********************************************************************************************\
@@ -2279,28 +2307,27 @@ void MI32BLELoop()
     MI32.mode.triggerBerryConnCB = 0;
   }
 
-  // server callback
-  if(MI32.mode.connected == 0 && BLERingBufferQueue != nullptr){
+  // Bridge mode (connected==0): drain ring buffer into conCtx and defer
+  // dispatch via triggerBerryConnCB, same as the client branch above.
+  // triggerNextJob==0 guard: don't clobber an op Berry just staged.
+  if(MI32.mode.connected == 0 && BLERingBufferQueue != nullptr
+     && MI32.mode.triggerBerryConnCB == 0 && MI32.mode.readyForNextJob == 1
+     && MI32.mode.triggerNextJob == 0){
     size_t size;
     BLERingBufferItem_t *q = (BLERingBufferItem_t *)xRingbufferReceive(BLERingBufferQueue, &size, pdMS_TO_TICKS(1));
 
     if(q != nullptr){
       if(q->length != 0){
         memcpy(MI32.conCtx->buffer,&q->length,q->length + 1);
+      } else {
+        MI32.conCtx->buffer[0] = 0; // empty payload framing (memcpy above is skipped)
       }
-      MI32.conCtx->buffer[0] = q->length;
       MI32.conCtx->returnCharUUID = q->returnCharUUID;
       MI32.conCtx->handle = q->handle;
       MI32.conCtx->operation = q->type;
       MI32.conCtx->error = 0;
       vRingbufferReturnItem(BLERingBufferQueue, (void *)q);
-      if(MI32.beServerCB != nullptr){
-        void (*func_ptr)(int, int, int, int) = (void (*)(int, int, int, int))MI32.beServerCB;
-        char _message[32];
-        GetTextIndexed(_message, sizeof(_message), MI32.conCtx->error, kMI32_ConnErrorMsg);
-        AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: BryCbMsg: %s"),_message);
-        func_ptr(MI32.conCtx->error, MI32.conCtx->operation , MI32.conCtx->returnCharUUID, MI32.conCtx->handle);
-      }
+      MI32.mode.triggerBerryConnCB = 1;
     }
   }
   if(MI32.infoMsg > 0){
@@ -2338,7 +2365,7 @@ void MI32EverySecond(bool restart){
   }
 
   // should not be needed with a stable BLE stack
-  if(MI32.role == 1 && MI32.mode.runningScan == 0){
+  if((MI32.role & MI32_ROLE_SCAN) && MI32.mode.runningScan == 0){
     AddLog(LOG_LEVEL_INFO,PSTR("BLE: restart scan"));
     MI32StartTask(MI32_TASK_SCAN);
   }
@@ -2489,7 +2516,7 @@ bool MI32HandleWebGUIResponse(void){
 
 #ifdef USE_MI_ESP32_ENERGY
 // ultra simple integer log2 using builtin CLZ
-int MI32ln(uint32_t x) {
+int MI32ln(uint32_t v) {
   return 31 - __builtin_clz(v);
 }
 #endif //USE_MI_ESP32_ENERGY
@@ -2527,10 +2554,17 @@ void MI32createGraph(char *buffer, uint8_t *history, uint8_t r, uint8_t g, uint8
 #ifdef USE_MI_ESP32_ENERGY
 void MI32sendEnergyWidget(){
   if (Energy->current_available && Energy->voltage_available) {
-    WSContentSend_P(HTTP_MI32_POWER_WIDGET,MIBLEsensors.size()+1, Energy->voltage,Energy->current[1]);
+    // picolibc integer-only vfprintf: route floats through ext_snprintf_P (%*_f, pass-by-pointer)
+    char _voltStr[16];
+    char _currStr[16];
+    char _powStr[16];
+    ext_snprintf_P(_voltStr, sizeof(_voltStr), PSTR("%*_f"), -1, &Energy->voltage[0]);
+    ext_snprintf_P(_currStr, sizeof(_currStr), PSTR("%*_f"), -3, &Energy->current[1]);
+    ext_snprintf_P(_powStr,  sizeof(_powStr),  PSTR("%*_f"), -1, &Energy->active_power[0]);
+    WSContentSend_P(HTTP_MI32_POWER_WIDGET, MIBLEsensors.size()+1, _voltStr, _currStr);
     char _graph[256];
     MI32createGraph(_graph, MI32.energy_history, 185, 124, 124);
-    WSContentSend_P(PSTR("<p>" D_POWERUSAGE ": %.1f " D_UNIT_WATT "%s</p></div>"), Energy->active_power, _graph);
+    WSContentSend_P(PSTR("<p>" D_POWERUSAGE ": %s " D_UNIT_WATT "%s</p></div>"), _powStr, _graph);
   }
 }
 #endif //USE_MI_ESP32_ENERGY
@@ -2589,22 +2623,31 @@ void MI32sendWidget(uint32_t slot){
     if(!isnan(_sensor.temp)){
       char _graph[256];
       MI32createGraph(_graph, _sensor.temp_history, 185, 124, 124);
-      WSContentSend_P(PSTR("<p>" D_JSON_TEMPERATURE ": %.1f °C%s</p>"), _sensor.temp, _graph);
+      char _tempStr[16];
+      ext_snprintf_P(_tempStr, sizeof(_tempStr), PSTR("%*_f"), -1, &_sensor.temp);
+      WSContentSend_P(PSTR("<p>" D_JSON_TEMPERATURE ": %s °C%s</p>"), _tempStr, _graph);
     }
     if(!isnan(_sensor.hum)){
       char _graph[256];
       MI32createGraph(_graph, _sensor.hum_history, 151, 190, 216);
-      WSContentSend_P(PSTR("<p>" D_JSON_HUMIDITY ": %.1f %%%s</p>"), _sensor.hum, _graph);
+      char _humStr[16];
+      ext_snprintf_P(_humStr, sizeof(_humStr), PSTR("%*_f"), -1, &_sensor.hum);
+      WSContentSend_P(PSTR("<p>" D_JSON_HUMIDITY ": %s %%%s</p>"), _humStr, _graph);
     }
     if(!isnan(_sensor.temp) && !isnan(_sensor.hum)){
-      WSContentSend_P(PSTR("" D_JSON_DEWPOINT ": %.1f °C"),CalcTempHumToDew(_sensor.temp,_sensor.hum));
+      char _dewStr[16];
+      float _dewVal = CalcTempHumToDew(_sensor.temp, _sensor.hum);
+      ext_snprintf_P(_dewStr, sizeof(_dewStr), PSTR("%*_f"), -1, &_dewVal);
+      WSContentSend_P(PSTR("" D_JSON_DEWPOINT ": %s °C"), _dewStr);
     }
   }
   else if(_sensor.feature.temp == 1){
     if(!isnan(_sensor.temp)){
       char _graph[256];
       MI32createGraph(_graph, _sensor.temp_history, 185, 124, 124);
-      WSContentSend_P(PSTR("<p>" D_JSON_TEMPERATURE ": %.1f °C%s</p>"), _sensor.temp, _graph);
+      char _tempStr[16];
+      ext_snprintf_P(_tempStr, sizeof(_tempStr), PSTR("%*_f"), -1, &_sensor.temp);
+      WSContentSend_P(PSTR("<p>" D_JSON_TEMPERATURE ": %s °C%s</p>"), _tempStr, _graph);
     }
   }
   if(_sensor.feature.lux == 1){
@@ -2718,7 +2761,6 @@ void MI32Show(bool json)
       if(MI32.option.noSummary == 1) return; // no message at TELEPERIOD
       }
     if(TasmotaGlobal.masterlog_level == LOG_LEVEL_DEBUG_MORE) return; // we want to announce sensors unlinked to the ESP, check for LOG_LEVEL_DEBUG_MORE is medium-safe
-    MI32suspendScanTask();
     for (uint32_t i = 0; i < MIBLEsensors.size(); i++) {
       if(MI32.mode.triggeredTele == 1 && MIBLEsensors[i].eventType.raw == 0) continue;
       if(MI32.mode.triggeredTele == 1 && MIBLEsensors[i].shallSendMQTT==0) continue;
@@ -2887,11 +2929,8 @@ void MI32Show(bool json)
     MI32addHistory(MI32.energy_history,Energy->active_power[0],100); //TODO: which value??
 #endif //USE_MI_ESP32_ENERGY
 #endif //USE_MI_EXT_GUI
-    MI32resumeScanTask();
 #ifdef USE_WEBSERVER
     } else {
-      MI32suspendScanTask();
-
       WSContentSend_P(HTTP_MI32, MIBLEsensors.size());
 
 #ifndef USE_MI_EXT_GUI
@@ -2946,16 +2985,19 @@ void MI32Show(bool json)
 #endif //USE_MI_EXT_GUI
 #endif  // USE_WEBSERVER
     }
-    MI32resumeScanTask();
 }
 
 int ExtStopBLE(){
       if(Settings->flag5.mi32_enable == 0) return 0;
       if (MI32.ScanTask != nullptr){
         MI32.mode.deleteScanTask = 1;
-        MI32.role = 0;
+        MI32.role &= ~MI32_ROLE_SCAN;
         AddLog(LOG_LEVEL_INFO,PSTR("M32: stop BLE"));
-        while (MI32.mode.runningScan == 1) delay(5);
+        uint32_t _waitMs = 0;
+        while (MI32.mode.runningScan == 1 && _waitMs < 1000){
+          delay(5);
+          _waitMs += 5;
+        }
       }
       return 0;
 }


### PR DESCRIPTION
## Description:

This PR refactors the MI32/NimBLE driver to lay the foundation for reverse-role use cases, plus related cleanups. Main motivation was to allow Apple Notification Center Service (ANCS) to work. 

BLE driver
- Unified BLE connection task: client- and server-side ops now share a single MI32ConnectionTask, dispatched via the existing Berry entry point. This enables server-side ("reverse role") client queries toward a connected central.
- BLE.serv_cb is deprecated; server-side callbacks are routed through the unified BLE.conn_cb path. Existing client-side Berry API (BLE.run, BLE.conn_cb, BLE.set_svc, BLE.set_chr, …) is unchanged.
- Reverse-role/server-side client handling: serverPeer is borrowed from NimBLEServer (singleton, never deleted).
- Persistent bonding storage via Berry (BLE.store + onAuthenticationComplete). Circumvents NVS, can be saved to file system.
- advertised connection timing parameters are now automatically negotiated on connect, which vastly improves stability i.e. when commissioning a fresh ESP32 with Apple devices in the Home App via Matter to get WiFi credentials

MI32 cleanups
- MI32.role bit-flags converted to a typed enum MI32Role : uint8_t. Identifiers, bit values and storage type are preserved; no call-site changes.
- Removed many old quirks and workarounds that were needed for older buggier versions of the NimBLE stack for the ESP32 family.

Compatibility
- Client-side Berry API signatures unchanged.
- BLE.serv_cb deprecated (server callbacks now via BLE.conn_cb).
- Default behavior unchanged for users not using server/reverse-role features.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
