### PR TITLE
build: copy firmware artifacts with ELF-extracted build timestamp (opt-in)

### DIFF
--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -37,6 +37,8 @@ BIN_DIR = "bin_dir"
 DISABLE_MAP_GZ = "disable_map_gz"
 # if set, an alternative path to put generated .map files, relative to project directory
 MAP_DIR = "map_dir"
+# if set to 1, copies output .bin/.bin.gz with build timestamp appended to the filename
+APPEND_TIMESTAMP = "append_timestamp"
 
 # === END AVAILABLE OVERRIDES ===
 

--- a/pio-tools/timestamp-firmware.py
+++ b/pio-tools/timestamp-firmware.py
@@ -1,0 +1,128 @@
+Import("env")
+
+import re
+import shutil
+import struct
+import pathlib
+import subprocess
+import tasmotapiolib
+
+_MONTHS = {"Jan":1,"Feb":2,"Mar":3,"Apr":4,"May":5,"Jun":6,
+           "Jul":7,"Aug":8,"Sep":9,"Oct":10,"Nov":11,"Dec":12}
+
+
+def _nm_path(env):
+    return env.subst("$CC").replace("-gcc", "-nm")
+
+
+def _elf_sections(data):
+    """ELF32 LE: return (sh_addr, sh_offset, sh_size) for all SHT_PROGBITS sections."""
+    e_shoff,     = struct.unpack_from("<I", data, 32)
+    e_shentsize, = struct.unpack_from("<H", data, 46)
+    e_shnum,     = struct.unpack_from("<H", data, 48)
+    sections = []
+    for i in range(e_shnum):
+        b = e_shoff + i * e_shentsize
+        sh_type,   = struct.unpack_from("<I", data, b + 4)
+        sh_addr,   = struct.unpack_from("<I", data, b + 12)
+        sh_offset, = struct.unpack_from("<I", data, b + 16)
+        sh_size,   = struct.unpack_from("<I", data, b + 20)
+        if sh_type == 1 and sh_addr and sh_size:  # SHT_PROGBITS with content
+            sections.append((sh_addr, sh_offset, sh_size))
+    return sections
+
+
+def _elf_string(data, sections, vma):
+    """Read null-terminated ASCII string at VMA from ELF data."""
+    for addr, off, size in sections:
+        if addr <= vma < addr + size:
+            start = off + (vma - addr)
+            end   = data.index(b"\x00", start)
+            return data[start:end].decode("ascii")
+    return None
+
+
+def _build_timestamp(env, elf_path):
+    nm = _nm_path(env)
+    r  = subprocess.run([nm, "--defined-only", "--demangle", str(elf_path)],
+                        capture_output=True, text=True)
+    if r.returncode != 0:
+        return None
+
+    date_vma = None
+    time_vma = None
+    for line in r.stdout.splitlines():
+        m = re.match(r"^([0-9a-f]+) \S (.+)$", line)
+        if not m:
+            continue
+        vma, sym = int(m.group(1), 16), m.group(2)
+        if sym == "GetBuildDateAndTime()::mdate_P":
+            date_vma = vma
+        elif sym == "GetBuildDateAndTime()::mtime_P":
+            time_vma = vma
+
+    if date_vma is None or time_vma is None:
+        return None
+
+    data = elf_path.read_bytes()
+    secs = _elf_sections(data)
+
+    date_s = _elf_string(data, secs, date_vma)
+    time_s = _elf_string(data, secs, time_vma)
+    if not date_s or not time_s:
+        return None
+
+    # Parse __DATE__: "May  1 2026" or "Apr 30 2026"
+    parts = date_s.split()
+    if len(parts) != 3 or parts[0] not in _MONTHS:
+        return None
+    month, day, year = _MONTHS[parts[0]], int(parts[1]), int(parts[2])
+
+    # Parse __TIME__: "HH:MM:SS"
+    if not re.fullmatch(r"\d{2}:\d{2}:\d{2}", time_s):
+        return None
+    h, mi, s = (int(x) for x in time_s.split(":"))
+
+    return f"{year:04d}-{month:02d}-{day:02d}T{h:02d}-{mi:02d}-{s:02d}"
+
+
+def _do_copy(source, target, env):
+    if not tasmotapiolib.is_env_set(tasmotapiolib.APPEND_TIMESTAMP, env):
+        return
+
+    elf_path = pathlib.Path(env.subst("$BUILD_DIR")) / "firmware.elf"
+    if not elf_path.is_file():
+        print("timestamp-firmware: firmware.elf not found, skipping")
+        return
+
+    ts = _build_timestamp(env, elf_path)
+    if not ts:
+        print("timestamp-firmware: timestamp extraction failed, skipping")
+        return
+
+    bin_path = tasmotapiolib.get_final_bin_path(env)
+    variant  = bin_path.stem  # e.g. "tasmota-4M"
+
+    out_dir      = bin_path.parent
+    factory_path = out_dir / (bin_path.stem + ".factory.bin")
+    for old, suffix in [
+        (bin_path,                        ".bin"        ),
+        (bin_path.with_suffix(".bin.gz"), ".bin.gz"     ),
+        (factory_path,                    ".factory.bin"),
+        (elf_path,                        ".elf"        ),
+    ]:
+        if old.is_file():
+            new = out_dir / f"{variant}-{ts}{suffix}"
+            shutil.copy(str(old), str(new))
+            print(f"  -> {new.name}")
+
+    map_gz = tasmotapiolib.get_final_map_path(env).with_suffix(".map.gz")
+    if map_gz.is_file():
+        new = map_gz.parent / f"{variant}-{ts}.map.gz"
+        shutil.copy(str(map_gz), str(new))
+        print(f"  -> {new.name}")
+
+
+_act = env.Action(_do_copy)
+_act.strfunction = lambda target, source, env: ""
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", _act)

