### PR TITLE
ESP8266: fix heap metric functions and add OOM diagnostics

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -61,6 +61,9 @@ default_envs            =
 ;                         -DDEBUG_TASMOTA_CORE
 ;                         -DDEBUG_TASMOTA_DRIVER
 ;                         -DDEBUG_TASMOTA_SENSOR
+; *** ESP8266 heap debugging, activate as group
+;                         -DUMM_STATS_FULL
+;                         -DUMM_INLINE_METRICS
 ; Build variant 1MB = 1MB firmware no filesystem (default)
 ;board                   = ${common.board}
 ; Build variant 2MB = 1MB firmware, 1MB filesystem (most Shelly devices)

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2804,17 +2804,12 @@ void AddLogData(uint32_t loglevel, const char* log_data, const char* log_data_pa
   TasAutoMutex mutex((SemaphoreHandle_t *)&TasmotaGlobal.log_buffer_mutex);
 #endif  // ESP32
 
-  char mxtime[21];  // "13:45:21.999-123/12 "
+  char mxtime[25];  // "13:45:21.999-123/12 " or with fragmentation suffix
   snprintf_P(mxtime, sizeof(mxtime), PSTR("%02d" D_HOUR_MINUTE_SEPARATOR "%02d" D_MINUTE_SECOND_SEPARATOR "%02d.%03d"),
     RtcTime.hour, RtcTime.minute, RtcTime.second, RtcMillis());
   if (Settings->flag5.show_heap_with_timestamp) {
-#ifdef ESP8266
-    snprintf_P(mxtime, sizeof(mxtime), PSTR("%s-%03d"),
-      mxtime, ESP_getFreeHeap1024());
-#else
     snprintf_P(mxtime, sizeof(mxtime), PSTR("%s-%03d/%02d"),
       mxtime, ESP_getFreeHeap1024(), ESP_getHeapFragmentation());
-#endif
   }
   strcat(mxtime, " ");
 

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -17,6 +17,10 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef ESP8266
+#include <umm_malloc/umm_malloc_cfg.h>
+#endif
+
 const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   // SetOptions synonyms
   D_SO_WIFINOSLEEP "|"
@@ -901,7 +905,11 @@ void CmndStatus(void)
 
   if (0 == XdrvMailbox.index) { payload = 0; }  // All status messages in one MQTT message (status0)
 
+#ifdef ESP8266
+  if (payload > MAX_STATUS && 44 != payload) { return; }  // {"Command":"Error"}
+#else
   if (payload > MAX_STATUS) { return; }  // {"Command":"Error"}
+#endif
   if (!Settings->flag.mqtt_enabled && (6 == payload)) { return; }  // SetOption3 - Enable MQTT
   if (!TasmotaGlobal.energy_driver && (9 == payload)) { return; }
 #ifndef FIRMWARE_MINIMAL
@@ -1041,6 +1049,14 @@ void CmndStatus(void)
     ResponseAppend_P(PSTR(",\"MaxFreeBlock\":%d,\"Frag\":%d"),
                           (uint32_t)ESP_getMaxAllocHeap()/1024,
                           (int32_t)ESP_getHeapFragmentation());
+#if defined(UMM_INLINE_METRICS) || defined(UMM_STATS_FULL)
+    ResponseAppend_P(PSTR(",\"OomCount\":%d"), (uint32_t)umm_get_oom_count());
+#endif
+#ifdef UMM_STATS_FULL
+    ResponseAppend_P(PSTR(",\"HeapLwm\":%d,\"MaxAllocSz\":%d"),
+                          (uint32_t)umm_free_heap_size_lw_min()/1024,
+                          (uint32_t)umm_get_max_alloc_size());
+#endif  // UMM_STATS_FULL
 #endif  // ESP8266
     ResponseAppendFeatures();
     XsnsDriverState();
@@ -1189,6 +1205,19 @@ void CmndStatus(void)
     if (ShutterStatus()) { CmndStatusResponse(13); }
   }
 #endif
