### PR TITLE
Berry mapping minor fixes

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -352,7 +352,7 @@ extern "C" {
       if (pixel_size > 4) { pixel_size = 4; }
       // arg5: bri:int (0..255)
       int32_t bri255 = 255;
-      if (top >= 3 && be_isint(vm, 5)) {
+      if (top >= 5 && be_isint(vm, 5)) {  // L-16: was `top >= 3` which never guards slot 5 correctly
         bri255 = be_toint(vm, 5);
       }
       if (bri255 < 0)  { bri255 = 0; }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
@@ -243,7 +243,7 @@ extern "C" {
   #else
         head->addr.u_addr.ip4.addr = (uint32_t) ip;
   #endif
-      } while (0);
+      }
 
       if (err == ESP_OK && head != nullptr) {
         err = mdns_delegate_hostname_add(hostname, head);

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tcpserver.ino
@@ -150,10 +150,16 @@ void WiFiServerAsync::begin(uint16_t port, int enable){
   }
   memset(server.sin6_addr.s6_addr, 0x0, 16);
   server.sin6_port = htons(_port);
-  if(bind(sockfd, (struct sockaddr *)&server, sizeof(server)) < 0)
+  if(bind(sockfd, (struct sockaddr *)&server, sizeof(server)) < 0) {
+    lwip_close(sockfd);   // close fd to avoid leak on bind failure
+    sockfd = -1;
     return;
-  if(listen(sockfd , _max_clients) < 0)
+  }
+  if(listen(sockfd , _max_clients) < 0) {
+    lwip_close(sockfd);   // close fd to avoid leak on listen failure
+    sockfd = -1;
     return;
+  }
   fcntl(sockfd, F_SETFL, O_NONBLOCK);
   _listening = true;
   _noDelay = false;

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -546,6 +546,7 @@ void BrREPLRun(char * cmd) {
   size_t cmd_len = strlen(cmd);
   size_t cmd2_len = cmd_len + 12;
   char * cmd2 = (char*) malloc(cmd2_len);
+  if (!cmd2) { return; }  // guard against malloc failure
   do {
     int32_t ret_code;
 


### PR DESCRIPTION
## Description:

Berry mapping minor fixes:
- `xdrv_52_3_berry_leds.ino`: wrong parameter number check in `be_leds_set_pixels()`
- `xdrv_52_3_berry_mdns.ino`: remove dead code `while(0);`
- `xdrv_52_3_berry_tcpserver.ino`: close socket in case of error with `lwip_close()`
- `xdrv_52_9_berry.ino`: check `NULL` on `malloc()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
