### PR TITLE
Ethernet strcat safety

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -258,7 +258,7 @@ void EthernetInit(void) {
   eth_config_change = 0;
 
   strlcpy(eth_hostname, TasmotaGlobal.hostname, sizeof(eth_hostname) -5);  // Make sure there is room for "-eth"
-  strcat(eth_hostname, "-eth");
+  strlcat(eth_hostname, "-eth", sizeof(eth_hostname));  // use strlcat for defense in depth
 
   WiFi.onEvent(EthernetEvent);
 


### PR DESCRIPTION
## Description:

Use `strlcat` instead of `strcat` as a safer option.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
