### PR TITLE
UDISP: Fix I80 pushColors swap logic for parallel displays

### DIFF
--- a/lib/lib_display/UDisplay/src/uDisplay_I80_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_I80_panel.cpp
@@ -258,10 +258,10 @@ bool I80Panel::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
     return true;
 }
 
-bool I80Panel::pushColors(uint16_t *data, uint32_t len, bool swapped) {
+bool I80Panel::pushColors(uint16_t *data, uint32_t len, bool not_swapped) {
     // Match old code: just push pixels, no transaction management
     // Transaction is managed by setAddrWindow()
-    pb_pushPixels(data, len, !swapped, false);  // swap_bytes=true to match old driver
+    pb_pushPixels(data, len, not_swapped, false);
     return true;
 }
 


### PR DESCRIPTION
## Description:

Fix I80 parallel color byte order in pushColors to match the old single-file implementation.

Used more commonly used function argument `not_swapped`, but the code was always quite hard to follow due to inconsistent variable naming.

Tested on device successfully.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
