### PR TITLE
Fix various bugs

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
@@ -75,7 +75,6 @@ class SendEmail
     const String user;
     const String passwd;
     const int timeout;
-    const bool ssl;
     const int auth_used;
     // use bear ssl
     BearSSL::WiFiClientSecure_light *client;
@@ -96,7 +95,6 @@ SendEmail::SendEmail(const String& host, const int port, const String& user, con
   user(user),
   passwd(passwd),
   timeout(timeout),
-  ssl(ssl),
   auth_used(auth_used),
   client(new BearSSL::WiFiClientSecure_light(1024,1024)) {
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_122_file_json_settings_demo.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_122_file_json_settings_demo.ino
@@ -164,7 +164,7 @@ void CmndDrvText(void) {
       // Command DrvText<index> <text>
       uint32_t index = XdrvMailbox.index -1;
       if (XdrvMailbox.data_len > 0) {
-        snprintf_P(DrvDemoSettings.drv_text[index], sizeof(DrvDemoSettings.drv_text[index]), XdrvMailbox.data);
+        snprintf_P(DrvDemoSettings.drv_text[index], sizeof(DrvDemoSettings.drv_text[index]), PSTR("%s"), XdrvMailbox.data);
       }
       ResponseCmndIdxChar(DrvDemoSettings.drv_text[index]);
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_122_file_settings_demo.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_122_file_settings_demo.ino
@@ -68,7 +68,7 @@ void CmndDrvText(void) {
       // Command DrvText<index> <text>
       uint32_t index = XdrvMailbox.index -1;
       if (XdrvMailbox.data_len > 0) {
-        snprintf_P(DrvDemoSettings.drv_text[index], sizeof(DrvDemoSettings.drv_text[index]), XdrvMailbox.data);
+        snprintf_P(DrvDemoSettings.drv_text[index], sizeof(DrvDemoSettings.drv_text[index]), PSTR("%s"), XdrvMailbox.data);
       }
       ResponseCmndIdxChar(DrvDemoSettings.drv_text[index]);
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_31_tasmota_client.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_31_tasmota_client.ino
@@ -77,7 +77,7 @@ struct SimpleHexParse {
 
 uint8_t SimpleHexParseGetByte(char* hexline, uint8_t idx) {
   char buff[3];
-  buff[3] = '\0';
+  buff[2] = '\0';
   memcpy(&buff, &hexline[(idx*2)-2], 2);
   return strtol(buff, 0, 16);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
@@ -56,7 +56,7 @@ extern "C" {
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 1 && be_isint(vm, 1)) {
       int32_t n = be_toint(vm, 1);
-      if (n < 0 || n > 4096) { be_raise(vm, "value_error", ""); }
+      if (n < 0 || n > 2048) { be_raise(vm, "value_error", ""); }
 
       uint8_t rand_bytes[n];
       esp_fill_random(rand_bytes, n);

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_pixmat.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_pixmat.ino
@@ -376,7 +376,12 @@ int be_pixmat_scroll(bvm* vm) {
     }
 
     size_t need = (dir < 2 ? w : h) * bpp;
-    uint8_t edge[256], pix[8];
+    uint8_t* edge_heap = nullptr;
+    uint8_t* edge = (need <= 2048)
+                    ? (uint8_t*)alloca(need > 0 ? need : 1)
+                    : (edge_heap = (uint8_t*)malloc(need));
+    if (!edge) be_raise(vm, "memory_error", "scroll: out of memory");
+    uint8_t pix[8];
 
     auto save_row  = [&](int y, PixmatCore* m) { for (int x = 0; x < w; ++x) m->load(x, y, edge + x * bpp); };
     auto save_col  = [&](int x, PixmatCore* m) { for (int y = 0; y < h; ++y) m->load(x, y, edge + y * bpp); };
@@ -425,6 +430,7 @@ int be_pixmat_scroll(bvm* vm) {
             break;
     }
 
+    free(edge_heap);
     be_return_nil(vm);
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tf_lite_micro.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tf_lite_micro.ino
@@ -493,7 +493,7 @@ void TFL_task_loop(void *pvParameters){
       TFL->stats->invocations++;
       TFL->option.unread_output = 1;
       TFL->option.running_invocation = 0;
-      TFL->option.new_input_data == 0;
+      TFL->option.new_input_data = 0;
     }
     if(TFL->option.running_loop == 1) vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(1000 / TFL->max_invocations)); //maybe we already want to exit
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -985,13 +985,13 @@ public:
     // AddLog(LOG_LEVEL_INFO, "FLASH: addr=%p  hex=%*_H  size=%i", addr_start + offset, 32, buffer, size);
     if (offset + size > signed_size){
       AddLog(LOG_LEVEL_ERROR, "BERRYWC: buffer overrun");
-      return size;
+      return 0;
     }
 
     char *bytebuf = (char*) be_tobytes(vm, -1, NULL); /* we get the address of the internam buffer of size 'size' */
     if (!bytebuf){
       AddLog(LOG_LEVEL_ERROR, "BERRYWC: buffer null??");
-      return size;
+      return 0;
     }
 
     // stream in our chunk

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -74,7 +74,7 @@ TwoWire & getWire(bvm *vm) {
 #endif  // MAX_I2C
   } else {
     be_raise(vm, "configuration_error", "I2C bus not initiliazedd");
-    return *(TwoWire*)nullptr;
+    __builtin_unreachable();  // be_raise() never returns (longjmp); suppress missing-return warning
   }
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -495,9 +495,14 @@ void CmndBrRun(void) {
 
   if (berry.vm == nullptr) { ResponseCmndChar_P(PSTR(D_BR_NOT_STARTED)); return; }
 
-  char br_cmd[XdrvMailbox.data_len+12];
+  // Use stack VLA for small payloads (≤ 2048 bytes); heap for large ones to avoid stack overflow
+  const uint32_t br_cmd_len = XdrvMailbox.data_len + 12;
+  char* br_cmd_heap = (br_cmd_len > 2048) ? (char*)malloc(br_cmd_len) : nullptr;
+  if (br_cmd_len > 2048 && br_cmd_heap == nullptr) { ResponseCmndChar_P(PSTR("out of memory")); return; }
+  char br_cmd_vla[br_cmd_len <= 2048 ? br_cmd_len : 1];  // only used when br_cmd_len <= 2048
+  char* br_cmd = (br_cmd_len <= 2048) ? br_cmd_vla : br_cmd_heap;
   // encapsulate into a function, copied from `be_repl.c` / `try_return()`
-  snprintf_P(br_cmd, sizeof(br_cmd), PSTR("return (%s)"), XdrvMailbox.data);
+  snprintf_P(br_cmd, br_cmd_len, PSTR("return (%s)"), XdrvMailbox.data);
 
   checkBeTop();
   do {
@@ -530,11 +535,9 @@ void CmndBrRun(void) {
   }
 
   checkBeTop();
+  if (br_cmd_heap != nullptr) { free(br_cmd_heap); }
 }
 
-/*********************************************************************************************\
- * Berry console
-\*********************************************************************************************/
 #ifdef USE_WEBSERVER
 
 void BrREPLRun(char * cmd) {


### PR DESCRIPTION
## Description:

Fix various bugs found by Claude Sonnet 4.6 after systematic scan:
- `xdrv_01_1_webserver_mail.ino`: remove unused `ssl` field
- `xdrv_52_3_berry_pixmat.ino`: potential buffer overflow for large matrix
- `xdrv_52_3_berry_tf_lite_micro.ino`: typo
- `xdrv_52_3_berry_webclient.ino`: wrong return argument in case of error
- `xdrv_52_3_berry_wire.ino`: use preferabl `__builtin_unreachable();`construct
- `xdrv_52_9_berry.ino`: protect stack in case of `BrRun` with payload above 2048 bytes
- `xdrv_122_file_json_settings_demo.ino` and `xdrv_122_file_settings_demo.ino`: harden string formatting
- `xdrv_31_tasmota_client.ino`: wrong termination of string
- `xdrv_52_3_berry_crypto.ino`: limit `crypto.random()` to 2048 bytes to protect the stack

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
