### PR TITLE
Berry `write(value:int | s:string) -> nil` internal argument parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 - Seesaw encoder position tracking in light control mode (#24730)
 - I80 pushColors swap logic for parallel displays (#24766)
 - Crash when MQTT-TLS when tcp connection failed
+- Berry `write(value:int | s:string) -> nil` internal argument parsing
 
 ### Removed
 - `USE_UNIVERSAL_TOUCH` no more forced when `USE_UNIVERSAL_DISPLAY` is enabled (#24743)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -199,7 +199,7 @@ extern "C" {
         int32_t value = be_toint(vm, 2);
         myWire.write(value);
       } else if (be_isstring(vm, 2)) {
-        const char * s = be_tostring(vm, 1);
+        const char * s = be_tostring(vm, 2);
         myWire.write((uint8_t*) s, strlen(s));
       } else if ((buf = be_tobytes(vm, 2, &len)) != nullptr) {
         myWire.write((uint8_t*) buf, len);


### PR DESCRIPTION
## Description:

Fix embarassing bug in `write(value:int | s:string) -> nil` that would fail completely when the argument is a string. Luckily it looks like nobody ever used this feature.

Found by Claude Sonnet 4.6

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
