### PR TITLE
Artnet check `datalen` does not exceed payload length

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
@@ -143,9 +143,7 @@ void ArtNetProcessPacket(uint8_t * buf, size_t len) {
 //  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("DMX: opcode=0x%04X procotol=%i universe=%i datalen=%i univ_start=%i univ_end=%i"), opcode, protocol, universe, datalen, artnet_conf.univ, artnet_conf.univ + artnet_conf.rows);
   if (opcode != 0x5000 || protocol != 14) { return; }
 
-//  if (len + 18 < datalen) {
-//    AddLog(LOG_LEVEL_DEBUG, PSTR("DMX: packet is truncated. Expected: %u Bytes, Received: %u Bytes."), datalen, len + 18);
-//  }
+  if (datalen > len - 18) { return; }  // datalen must not exceed actual received payload length
 
   if (universe < artnet_conf.univ || universe >= artnet_conf.univ + artnet_conf.rows) { return; }  // universe is not ours, ignore
   size_t idx = 18;      // start of payload data in the UDP frame


### PR DESCRIPTION
## Description:

Artnet check `datalen` does not exceed payload length.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