+
+#ifdef ESP8266
+  // Status 44 - trigger umm heap dump to serial + OOM test
+  // ESP8266-only heap diagnostic. Chosen above the standard range
+  // (0-MAX_STATUS = 0-13) and below the reserved value 99 (full status dump).
+  if (44 == payload) {
+    umm_info(nullptr, true);
+    ESP_HeapOomTest();
+    Response_P(PSTR("{\"" D_CMND_STATUS "44\":{\"HeapDump\":\"serial\"}}"));
+    CmndStatusResponse(44);
+    return;
+  }
+#endif  // ESP8266
 
   CmndStatusResponse(99);
 

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1036,6 +1036,12 @@ void CmndStatus(void)
 #endif // ESP8266
                           , ESP_getFlashChipId()
                           , ESP_getFlashChipSpeed()/1000000);
+#ifdef ESP8266
+    ESP_UpdateHeapMetrics();
+    ResponseAppend_P(PSTR(",\"MaxFreeBlock\":%d,\"Frag\":%d"),
+                          (uint32_t)ESP_getMaxAllocHeap()/1024,
+                          (int32_t)ESP_getHeapFragmentation());
+#endif  // ESP8266
     ResponseAppendFeatures();
     XsnsDriverState();
     ResponseAppend_P(PSTR(",\"Sensors\":"));

--- a/tasmota/tasmota_support/support_esp8266.ino
+++ b/tasmota/tasmota_support/support_esp8266.ino
@@ -11,6 +11,8 @@
  * ESP8266 and ESP8285 Support
 \*********************************************************************************************/
 
