### PR TITLE
Add missing break

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -267,6 +267,7 @@ void BerryObservability(bvm *vm, int event, ...) {
           be_dumpstack(vm);
         }
       }
+      break;
     case BE_OBS_GC_START:
       {
         gc_time = millis();


### PR DESCRIPTION
## Description:

Fix missing `breal;` in Berry observability `case`. Impact if low, it would occasionally make wrong GC stats.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
