### PR TITLE
Fix Crash when MQTT-TLS when tcp connection failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - NeoPool possible overflow/div-zero errors and Hydrolysis module detection (#24724)
 - Seesaw encoder position tracking in light control mode (#24730)
 - I80 pushColors swap logic for parallel displays (#24766)
+- Crash when MQTT-TLS when tcp connection failed
 
 ### Removed
 - `USE_UNIVERSAL_TOUCH` no more forced when `USE_UNIVERSAL_DISPLAY` is enabled (#24743)

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -121,7 +121,7 @@ class WiFiClientSecure_light : public WiFiClient {
       }
     }
     int32_t getLastCipherSuite(void) {
-      return _eng->session.cipher_suite;
+      return _eng ? _eng->session.cipher_suite : 0;
     }
     inline void setLastError(int32_t err) {
       _last_error = err;

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -1429,7 +1429,7 @@ void MqttReconnect(void) {
     MqttDisconnected(MqttClient.state());
   }
 #ifdef USE_MQTT_TLS
-  if (Mqtt.mqtt_tls) {
+  if (Mqtt.mqtt_tls && (tlsClient != NULL)) {
     int32_t cipher_suite = tlsClient->getLastCipherSuite();
     if (BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 == cipher_suite) {
       AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_MQTT "TLS cipher suite: %s"), PSTR("ECDHE_RSA_AES_128_GCM_SHA256"));


### PR DESCRIPTION
## Description:

Fix Crash when MQTT-TLS when tcp connection failed

**Related issue (if applicable):** fixes #24778

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