+#include <umm_malloc/umm_malloc_cfg.h>
+
 const static char kWifiPhyMode[] PROGMEM = "low rate|11b|11g|11n"; // Wi-Fi Modes
 
 extern "C" {
@@ -104,8 +106,26 @@ float ESP_getFreeHeap1024(void) {
 }
 */
 
+// umm_max_block_size() requires a heap walk (ICACHE_FLASH_ATTR, IRQs disabled).
+// Cache the result; refresh once per second via ESP_UpdateHeapMetrics().
+// umm_max_block_size() and umm_free_heap_size_lw() are available unconditionally
+// (UMM_INFO and UMM_STATS are hardcoded active in umm_malloc_cfg.h).
+static uint32_t s_umm_max_free_block = 0;
+
+void ESP_UpdateHeapMetrics(void) {
+  s_umm_max_free_block = umm_max_block_size();
+}
+
 uint32_t ESP_getMaxAllocHeap(void) {
-  return ESP.getFreeHeap();
+  return s_umm_max_free_block ? s_umm_max_free_block : ESP.getFreeHeap();
+}
+
+int32_t ESP_getHeapFragmentation(void) {
+  // Same formula as ESP32: 100 - (largestFreeBlock * 100 / totalFree)
+  uint32_t free_heap = umm_free_heap_size_lw();  // ISR-safe, no heap walk
+  if (free_heap == 0 || s_umm_max_free_block == 0) { return 0; }
+  int32_t frag = 100 - (int32_t)(s_umm_max_free_block * 100 / free_heap);
+  return (frag < 0) ? 0 : frag;
 }
 
 uint32_t ESP_getFlashChipId(void) {

--- a/tasmota/tasmota_support/support_esp8266.ino
+++ b/tasmota/tasmota_support/support_esp8266.ino
@@ -128,6 +128,23 @@ int32_t ESP_getHeapFragmentation(void) {
   return (frag < 0) ? 0 : frag;
 }
 
+void ESP_HeapOomCheck(void) {
+#if defined(UMM_INLINE_METRICS) || defined(UMM_STATS_FULL)
+  static size_t oom_prev = 0;
+  size_t oom = UMM_OOM_COUNT;
+  if (oom != oom_prev) {
+    AddLog(LOG_LEVEL_INFO, PSTR("OOM: count %u (+%u)"), oom, oom - oom_prev);
+    oom_prev = oom;
+  }
+#endif
+}
+
+void ESP_HeapOomTest(void) {
+#if defined(UMM_INLINE_METRICS) || defined(UMM_STATS_FULL)
+  AddLog(LOG_LEVEL_INFO, PSTR("OOM: count %u (test-trigger)"), (uint32_t)umm_get_oom_count());
+#endif
+}
+
 uint32_t ESP_getFlashChipId(void) {
   return ESP.getFlashChipId();
 }

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1131,6 +1131,7 @@ void PerformEverySecond(void)
   if (Settings->flag5.show_heap_with_timestamp) {
     ESP_UpdateHeapMetrics();
   }
+  ESP_HeapOomCheck();
 #endif
 
   if (POWER_CYCLE_TIME == TasmotaGlobal.uptime) {

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1127,6 +1127,12 @@ void PerformEverySecond(void)
 {
   TasmotaGlobal.uptime++;
 
+#ifdef ESP8266
+  if (Settings->flag5.show_heap_with_timestamp) {
+    ESP_UpdateHeapMetrics();
+  }
+#endif
+
   if (POWER_CYCLE_TIME == TasmotaGlobal.uptime) {
     UpdateQuickPowerCycle(false);
   }


### PR DESCRIPTION
# Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

## Summary

Two commits addressing ESP8266 heap observability. Commit 1 is self-contained
and useful independently; Commit 2 builds on the corrected metric functions.

---

## Commit 1 - Adapt ESP_getMaxAllocHeap() and ESP_getHeapFragmentation()

**Problem:**
`ESP_getMaxAllocHeap()` returned `ESP.getFreeHeap()` (total free heap, not the
largest contiguous allocatable block).
`ESP_getHeapFragmentation()` read `ummHeapInfo.maxFreeContiguousBlocks`, which
is only valid immediately after a `umm_info()` heap walk - stale or zero otherwise.

**Fix:**
Both functions now align with their ESP32 equivalents, returning accurate live
values derived from `umm_max_block_size()` and `umm_free_heap_size_lw()`.

A new `ESP_UpdateHeapMetrics()` caches the result of `umm_max_block_size()`
(heap walk, brief IRQ disable). The cache is refreshed:
- once per second in `PerformEverySecond()` when SetOption130 is active
- on demand in `CmndStatus()` before Status 4 output

`umm_max_block_size()` and `umm_free_heap_size_lw()` are unconditionally
available (UMM_INFO and UMM_STATS are hardcoded in `umm_malloc_cfg.h`);
no additional build flags are required.

**Observable changes:**
- SetOption130 heap timestamp on ESP8266 now includes the fragmentation
  percentage. Format changes from `HH:MM:SS.mmm-FreeKB` to
  `HH:MM:SS.mmm-FreeKB/Frag%`. Log parsers using the ESP8266-specific
  single-field format will need updating. The new format matches ESP32 behavior.
- Status 4 (StatusMEM) gains two ESP8266-specific fields:
  `MaxFreeBlock` (KB) and `Frag` (%).

---

## Commit 2 - OOM diagnostics, Status 4 extensions, Status 44 heap dump

Opt-in heap diagnostics gated on `UMM_INLINE_METRICS` or `UMM_STATS_FULL`
build flags. Without these flags: no runtime behavior change.

**OOM event monitoring** (requires `UMM_INLINE_METRICS` or `UMM_STATS_FULL`):
- `ESP_HeapOomCheck()`: called once per second; logs OOM counter delta on
  change (`OOM: count N (+M)`)
- `ESP_HeapOomTest()`: logs current OOM count on demand

**Additional Status 4 fields:**
- `OomCount` - cumulative OOM events (`UMM_INLINE_METRICS` or `UMM_STATS_FULL`)
- `HeapLwm` (KB) - heap low-watermark since boot (`UMM_STATS_FULL`)
- `MaxAllocSz` (bytes) - peak single allocation size (`UMM_STATS_FULL`)

**Status 44** (ESP8266-only):
- Triggers `umm_info(nullptr, true)`: prints full heap block map to serial
- Returns `{"Status44":{"HeapDump":"serial"}}`
- Command number chosen above the standard Status range (0–MAX_STATUS = 0–13)
  and below the reserved value 99 (full status dump)

**Enabling the diagnostic flags:**
The flags must reach the ESP8266 Arduino framework's `umm_malloc` allocator,
which is compiled separately from the Tasmota sketch. `user_config_override.h`
affects only sketch compilation units and cannot reach the framework.
The required mechanism is `build_flags` in `platformio_override.ini`:

```ini
[env]
build_flags = ${common.build_flags}
              -DUMM_STATS_FULL
              -DUMM_INLINE_METRICS
```

Example lines are added to `platformio_override_sample.ini`.

---

### Memory impact (ESP8266, tasmota release build)

| Scope | Flash | RAM | IRAM |
|---|---|---|---|
| Commit 1 (always active) | +~1960 B | +~32 B | 0 |
| Commit 2, no flags | +~84 B | 0 | 0 |
| Commit 2, with `UMM_*` flags | +~492 B | +~40 B | +~300 B |
| **Total, no flags** | **+~2044 B** | **+~32 B** | **0** |
| **Total, with flags** | **+~2452 B** | **+~72 B** | **+~300 B** |

The +300 B IRAM with flags is attributable to OOM monitoring functions
compiled IRAM-resident. This applies only to explicit diagnostic builds;
standard release builds are unaffected (0 IRAM impact).

---

### Tested

Developed and initially tested on Tasmota v15.4.0, ESP-12F.
Build-tested and target-tested on the development branch.
SetOption130 active in both captures below.

**Before** (upstream development, no flags):

```
18:36:07.615-024 CMD: Status 4
18:36:07.627-021 MQT: feedback/heizstab/STATUS4 = {"StatusMEM":{"ProgramSize":659,
  "Free":1388,"Heap":24,"ProgramFlashSize":4096,"FlashSize":4096,
  "FlashChipId":"1625C2","FlashFrequency":40,"FlashMode":"DOUT",
  "Features":[...],"Drivers":"...","Sensors":"..."}}
```

**After** (this PR, `UMM_STATS_FULL` + `UMM_INLINE_METRICS` active):

```
18:40:08.501-023/02 CMD: Status 4
18:40:08.518-020/00 MQT: feedback/heizstab/STATUS4 = {"StatusMEM":{"ProgramSize":662,
  "Free":1384,"Heap":23,"ProgramFlashSize":4096,"FlashSize":4096,
  "FlashChipId":"1625C2","FlashFrequency":40,"FlashMode":"DOUT",
  "MaxFreeBlock":23,"Frag":1,"OomCount":0,"HeapLwm":18,"MaxAllocSz":4096,
  "Features":[...],"Drivers":"...","Sensors":"..."}}
```

Visible changes:
- Timestamp format: `-024` → `-023/02` (FreeKB → FreeKB/Frag%)
- New Status 4 fields: `MaxFreeBlock`, `Frag`, `OomCount`, `HeapLwm`, `MaxAllocSz`
- `ProgramSize` delta: 659 → 662 KB (+3 KB, consistent with measured flash impact)

**Status 44** (heap block map printed to serial, excerpt;
heap map format reference:
[source - umm\_info.c in ESP8266 Arduino core](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/umm_malloc/umm_info.c) /
[docs - rhempel/umm\_malloc](https://github.com/rhempel/umm_malloc)):

```
18:42:20.928-023/03 CMD: Status 44

+----------+-------+--------+--------+-------+--------+--------+
|0x3fff24c0|B     0|NB     1|PB     0|Z     1|NF    67|PF  1313|
|0x3fff24c8|B     1|NB     7|PB     0|Z     6|
|0x3fff25e8|B    37|NB    39|PB    28|Z     2|NF   177|PF   220|
|0x3fff3590|B   538|NB  1051|PB   535|Z   513|
|0x3fff63b8|B  2015|NB  4967|PB  1954|Z  2952|NF  1202|PF  1842|
|0x3fffbff8|B  4967|NB     0|PB  2015|Z     1|NF     0|PF     0|
... (128 entries total)
+----------+-------+--------+--------+-------+--------+--------+
Total Entries   128    Used Entries   116    Free Entries    12
Total Blocks   4966    Used Blocks   1936    Free Blocks   3030
+--------------------------------------------------------------+
Usage Metric:                  63
Fragmentation Metric:           3
+--------------------------------------------------------------+
umm heap statistics:
  Raw Free Space    24240
  OOM Count             0
  Low Watermark     17160
  Low Watermark ISR 21400
  MAX Alloc Request  4096
  Size of umm_block     8
+--------------------------------------------------------------+
18:42:20.557-023/03 OOM: count 0 (test-trigger)
18:42:21.002-020/00 MQT: feedback/heizstab/STATUS44 = {"Status44":{"HeapDump":"serial"}}
```
