### PR TITLE
dali: allow using TM_DALI_SEND_TWICE for 3 byte frames

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_75_dali.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_75_dali.ino
@@ -354,7 +354,7 @@ void DaliSendData(uint32_t adr, uint32_t cmd) {
   DaliFrame frame;
   if (adr & TM_DALI_EVENT_FRAME) {             // 24-bit event frame
     frame.data = cmd;
-    frame.meta = adr & TM_DALI_BIT_COUNT_MASK;
+    frame.meta = adr & (TM_DALI_BIT_COUNT_MASK | TM_DALI_SEND_TWICE);
   } else {                                     // 16-bit command frame
     adr &= 0xFF;
     cmd &= 0xFF;
@@ -1289,7 +1289,14 @@ void CmndDaliSend(void) {
 
   if (255 == XdrvMailbox.index) {                   // DaliSend255 <bitcount>,<value> - Dali-2 24-bit frame
     if (params >= 2) {
-      DaliSendData(values[0] | TM_DALI_EVENT_FRAME, values[1]);
+      DaliSendData((values[0] & TM_DALI_BIT_COUNT_MASK) | TM_DALI_EVENT_FRAME, values[1]);
+      ResponseCmndDone();
+    }
+    return;
+  }
+  if (256 == XdrvMailbox.index) {                   // DaliSend256 <bitcount>,<value> - Dali-2 24-bit frame
+    if (params >= 2) {
+      DaliSendData((values[0] & TM_DALI_BIT_COUNT_MASK) | TM_DALI_EVENT_FRAME | TM_DALI_SEND_TWICE, values[1]);
       ResponseCmndDone();
     }
     return;


### PR DESCRIPTION
This helps configuring input devices as they need frames of three bytes length and need the command twice. Just calling DaliSend twice is not enough for this due to the delay.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
    - was tested on base of v15.3.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).