--- a/platformio.ini
+++ b/platformio.ini
@@ -66,6 +66,8 @@ lib_extra_dirs              =
 ;enable_esp32_gz = 1
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
+; Uncomment to append build timestamp to firmware artifact filenames (default off)
+;append_timestamp = 1
 ; Global build flags (used for all env) can be overridden in "platformio_override.ini"
 build_unflags               =
 build_flags                 =
@@ -82,6 +84,7 @@ extra_scripts               = pre:pio-tools/pre_source_dir.py
 extra_scripts               = post:pio-tools/name-firmware.py
                               post:pio-tools/gzip-firmware.py
                               post:pio-tools/metrics-firmware.py
+                              post:pio-tools/timestamp-firmware.py
                               pre:pio-tools/custom_target.py
 ;                              post:pio-tools/obj-dump.py
                               ${scripts_defaults.extra_scripts}

--- a/tasmota/tasmota_support/support_rtc.ino
+++ b/tasmota/tasmota_support/support_rtc.ino
@@ -82,6 +82,7 @@ String GetBuildDateAndTime(void) {
   char bdt[21];
   char *p;
   static const char mdate_P[] PROGMEM = __DATE__;  // "Mar  7 2017"
+  static const char mtime_P[] PROGMEM = __TIME__;  // "11:08:02"
   char mdate[strlen_P(mdate_P)+1];      // copy on stack first
   strcpy_P(mdate, mdate_P);
   char *smonth = mdate;
@@ -105,7 +106,7 @@ String GetBuildDateAndTime(void) {
   char MonthNamesEnglish[sizeof(kMonthNamesEnglish)];
   strcpy_P(MonthNamesEnglish, kMonthNamesEnglish);
   int month = (strstr(MonthNamesEnglish, smonth) -MonthNamesEnglish) /3 +1;
-  snprintf_P(bdt, sizeof(bdt), PSTR("%d" D_YEAR_MONTH_SEPARATOR "%02d" D_MONTH_DAY_SEPARATOR "%02d" D_DATE_TIME_SEPARATOR "%s"), year, month, day, PSTR(__TIME__));
+  snprintf_P(bdt, sizeof(bdt), PSTR("%d" D_YEAR_MONTH_SEPARATOR "%02d" D_MONTH_DAY_SEPARATOR "%02d" D_DATE_TIME_SEPARATOR "%s"), year, month, day, mtime_P);
   return String(bdt);  // 2017-03-07T11:08:02
 }
 


### PR DESCRIPTION
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

# Description

During the course of console log examination along a serious number of rebuild-and-try
sessions I stumbled across the recurring problem, that I could not easily match
the console output to the ELF file, that produced the output and the crash 
dumps - neither manually nor automatically. The latter was the more painful problem for
my test series'.

A typical solution for this in my MCU world is, to take the firmware timestamp,
which is output at start. Such a timestamp is taken from the compiler while 
building some sort of version header or version build artifact. 

Tasmota has the same best practice of taking the build timestamp and putting it
to the console while booting. This is a lean solution which I aprecciate and tried
to keep, despite the fact, that the information is needed by my tools externally 
from the build artifact. 

## Suggested solution

Some solutions in MCU build systems create the timestamp at start of the build system 
or at start of the compilation stage or at start of the linking stage and inject them
into the build artifacts. This could rely in file system timestamps, on macro
defintions or other mechanisms, like binary patches, etc.

Not relying on file system timestamps, which are unreliable on windows anyways, a
different way of taking the build timestamp from the build process was my option.

Extracting the build timestamp from the resulting ELF file seems the least invasive
idea for the build system and the firmware. Some research showed, that the date part
of the timestamp is alread in a named symbol, the time part not yet - it was anonymous. 

So making a named symbol for the time part was a tiny step in the firmware itself.

Now both timestamp parts are extractable from the ELF file without guessing and an 
external tool could do the rest of the lifting. 

This PR adds `pio-tools/timestamp-firmware.py`, a post-build script that 
copies firmware artifacts to timestamped filenames. Opt-in; disabled by default; 
standard builds are unaffected.

Intended use: correlating captured logs (crash dumps in serial output, automated
test results) with the exact binary that produced them, when multiple builds and 
console logs are archived side by side.

## Enabling

Add to the `[tasmota]` section of `platformio_override.ini`:

```ini
append_timestamp = 1
```

A commented-out example is added to `platformio.ini` alongside the existing
`bin_dir`, `map_dir`, and similar options.

## Artifacts written

(example: `tasmota-4M-2026-05-01T19-02-06`):

```
build_output/firmware/tasmota-4M-2026-05-01T19-02-06.bin
build_output/firmware/tasmota-4M-2026-05-01T19-02-06.bin.gz
build_output/firmware/tasmota-4M-2026-05-01T19-02-06.factory.bin  (ESP32 only)
build_output/firmware/tasmota-4M-2026-05-01T19-02-06.elf
build_output/map/tasmota-4M-2026-05-01T19-02-06.map.gz
```

The originals are kept; the timestamped copies are additions.

---

## Timestamp extraction

The timestamp is read from the ELF symbol table via `nm --defined-only --demangle`,
not from the host clock, not from the file system. This guarantees that the filename 
timestamp matches exactly the one the firmware reports at boot (via `GetBuildDateAndTime()`).

`GetBuildDateAndTime()` in `support_rtc.ino` already stored `__DATE__` in a named
PROGMEM variable (`mdate_P`). This PR adds the equivalent for `__TIME__`:

```cpp
static const char mtime_P[] PROGMEM = __TIME__;
```

Both symbols are then visible to `nm` without a `-g` debug build:

- ESP8266: `PROGMEM` places the symbol in `.irom0.text` (type `t` in nm output);
  visible without `-g`.
- ESP32: `PROGMEM` is a no-op; the `static const` ends up in `.rodata` (type `d`);
  visible without `-g`.

Without the named variable, `PSTR(__TIME__)` produces an anonymous string that is
not locatable by symbol name, particularly on ESP32 where PROGMEM is a no-op.

`nm` is available as the platform-specific `<toolchain-prefix>-nm` alongside the
compiler; `timestamp-firmware.py` derives the path from `$CC` (replacing `-gcc`
with `-nm`), so no additional tool installation is required.

---

## Firmware change

**No firmware behavior change.** The Python script runs post-build and does not
modify firmware content. 

The only firmware change is the added `mtime_P` named variable in 
`support_rtc.ino`; the `snprintf_P` call is updated to reference it
instead of an anonymous `PSTR(__TIME__)`. The string content is identical.

---

**Memory impact (ESP8266, tasmota release build):**

For this type of source change, the final impact is highly dependent on the
version of the optimizers in use. It might introduce an additional stored pointer
or not to the assembly. The tested GCC version introduced the stored pointer.

| | Flash | RAM | IRAM |
|---|---|---|---|
| `mtime_P` named variable (always active) | +4 B | 0 | 0 |
| Post-build script | 0 | 0 | 0 |

+4 B Flash from naming the `__TIME__` string; the string was already present in
the binary as an anonymous literal.

---

## Tested

Build-tested on all available Tasmota targets (ESP8266: all 37 targets pass;
ESP32 Xtensa and RISC-V: all standard targets pass). Symbol extraction verified
on ESP8266 and ESP32 Xtensa without `-g`. RISC-V nm symbol extraction not
explicitly verified, but compilation passed and produced timestamped files too.
