### PR TITLE
Serial console support for Backspace when enabling `#define USE_SERIAL_BACKSPACE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [15.4.0.3]
 ### Added
+- Serial console support for Backspace when enabling `#define USE_SERIAL_BACKSPACE`
 
 ### Breaking Changed
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -412,6 +412,9 @@
 #define WIFI_SOFT_AP_CHANNEL   1                 // Soft Access Point Channel number between 1 and 13 as used by Wi-Fi Manager web GUI
 #define USE_IMPROV                               // Add support for IMPROV serial protocol as used by esp-web-tools (+2k code)
 
+// -- Serial input --------------------------------
+//#define USE_SERIAL_BACKSPACE                     // Add support for backspace (0x08) in serial console input, removing the last typed character
+
 // -- IPv6 support -------------------------------
 // #define USE_IPV6                                 // Enable IPv6 support (if the underlying esp-idf is also configured to support it)
                                                  // Code size increase: ESP8266: +34.5kb

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1877,6 +1877,11 @@ void SerialInput(void) {
           serial_buffer_overrun = true;                                            // Signal overrun but continue reading input to flush until '\n' (EOL)
         }
       }
+#ifdef USE_SERIAL_BACKSPACE
+      else if (TasmotaGlobal.serial_in_byte == 0x08 && TasmotaGlobal.serial_in_byte_counter > 0) { // Backspace (BS) - remove last char from buffer
+        TasmotaGlobal.serial_in_byte_counter--;
+      }
+#endif  // USE_SERIAL_BACKSPACE
     } else {
       if (TasmotaGlobal.serial_in_byte || Settings->flag.mqtt_serial_raw) {        // Any char between 1 and 127 or any char (0 - 255) - CMND_SERIALSEND3
         bool in_byte_is_delimiter =                                                // Char is delimiter when...
@@ -1997,6 +2002,11 @@ void TasConsoleInput(void) {
     if (XYZModemStart(TXMP_TASCONSOLE, console_in_byte)) { return; }
 #endif  // USE_XYZMODEM
 
+#ifdef USE_SERIAL_BACKSPACE
+    if (console_in_byte == 0x08 && console_buffer.length() > 0) { // Backspace (BS) - remove last char from buffer
+      console_buffer.remove(console_buffer.length() - 1);
+    } else
+#endif  // USE_SERIAL_BACKSPACE
     if (isprint(console_in_byte)) {                       // Any char between 32 and 127
       if (console_buffer.length() < INPUT_BUFFER_SIZE) {  // Add char to string if it still fits
         console_buffer += console_in_byte;


### PR DESCRIPTION
## Description:

Optional support for backspace in Serial console when compiling with `#define USE_SERIAL_BACKSPACE` (not enabled by default)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
