### PR TITLE
rules: pre-populate decompressed rule cache before network stack init

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -933,6 +933,17 @@ void RulesInit(void)
     }
   }
   Rules.teleperiod = false;
+
+#ifdef USE_UNISHOX_COMPRESSION
+  // Pre-populate k_rules[] cache here (FUNC_PRE_INIT), before WiFi/MQTT/WebServer
+  // allocate heap, so the persistent cache lands at low heap addresses instead of
+  // fragmenting the middle of the heap when first rule evaluation occurs later.
+  if (!Settings->flag4.compress_rules_cpu) {
+    for (uint32_t i = 0; i < MAX_RULE_SETS; i++) {
+      if (GetRuleLen(i) > 0) { GetRule(i); }
+    }
+  }
+#endif
 }
 
 void RulesEvery50ms(void)


### PR DESCRIPTION
# Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

# Description

## Problem

`k_rules[]` holds the decompressed text for each active rule set as heap-allocated
`String` objects (800-1100 bytes each, depending on rule content). These were
populated lazily on the first rule evaluation, which occurs after WiFi, MQTT, and
WebServer have already allocated heap. The cache therefore landed in the middle of
an already-fragmented heap and remained there permanently, acting as fragmentation
anchors that split the free heap into smaller non-contiguous regions.

Observed on ESP8266: heap fragmentation at boot reached 25-50%, leaving as little
as 4-8 KB of contiguous free space despite 20+ KB total free heap. Transient
allocations (JSON parsing, MQTT payloads, rule evaluation temporaries) competed
for those fragments; under sustained rule activity this led to allocation failures.

## Fix

Pre-populate `k_rules[]` during `FUNC_PRE_INIT` (`RulesInit`), before any network
stack allocation. The cache then lands at low heap addresses in a clean contiguous
region, leaving the upper heap as a single large unfragmented block available for
transient allocations.

```cpp
#ifdef USE_UNISHOX_COMPRESSION
  if (!Settings->flag4.compress_rules_cpu) {
    for (uint32_t i = 0; i < MAX_RULE_SETS; i++) {
      if (GetRuleLen(i) > 0) { GetRule(i); }
    }
  }
#endif
```

Active only when `USE_UNISHOX_COMPRESSION` is defined (standard Tasmota build) and
`compress_rules_cpu` is off (SetOption93 = 0, the cache-active code path).
When SetOption93 = 1, rules are decompressed on each evaluation with no persistent
cache; this code path is unchanged.

## Observed effect (ESP8266, two nearly-full rule sets)

- Heap fragmentation at boot: 25-50% -> ~1%
- Contiguous free space after boot: 4-8 KB -> ~24 KB

The cache objects themselves are the same size as before; only their position in
the heap changes. Total heap consumption at steady state is unchanged.

## Memory impact (ESP8266, tasmota release build)

| | Flash | RAM | IRAM |
|---|---|---|---|
| Code change | +32 B | 0 | 0 |

0 static RAM: no new variables. 0 IRAM: rules code resides in flash.
Runtime heap: unchanged in total; allocation order changes as described above.
The +32 B Flash is the cost of moving from lazy to eager cache population.

## Tested

Developed and target-tested on ESP8266 (ESP-12F). Build-test on all targets passed
for all major targets.
