### PR TITLE
Code hardening replacing `strcat` and `strcpy` with safer alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - SCD30 library FrogmoreScd30 to Sensirion arduino-i2c-scd30 v1.1.1
 - SCD4x library FrogmoreScd40 to Sensirion arduino-i2c-scd4x v1.1.0
 - SPS30 library Sensirion arduino-i2c-sps30 v1.0.1
+- Code hardening replacing `strcat` and `strcpy` with safer alternatives
 
 ### Fixed
 

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2820,7 +2820,7 @@ void AddLogData(uint32_t loglevel, const char* log_data, const char* log_data_pa
       mxtime, ESP_getFreeHeap1024(), ESP_getHeapFragmentation());
 #endif  // ESP8266 or ESP32
   }
-  strcat(mxtime, " ");
+  strlcat(mxtime, " ", sizeof(mxtime));
 
   char empty[2] = { 0 };
   if (!log_data_payload) { log_data_payload = empty; }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -551,9 +551,8 @@ void CmndBacklog(void) {
       }
       // Do not allow command Reset in backlog
       if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0))  {
-        char* temp = (char*)malloc(strlen(blcommand)+1);
+        char* temp = strdup(blcommand);
         if (temp != nullptr) {
-          strcpy(temp, blcommand);
           char* &elem = backlog.addToLast();
           elem = temp;
         }
@@ -773,9 +772,8 @@ bool SetTimedCmnd(uint32_t time, const char *command) {
     }
   }
   // Add command
-  char* cmnd = (char*)malloc(strlen(command) +1);
+  char* cmnd = strdup(command);
   if (cmnd) {
-    strcpy(cmnd, command);
     tTimedCmnd &elem = timed_cmnd.addToLast();
     elem.time = millis() + time;
     elem.command = cmnd;
@@ -1964,7 +1962,7 @@ void CmndModule(void)
   if (XdrvMailbox.index == 2) {
     module_real = Settings->fallback_module;
     module_number = (USER_MODULE == Settings->fallback_module) ? 0 : Settings->fallback_module +1;
-    strcat(XdrvMailbox.command, "2");
+    strlcat(XdrvMailbox.command, "2", CMDSZ);
   }
   Response_P(S_JSON_COMMAND_NVALUE_SVALUE, XdrvMailbox.command, module_number, AnyModuleName(module_real).c_str());
 }

--- a/tasmota/tasmota_support/support_device_groups.ino
+++ b/tasmota/tasmota_support/support_device_groups.ino
@@ -143,12 +143,12 @@ void DeviceGroupsInit(void)
 
   struct device_group * device_group = device_groups;
   for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++, device_group++) {
-    strcpy(device_group->group_name, SettingsText(SET_DEV_GROUP_NAME1 + device_group_index));
+    strlcpy(device_group->group_name, SettingsText(SET_DEV_GROUP_NAME1 + device_group_index), sizeof(device_group->group_name));
 
     // If the device group name is not set, use the MQTT group topic (with the device group index +
     // 1 appended for device group indices > 0).
     if (!device_group->group_name[0]) {
-      strcpy(device_group->group_name, SettingsText(SET_MQTT_GRP_TOPIC));
+      strlcpy(device_group->group_name, SettingsText(SET_MQTT_GRP_TOPIC), sizeof(device_group->group_name));
       if (device_group_index) {
         snprintf_P(device_group->group_name, sizeof(device_group->group_name), PSTR("%s%u"), device_group->group_name, device_group_index + 1);
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
@@ -418,8 +418,8 @@ void attach_Array(char *aname) {
     snprintf_P(buff, sizeof(buff), PSTR("Content-Disposition: attachment; filename=\"%s.txt\"\r\n\r\n"), aname);
     g_client->write(buff);
     // send timestamp
-    strcpy(buff, GetDateAndTime(DT_LOCAL).c_str());
-    strcat(buff, "\t");
+    strlcpy(buff, GetDateAndTime(DT_LOCAL).c_str(), sizeof(buff));
+    strlcat(buff, "\t", sizeof(buff));
     g_client->write(buff);
 
     float *fp=array;
@@ -428,9 +428,9 @@ void attach_Array(char *aname) {
       char nbuff[16];
       flt2char(*fp++, nbuff);
       if (cnt < (alen - 1)) {
-        strcat(nbuff, "\t");
+        strlcat(nbuff, "\t", sizeof(nbuff));
       } else {
-        strcat(nbuff, "\n");
+        strlcat(nbuff, "\n", sizeof(nbuff));
       }
       g_client->write(nbuff, strlen(nbuff));
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_2_webserver_esp32_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_2_webserver_esp32_mail.ino
@@ -283,8 +283,8 @@ uint16_t SendMail(char *buffer) {
 void attach_File(char *path) {
   SMTP_Attachment att;
   if (num_attachments < MAX_ATTCHMENTS) {
-    attachments[num_attachments] = (char*)malloc(32);
-    strcpy(attachments[num_attachments], path);
+    attachments[num_attachments] = strdup(path);
+    if (!attachments[num_attachments]) { return; }
 
     char *cp = attachments[num_attachments];
     att.file.path = cp;
@@ -331,16 +331,17 @@ void attach_Array(char *aname) {
       char nbuff[16];
       flt2char(*fp++, nbuff);
       if (cnt < (alen - 1)) {
-        strcat(nbuff, "\t");
+        strlcat(nbuff, "\t", sizeof(nbuff));
       } else {
-        strcat(nbuff, "\n");
+        strlcat(nbuff, "\n", sizeof(nbuff));
       }
       ttstr += nbuff;
     }
 
     if (num_attachments < MAX_ATTCHMENTS) {
       attachments[num_attachments] = (char*)malloc(ttstr.length() + 1 + 32);
-      strcpy(attachments[num_attachments] + 32, ttstr.c_str());
+      if (!attachments[num_attachments]) { return; }
+      strlcpy(attachments[num_attachments] + 32, ttstr.c_str(), ttstr.length()+1);
       sprintf(attachments[num_attachments], "%s.txt", aname);
       attach_Data(attachments[num_attachments], (uint8_t*)attachments[num_attachments]+32, ttstr.length());
       num_attachments++;

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -829,7 +829,7 @@ void MqttPublishPayloadPrefixTopic_P(uint32_t prefix, const char* subtopic, cons
     // compute the target topic
     char *topic = SettingsText(SET_MQTT_TOPIC);
     char topic2[strlen(topic)+1];       // save buffer onto stack
-    strcpy(topic2, topic);
+    strlcpy(topic2, topic, sizeof(topic2));
     // replace any '/' with '_'
     char *s = topic2;
     while (*s) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_07_domoticz.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_07_domoticz.ino
@@ -277,7 +277,7 @@ bool DomoticzMqttData(void) {
 
 #ifdef USE_DOMOTICZ_DEBUG
   char dom_data[XdrvMailbox.data_len +1];
-  strcpy(dom_data, XdrvMailbox.data);
+  strlcpy(dom_data, XdrvMailbox.data, sizeof(dom_data));
   AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_DOMOTICZ "%s = %s"), XdrvMailbox.topic, RemoveControlCharacter(dom_data));
 #endif  // USE_DOMOTICZ_DEBUG
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_07_ufs_domoticz.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_07_ufs_domoticz.ino
@@ -468,7 +468,7 @@ bool DomoticzMqttData(void) {
 
 #ifdef USE_DOMOTICZ_DEBUG
   char dom_data[XdrvMailbox.data_len +1];
-  strcpy(dom_data, XdrvMailbox.data);
+  strlcpy(dom_data, XdrvMailbox.data, sizeof(dom_data));
   AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_DOMOTICZ "%s = %s"), XdrvMailbox.topic, RemoveControlCharacter(dom_data));
 #endif  // USE_DOMOTICZ_DEBUG
 
@@ -934,7 +934,7 @@ void HandleDomoticzConfiguration(void) {
 String DomoticzAddWebCommand(const char* command, const char* arg, uint32_t value) {
   char tmp[8];                       // WebGetArg numbers only
   WebGetArg(arg, tmp, sizeof(tmp));
-  if (!strlen(tmp)) { strcpy(tmp, "0"); }
+  if (!strlen(tmp)) { strlcpy(tmp, "0", sizeof(tmp)); }
   if (atoi(tmp) == value) { return ""; }
   return AddWebCommand(command, arg, PSTR("0"));
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1087,12 +1087,12 @@ bool RulesMqttData(void) {
   bool serviced = false;
   String buData = XdrvMailbox.data;            // Destroyed by JsonParser. Could be very long SENSOR message
   char ctopic[strlen(XdrvMailbox.topic)+1];
-  strcpy(ctopic, XdrvMailbox.topic);           // Destroyed by result of following iteration
+  strlcpy(ctopic, XdrvMailbox.topic, sizeof(ctopic));           // Destroyed by result of following iteration
 
   for (auto &event_item : subscriptions) {     // Looking for all matched topics
     char etopic[strlen(event_item.topic)+2];
-    strcpy(etopic, event_item.topic);          // tele/tasmota/SENSOR
-    strcat(etopic, "/");                       // tele/tasmota/SENSOR/
+    strlcpy(etopic, event_item.topic, sizeof(etopic));          // tele/tasmota/SENSOR
+    strlcat(etopic, "/", sizeof(etopic));                       // tele/tasmota/SENSOR/
     if ((strcmp(ctopic, event_item.topic) == 0) ||         // Equal tele/tasmota/SENSOR
         (strncmp(ctopic, etopic, strlen(etopic)) == 0)) {  // StartsWith tele/tasmota/SENSOR/
 
@@ -1107,7 +1107,7 @@ bool RulesMqttData(void) {
         if (!jsonData) { break; }              // Failed to parse JSON data, ignore this message.
 
         char ckey1[strlen(event_item.key)+1];
-        strcpy(ckey1, event_item.key);         // DS18B20.Temperature
+        strlcpy(ckey1, event_item.key, sizeof(ckey1));         // DS18B20.Temperature
         char* ckey2 = strchr(ckey1, '.');
         if (ckey2 != nullptr) {                // .Temperature
           *ckey2++ = '\0';                     // Temperature and ckey1 becomes DS18B20
@@ -1142,8 +1142,8 @@ bool RuleUnsubscribe(const char* event) {
         (strcmp(event, index.event) == 0)) {   // Equal
       //If find exists one, remove it.
       char stopic[strlen(index.topic)+3];
-      strcpy(stopic, index.topic);
-      strcat(stopic, "/#");
+      strlcpy(stopic, index.topic, sizeof(stopic));
+      strlcat(stopic, "/#", sizeof(stopic));
       MqttUnsubscribe(stopic);
       free(index.key);
       free(index.topic);
@@ -1185,25 +1185,23 @@ void CmndSubscribe(void) {
       // Add "/#" to the topic
       uint32_t slen = strlen(topic);
       char stopic[slen +3];
-      strcpy(stopic, topic);
+      strlcpy(stopic, topic, sizeof(stopic));
       if (stopic[slen-1] != '#') {
         if (stopic[slen-1] == '/') {
-          strcat(stopic, "#");
+          strlcat(stopic, "#", sizeof(stopic));
         } else {
-          strcat(stopic, "/#");
+          strlcat(stopic, "/#", sizeof(stopic));
         }
       }
 
       if (!key) { key = EmptyStr; }
 
       // MQTT Subscribe
-      char* hevent = (char*)malloc(strlen(event) +1);
+      char* hevent = strdup(event);
       char* htopic = (char*)malloc(strlen(stopic) -1);  // Remove "/#"
-      char* hkey = (char*)malloc(strlen(key) +1);
+      char* hkey = strdup(key);
       if (hevent && htopic && hkey) {
-        strcpy(hevent, event);
         strlcpy(htopic, stopic, strlen(stopic)-1);      // Remove "/#" so easy to match
-        strcpy(hkey, key);
         MQTT_Subscription &subscription_item = subscriptions.addToLast();
         subscription_item.event = hevent;
         subscription_item.topic = htopic;
@@ -1640,7 +1638,7 @@ float evaluateExpression(const char * expression, unsigned int len) {
 void CmndIf(void) {
   if (XdrvMailbox.data_len > 0) {
     char parameters[XdrvMailbox.data_len +1];
-    strcpy(parameters, XdrvMailbox.data);
+    strlcpy(parameters, XdrvMailbox.data, sizeof(parameters));
     ProcessIfStatement(parameters);
   }
   ResponseCmndDone();
@@ -2010,9 +2008,8 @@ void ExecuteCommandBlock(const char * commands, int len)
 
     if (strlen(blcommand)) {
       //Insert into backlog
-      char* temp = (char*)malloc(strlen(blcommand)+1);
+      char* temp = strdup(blcommand);
       if (temp != nullptr) {
-        strcpy(temp, blcommand);
         char* &elem = backlog.insertAt(insertPosition++);
         elem = temp;
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_12_home_assistant.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_12_home_assistant.ino
@@ -968,7 +968,7 @@ void HAssAnnounceSensors(void)
     TasmotaGlobal.tele_period = tele_period_save;
     size_t sensordata_len = ResponseLength();
     char sensordata[sensordata_len+2];   // dynamically adjust the size
-    strcpy(sensordata, ResponseData());    // we can use strcpy since the buffer has the right size
+    strlcpy(sensordata, ResponseData(), sizeof(sensordata));    // we can use strlcpy since the buffer has the right size
 
     // ******************* JSON TEST *******************
     // char sensordata[512];

--- a/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_13_display.ino
@@ -1379,8 +1379,8 @@ void define_dt_var(uint32_t num, uint32_t xp, uint32_t yp,  uint32_t txtbcol,  u
     return;
   }
   dtp->rstr[0] = 0;
-  strcpy(dtp->unit, unit);
-  strcpy(dtp->jstrbuf, jstr);
+  strlcpy(dtp->unit, unit, sizeof(dtp->unit));
+  strlcpy(dtp->jstrbuf, jstr, jlen+2);
   if (!time) time = 1;
   dtp->timer = time;
 }
@@ -1398,9 +1398,9 @@ void draw_dt_vars(void) {
           dtp->timer = dtp->time;
           char vstr[MAX_DVTSIZE + 7];
           memset(vstr, ' ', sizeof(vstr));
-          strcpy(vstr, dtp->rstr);
-          strcat(vstr, " ");
-          strcat(vstr, dtp->unit);
+          strlcpy(vstr, dtp->rstr, sizeof(vstr));
+          strlcat(vstr, " ", sizeof(vstr));
+          strlcat(vstr, dtp->unit, sizeof(vstr));
           uint16_t slen = strlen(vstr);
           vstr[slen] = ' ';
 
@@ -1488,7 +1488,7 @@ void get_dt_vars(char *json) {
           if (res) {
             if (dt_vars[cnt]->dp < 0) {
               // use string
-              strcpy(dt_vars[cnt]->rstr, sbuf);
+              strlcpy(dt_vars[cnt]->rstr, sbuf, sizeof(dt_vars[cnt]->rstr));
             } else {
               // convert back and forth
               dtostrfd(CharToFloat(sbuf), dt_vars[cnt]->dp, dt_vars[cnt]->rstr);
@@ -1732,7 +1732,7 @@ void DisplayJsonValue(const char* topic, const char* mkey, const char* value) {
   uint32_t size = strlen(topic);
   if ((Settings->display_rows > 4) && size) {                             // Skip header if less than five rows
     if (strcmp(topic, disp_topic)) {                                      // Show topic header only once
-      strcpy(disp_topic, topic);
+      strlcpy(disp_topic, topic, sizeof(disp_topic));
       char buffer2[Settings->display_cols[0] +1];                         // Max sized buffer string
       memset(buffer2, '-', sizeof(buffer2));                              // Set to -
       buffer2[sizeof(buffer2) -1] = '\0';
@@ -2375,7 +2375,7 @@ void DisplayReInitDriver(void) {
 // very limited path size, so, add .jpg
 void draw_picture(char *path, uint32_t xp, uint32_t yp, uint32_t xs, uint32_t ys, uint32_t ocol, bool inverted) {
 char ppath[16];
-  strcpy(ppath, path);
+  strlcpy(ppath, path, sizeof(ppath));
   uint8_t plen = strlen(path) -1;
   if (ppath[plen]=='1') {
     // index mode
@@ -2385,9 +2385,9 @@ char ppath[16];
     inverted = false;
   }
   if (ocol == 9) {
-    strcat(ppath, ".rgb");
+    strlcat(ppath, ".rgb", sizeof(ppath));
   } else {
-    strcat(ppath, ".jpg");
+    strlcat(ppath, ".jpg", sizeof(ppath));
   }
   Draw_RGB_Bitmap(ppath, xp, yp, 0, inverted, 0, 0);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v2.ino
@@ -260,7 +260,7 @@ int init_tuya_struct() {
   if (pTuya) return 0;  // done already
   pTuya = (TUYA_STRUCT *)calloc(sizeof(TUYA_STRUCT), 1);
   if (!pTuya) return 0;
-  strcpy(pTuya->RGBColor, "000000");            // Stores RGB Color string in Hex format
+  strlcpy(pTuya->RGBColor, "000000", sizeof(pTuya->RGBColor));            // Stores RGB Color string in Hex format
   pTuya->CTMin = 153;                   // Minimum CT level allowed - When SetOption82 is enabled will default to 200
   pTuya->CTMax = 500;                   // Maximum CT level allowed - When SetOption82 is enabled will default to 380
   pTuya->wifi_state = -2;                // Keep MCU wifi-status in sync with WifiState()

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -726,7 +726,7 @@ Z_Device & Z_Devices::parseDeviceFromName(const char * param, uint16_t * parsed_
   if (nullptr == param) { return device_unk; }
   size_t param_len = strlen(param);
   char dataBuf[param_len + 1];
-  strcpy(dataBuf, param);
+  strlcpy(dataBuf, param, sizeof(dataBuf));
   TrimSpace(dataBuf);
   if (parsed_shortaddr != nullptr) { *parsed_shortaddr = BAD_SHORTADDR; }   // if it goes wrong, mark as bad
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -529,7 +529,7 @@ void ZbSendSend(class JsonParserToken val_cmd, ZCLFrame & zcl) {
         // const char *s_const = value.as<const char*>();
         if (s_const != nullptr) {
           char s[strlen(s_const)+1];
-          strcpy(s, s_const);
+          strlcpy(s, s_const, sizeof(s));
           if ((nullptr != s) && (0x00 != *s)) {     // ignore any null or empty string, could represent 'null' json value
             char *sval = strtok(s, delim);
             if (sval) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -1085,7 +1085,7 @@ void UFSList(void) {
   // UfsList2      - List all files and directories in root directory
   // UfsList /dir1 - List all non-dot files and directories in directory dir1
   bool hide_dot = (XdrvMailbox.index != 2);
-  strcpy(ufs_path, "/");
+  strlcpy(ufs_path, "/", sizeof(ufs_path));
   if (XdrvMailbox.data_len > 0) {
     strlcpy(ufs_path, XdrvMailbox.data, sizeof(ufs_path));
   }
@@ -1412,7 +1412,7 @@ void UfsDirectory(void) {
   uint8_t depth = 0;
   uint8_t isdir = 0;
 
-  strcpy(ufs_path, "/");
+  strlcpy(ufs_path, "/", sizeof(ufs_path));
 
   if (Webserver->hasArg(F("dir"))) {
     String stmp = Webserver->arg(F("dir"));
@@ -1447,7 +1447,7 @@ void UfsDirectory(void) {
     char *cp = (char*)stmp.c_str();
     if (UfsDownloadFile(cp)) {
       // is directory
-      strcpy(ufs_path, cp);
+      strlcpy(ufs_path, cp, sizeof(ufs_path));
       isdir = 1;
     } else {
       return;
@@ -1578,9 +1578,9 @@ void UfsListDir(char *path, uint8_t depth) {
 #ifdef UFILESYS_RECURSEFOLDERS_GUI
           uint8_t plen = strlen(path);
           if (plen > 1) {
-            strcat(path, "/");
+            strlcat(path, "/", UFS_FILENAME_SIZE);
           }
-          strcat(path, ep);
+          strlcat(path, ep, UFS_FILENAME_SIZE);
           UfsListDir(path, depth + 4);
           path[plen] = 0;
 #endif          
@@ -1684,7 +1684,7 @@ uint8_t UfsDownloadFile(char *file) {
 
   UfsData.download_busy = true;
   char *path = (char*)malloc(128);
-  strcpy(path,file);
+  strlcpy(path, file, 128);
   BaseType_t ret = xTaskCreatePinnedToCore(download_task, "DT", 6000, (void*)path, 3, nullptr, 1);
   if (ret != pdPASS)
     AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_UFS "Download task failed with %d"), ret);
@@ -1856,14 +1856,14 @@ void UfsEditorUpload(void) {
   // recursively create folder(s)
   char tmp[UFS_FILENAME_SIZE];
   char folder[UFS_FILENAME_SIZE] = "";
-  strcpy(tmp, fname);
+  strlcpy(tmp, fname, sizeof(tmp));
   // zap file name off the end
   folderOnly(tmp);
   char *tf = strtok(tmp, "/");
   while(tf){
     if (*tf){
-      strcat(folder, "/");
-      strcat(folder, tf);
+      strlcat(folder, "/", sizeof(folder));
+      strlcat(folder, tf, sizeof(folder));
     }
     // we don;t care if it fails - it may already exist.
     dfsp->mkdir(folder);
@@ -1892,7 +1892,7 @@ void UfsEditorUpload(void) {
   // zap file name off the end
   folderOnly(fname);
   char t[20+UFS_FILENAME_SIZE] = "/ufsu?download=";
-  strcat(t, fname);
+  strlcat(t, fname, sizeof(t));
   Webserver->sendHeader(F("Location"), t);
   Webserver->send(303);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mdns.ino
@@ -97,10 +97,10 @@ extern "C" {
               const char* val = be_tostring(vm, -1);
               size_t key_len = strlen(key)+1;
               txt_items[i].key = (const char*)be_os_malloc(key_len);
-              if (txt_items[i].key) { strcpy((char*)txt_items[i].key, key); }
+              if (txt_items[i].key) { strlcpy((char*)txt_items[i].key, key, key_len); }
               size_t val_len = strlen(val)+1;
               txt_items[i].value = (const char*)be_os_malloc(val_len);
-              if (txt_items[i].value) { strcpy((char*)txt_items[i].value, val); }
+              if (txt_items[i].value) { strlcpy((char*)txt_items[i].value, val, val_len); }
               be_pop(vm, 2);
               i++;
             }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -1102,7 +1102,7 @@ extern "C" {
     va_start(arg, berry_buf);
     uint32_t len = ext_vsnprintf_P(log_data, LOGSZ-3, berry_buf, arg);
     va_end(arg);
-    if (len+3 > LOGSZ) { strcat(log_data, "..."); }  // Actual data is more
+    if (len+3 > LOGSZ) { strlcat(log_data, "...", sizeof(log_data)); }  // Actual data is more
     TasConsole.printf(log_data);
 #ifdef USE_SERIAL_BRIDGE
     SerialBridgeWrite(log_data, strlen(log_data));
@@ -1120,7 +1120,7 @@ extern "C" {
     va_start(arg, berry_buf);
     uint32_t len = ext_vsnprintf_P(log_data, LOGSZ-3, berry_buf, arg);
     va_end(arg);
-    if (len+3 > LOGSZ) { strcat(log_data, "..."); }  // Actual data is more
+    if (len+3 > LOGSZ) { strlcat(log_data, "...", sizeof(log_data)); }  // Actual data is more
     berry_log(log_data);
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -899,7 +899,7 @@ int getSeenDevicesToJson(char *dest, int maxlen){
 
   int len;
   if (!maxlen) return 0;
-  strcpy((dest), ",\"BLEDevices\":{");
+  strlcpy(dest, ",\"BLEDevices\":{", maxlen);
   len = strlen(dest);
   dest += len;
   maxlen -= len;
@@ -1197,12 +1197,12 @@ void setDetails(ble_advertisment_t *ad){
 
   *(p++) = '{';
   maxlen--;
-  strcpy(p, "\"DetailsBLE\":{");
+  strlcpy(p, "\"DetailsBLE\":{", maxlen);
   int len = strlen(p);
   p += len;
   maxlen -= len;
 
-  strcpy(p, "\"mac\":\"");
+  strlcpy(p, "\"mac\":\"", maxlen);
   len = strlen(p);
   p += len;
   maxlen -= len;
@@ -1218,11 +1218,11 @@ void setDetails(ble_advertisment_t *ad){
 
   const char *alias = BLE_ESP32::getAlias(ad->addr);
   if (alias && (*alias)){
-    strcpy(p, ",\"a\":\"");
+    strlcpy(p, ",\"a\":\"", maxlen);
     len = strlen(p);
     p += len;
     maxlen -= len;
-    strcpy(p, alias);
+    strlcpy(p, alias, maxlen);
     len = strlen(p);
     p += len;
     maxlen -= len;
@@ -1235,7 +1235,7 @@ void setDetails(ble_advertisment_t *ad){
 
   if (BLEAdvertismentDetailsJsonLost){
     BLEAdvertismentDetailsJsonLost = 0;
-    strcpy(p, ",\"lost\":true");
+    strlcpy(p, ",\"lost\":true", maxlen);
     len = strlen(p);
     p += len;
     maxlen -= len;
@@ -1246,7 +1246,7 @@ void setDetails(ble_advertisment_t *ad){
   const uint8_t* payload = advertisedDevice->getPayload().data();
   size_t payloadlen = advertisedDevice->getPayload().size();
   if (payloadlen  && (maxlen > 30)){ // will truncate if not enough space
-    strcpy(p, ",\"p\":\"");
+    strlcpy(p, ",\"p\":\"", maxlen);
     p += 6;
     maxlen -= 6;
     dump(p, maxlen-10, payload, payloadlen);
@@ -1277,7 +1277,7 @@ void setDetails(ble_advertisment_t *ad){
       if (maxlen -10 > svclen){
         *(p++) = ',';
         *(p++) = '\"';
-        strcpy(p, strUUID.c_str());
+        strlcpy(p, strUUID.c_str(), maxlen);
         p += strUUID.length();
         *(p++) = '\"';
         *(p++) = ':';
@@ -2578,7 +2578,7 @@ int getAddr(uint8_t *dest, char *src){
   char tmp[12+5+1+2];
   int srclen = strlen(src);
   if ((srclen == 12+5) || (srclen == 12+5+2)){
-    strcpy(tmp, src);
+    strlcpy(tmp, src, sizeof(tmp));
     stripColon(tmp);
     src = tmp;
   }
@@ -3551,7 +3551,7 @@ std::string BLETriggerResponse(generic_sensor_t *toSend){
   if (toSend->readlen){
     dump(temp, 99, toSend->dataRead, toSend->readlen);
     if (toSend->readtruncated){
-      strcat(temp, "+");
+      strlcat(temp, "+", sizeof(temp));
     }
     out = out + ",\"read\":\"";
     out = out + temp;
@@ -3566,7 +3566,7 @@ std::string BLETriggerResponse(generic_sensor_t *toSend){
   if (toSend->notifylen){
     dump(temp, 99, toSend->dataNotify, toSend->notifylen);
     if (toSend->notifytruncated){
-      strcat(temp, "+");
+      strlcat(temp, "+", sizeof(temp));
     }
     out = out + ",\"notify\":\"";
     out = out + temp;

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -291,8 +291,8 @@ char *topicPrefix(int prefix, const uint8_t *addr, int useAlias){
   const char *id = addrStr(addr, useAlias);
   if (!EQ3TopicStyle){
     GetTopic_P(stopic, prefix, TasmotaGlobal.mqtt_topic, PSTR(""));
-    strcat(stopic, PSTR("EQ3/"));
-    strcat(stopic, id);
+    strlcat(stopic, PSTR("EQ3/"), sizeof(stopic));
+    strlcat(stopic, id, sizeof(stopic));
   } else {
     char p[] = "EQ3";
     GetTopic_P(stopic, prefix, p, id);
@@ -984,8 +984,8 @@ int EQ3SendResult(char *requested, const char *result){
   Response_P(PSTR("{\"result\":\"%s\"}"), result);
   static char stopic[TOPSZ];
   GetTopic_P(stopic, STAT, TasmotaGlobal.mqtt_topic, PSTR(""));
-  strcat(stopic, PSTR("EQ3/"));
-  strcat(stopic, requested);
+  strlcat(stopic, PSTR("EQ3/"), sizeof(stopic));
+  strlcat(stopic, requested, sizeof(stopic));
   MqttPublish(stopic, false);
   return 0;
 }

--- a/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_15_tm1637.ino
@@ -478,7 +478,7 @@ bool CmndTM1637Float(bool clear)
   {
     char tmptxt[30];
     ext_snprintf_P(tmptxt, sizeof(tmptxt), "%*s%s", strlen(txt)-(length+1), "", txt);
-    strcpy (txt, tmptxt);
+    strlcpy(txt, tmptxt, sizeof(txt));
   }
 
   AddLog(LOG_LEVEL_DEBUG, PSTR("TM7: num %4_f, prec %d, len %d"), &fnum, precision, length);

--- a/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
@@ -486,7 +486,7 @@ void DataCallback(struct _ValueList * me, uint8_t  flags)
             // Serial Number of device
             else if (ilabel == LABEL_ADCO || ilabel == LABEL_ADSC)
             {
-                strcpy(serialNumber, me->value);
+                strlcpy(serialNumber, me->value, sizeof(serialNumber));
                 AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("TIC: %s set to %s"), me->name, serialNumber);
             }
             // Status
@@ -581,7 +581,7 @@ bool ResponseAppendTInfo(char sep, bool all)
                             // Some values contains space 
                             if (strcmp(me->name, "NGTF")==0 || strcmp(me->name, "LTARF")==0 || strcmp(me->name, "MSG1")==0) {
                                 char trimmed_value[strlen(me->value)+1];
-                                strcpy(trimmed_value, me->value);
+                                strlcpy(trimmed_value, me->value, sizeof(trimmed_value));
                                 ResponseAppend_P( PSTR("\"%s\""), Trim(trimmed_value) );
                             } else {
                                 ResponseAppend_P( PSTR("\"%s\""), me->value );

--- a/tasmota/tasmota_xsns_sensor/xsns_107_gm861.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_107_gm861.ino
@@ -113,7 +113,7 @@ String Gm861AIMId2AIM(const char* aim_id) {
   strcpy_P(aim_ids, kGm861AIMID);
   int index = (strstr(aim_ids, aim_id) -aim_ids) /2;
   if (index < 0) {                     // Unknown
-    strcpy(aim_ids, aim_id);           // Return AIM-id
+    strlcpy(aim_ids, aim_id, sizeof(aim_ids));           // Return AIM-id
   } else {
     GetTextIndexed(aim_ids, sizeof(aim_ids), index, kGm861AIM);
   }
@@ -237,7 +237,7 @@ void Gm861SerialInput(void) {
     // Prepare GUI result
     snprintf_P(Gm861->barcode, sizeof(Gm861->barcode) -3, PSTR("%s"), buffer + offset);
     if (strlen(buffer) > sizeof(Gm861->barcode) -3) {
-      strcat(Gm861->barcode, "...");
+      strlcat(Gm861->barcode, "...", sizeof(Gm861->barcode));
     }
 
     ResponseTime_P(PSTR(",\"GM861\":{"));

--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -977,7 +977,7 @@ void dump2log(void) {
             	// new packet, plot last one
             	sml_globs.log_data[sml_globs.sml_logindex] = 0;
             	AddLogData(LOG_LEVEL_INFO, sml_globs.log_data);
-            	strcpy(&sml_globs.log_data[0], ": aa ");
+            	strlcpy(sml_globs.log_data, ": aa ", sizeof(sml_globs.log_data));
             	sml_globs.sml_logindex = 5;
           	}
           	continue;
@@ -1549,11 +1549,11 @@ void sml_shift_in(uint32_t meters, uint32_t shard) {
     if (cp->telestartpos==-1)  {
       //check start of buffer for start sequence
       if(cp->crcbuff_pos>=8) {
-        if (memcmp(&cp->crcbuff[0], "\x1B\x1B\x1B\x1B\x01\x01\x01\x01", 8) == 0 ) {
+        if (memcmp(cp->crcbuff, "\x1B\x1B\x1B\x1B\x01\x01\x01\x01", 8) == 0 ) {
           //found start sequence
           cp->telestartpos=0;
         } else {
-          memmove(&cp->crcbuff[0], &cp->crcbuff[1], cp->crcbuff_pos-1);
+          memmove(cp->crcbuff, &cp->crcbuff[1], cp->crcbuff_pos-1);
           cp->crcbuff_pos--;
         }
 
@@ -1571,7 +1571,7 @@ void sml_shift_in(uint32_t meters, uint32_t shard) {
           uint16_t len=cp->teleendpos + 1;
           //testing: fake some error for testing 
           //if (random(0, 50) < 30) {cp->crcbuff[12]=99;}
-          uint16_t calculated_crc = calculateSMLbinCRC(&cp->crcbuff[0], len-2, cp->crcmode);
+          uint16_t calculated_crc = calculateSMLbinCRC(cp->crcbuff, len-2, cp->crcmode);
           if (calculated_crc == extracted_crc) {
             cp->crcfinecnt++;
             //AddLog(LOG_LEVEL_INFO, PSTR("SML: CRC ok"));
@@ -1720,7 +1720,7 @@ void sml_shift_in(uint32_t meters, uint32_t shard) {
         mp->spos = 0;
       } else if (iob == 0x0d) {
         uint8_t index = 0;
-        uint8_t *ucp = &mp->sbuff[0];
+        uint8_t *ucp = mp->sbuff;
         for (uint16_t cnt = 0; cnt < mp->spos; cnt++) {
           uint8_t iob = mp->sbuff[cnt] ;
           if (iob == 0x1b) {
@@ -1731,7 +1731,7 @@ void sml_shift_in(uint32_t meters, uint32_t shard) {
           }
           index++;
         }
-        uint16_t crc = KS_calculateCRC(&mp->sbuff[0], index);
+        uint16_t crc = KS_calculateCRC(mp->sbuff, index);
         if (!crc) {
           SML_Decode(meters);
         }
@@ -1759,7 +1759,7 @@ void sml_shift_in(uint32_t meters, uint32_t shard) {
           uint8_t tlen = (mp->sbuff[4] << 8) | mp->sbuff[5];
           if (mp->spos == 6 + tlen) {
             mp->spos = 0;
-            memmove(&mp->sbuff[0], &mp->sbuff[6], mp->sbsiz - 6);
+            memmove(mp->sbuff, &mp->sbuff[6], mp->sbsiz - 6);
 #ifdef MODBUS_DEBUG
             AddLog(LOG_LEVEL_INFO, PSTR("meter %d, receive index >> %d"), meters, mp->index);
             Hexdump(mp->sbuff, 10);
@@ -3631,7 +3631,7 @@ void SML_Init(void) {
             lp1++;
 #ifdef USE_SML_TCP
 #ifdef USE_SML_TCP_IP_STR
-            strcpy(mmp->ip_addr, str);
+            strlcpy(mmp->ip_addr, str, sizeof(mmp->ip_addr));
 #else
             mmp->ip_addr.fromString(str);
 #endif
@@ -4329,7 +4329,7 @@ uint32_t SML_Read(int32_t meter, char *str, uint32_t slen) {
   mp->sbuff[mp->spos] = 0;
 
   if (!hflg) {
-    strlcpy(str, (char*)&mp->sbuff[0], slen);
+    strlcpy(str, (char*)mp->sbuff, slen);
   } else {
     uint32_t index = 0;
     for (uint32_t cnt = 0; cnt < mp->spos; cnt++) {
@@ -4796,9 +4796,9 @@ int32_t sml_tcp_init(struct METER_DESC *mp) {
     int32_t err = mp->client->connect(mp->ip_addr, mp->params);
     char ipa[32];
 #ifdef USE_SML_TCP_IP_STR
-    strcpy(ipa, mp->ip_addr);
+    strlcpy(ipa, mp->ip_addr, sizeof(ipa));
 #else
-    strcpy(ipa, mp->ip_addr.toString().c_str());
+    strlcpy(ipa, mp->ip_addr.toString().c_str(), sizeof(ipa));
 #endif
     if (!err) {
       AddLog(LOG_LEVEL_INFO, PSTR("SML: could not connect TCP to %s:%d"),ipa, mp->params);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_MI_HM10.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_MI_HM10.ino
@@ -896,7 +896,7 @@ void HM10ParseMiScalePacket(char * _buf, uint32_t _slot, uint16_t _type){
     MIBLEsensors[_slot].weight_removed = 0;
     MIBLEsensors[_slot].weight = 0.0f;
     MIBLEsensors[_slot].impedance = 0;
-    strcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"));
+    strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"), sizeof(MIBLEsensors[_slot].weight_unit));  // Mi Scale V2 init
   }
 
   // Mi Scale V1
@@ -918,17 +918,17 @@ void HM10ParseMiScalePacket(char * _buf, uint32_t _slot, uint16_t _type){
 
         if (_packetV1->status & (1 << 0))
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV1->weight / 100.0f;
         }
         else if (_packetV1->status & (1 << 4))
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV1->weight / 100.0f;
         }
         else
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV1->weight / 200.0f;
         }
 
@@ -975,22 +975,22 @@ void HM10ParseMiScalePacket(char * _buf, uint32_t _slot, uint16_t _type){
         MIBLEsensors[_slot].weight_removed = weight_removed;
         if (_packetV2->weight_unit & (1 << 4))
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
         }
         else if (_packetV2->weight_unit == 3)
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
         }
         else if (_packetV2->weight_unit == 2)
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV2->weight / 200.0f;
         }
         else
         {
-          strcpy(MIBLEsensors[_slot].weight_unit, PSTR(""));
+          strlcpy(MIBLEsensors[_slot].weight_unit, PSTR(""), sizeof(MIBLEsensors[_slot].weight_unit));
           MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
         }
 

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -1112,8 +1112,7 @@ void MI32loadCfg(){
           _val = _device[PSTR("name")];
           if (_val) {
             char *_name = (char *)_val.getStr();
-            MIBLEsensors[_numberOfDevices].name = new char[strlen(_name) + 1];
-            strcpy(MIBLEsensors[_numberOfDevices].name, _name);
+            MIBLEsensors[_numberOfDevices].name = strdup(_name);
             AddLog(LOG_LEVEL_INFO,PSTR("M32: found name: %s"), _name);
           }
           _val = _device[PSTR("feat")];
@@ -2396,14 +2395,13 @@ void CmndMi32Name(void) {
     return;
   }
   if(MIBLEsensors[XdrvMailbox.index].name != nullptr){
-    delete []MIBLEsensors[XdrvMailbox.index].name;
+    free(MIBLEsensors[XdrvMailbox.index].name);
   }
   if(XdrvMailbox.data_len==0){
     MIBLEsensors[XdrvMailbox.index].name = nullptr;
   }
   else{
-    MIBLEsensors[XdrvMailbox.index].name = new char[XdrvMailbox.data_len + 1];
-    strcpy(MIBLEsensors[XdrvMailbox.index].name,XdrvMailbox.data);
+    MIBLEsensors[XdrvMailbox.index].name = strdup(XdrvMailbox.data);
   }
   ResponseCmndChar((const char*)MI32getDeviceName(XdrvMailbox.index));
 }

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -1866,13 +1866,13 @@ void MI32ParseMiScalePacket(const uint8_t * _buf, uint32_t length, const uint8_t
       MIBLEsensors[_slot].weight_removed = weight_removed;
 
       if (_packetV1->status & (1 << 0)) {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV1->weight / 100.0f;
       } else if(_packetV1->status & (1 << 4)) {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV1->weight / 100.0f;
       } else {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV1->weight / 200.0f;
       }
 
@@ -1906,16 +1906,16 @@ void MI32ParseMiScalePacket(const uint8_t * _buf, uint32_t length, const uint8_t
       MIBLEsensors[_slot].weight_removed = weight_removed;
 
       if (_packetV2->weight_unit & (1 << 4)) {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("jin"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
       } else if(_packetV2->weight_unit == 3) {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("lbs"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
       } else if(_packetV2->weight_unit == 2) {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR("kg"), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV2->weight / 200.0f;
       } else {
-        strcpy(MIBLEsensors[_slot].weight_unit, PSTR(""));
+        strlcpy(MIBLEsensors[_slot].weight_unit, PSTR(""), sizeof(MIBLEsensors[_slot].weight_unit));
         MIBLEsensors[_slot].weight = (float)_packetV2->weight / 100.0f;
       }
 
@@ -2805,7 +2805,7 @@ void HandleMI32Key(){
 
   WSContentSend_P(HTTP_KEY_ADDED, mac, key);
 
-  strcat(key, mac);
+  strlcat(key, mac, sizeof(key));
   MI32AddKey(key, nullptr);
 
 //  WSContentSpaceButton(BUTTON_CONFIGURATION);
@@ -3579,30 +3579,30 @@ void MI32Show(bool json)
 #ifdef USE_MI_DECRYPTION
       bool showkey = false;
       char tmp[40];
-      strcpy(tmp, PSTR("KeyRqd"));
+      strlcpy(tmp, PSTR("KeyRqd"), sizeof(tmp));
       switch(p->needkey) {
         default:{
           snprintf(tmp, 39, PSTR("?%d?"), p->needkey );
           showkey = true;
         } break;
         case KEY_REQUIREMENT_UNKNOWN: {
-          strcpy(tmp, PSTR("WAIT"));
+          strlcpy(tmp, PSTR("WAIT"), sizeof(tmp));
           showkey = true;
         } break;
         case KEY_NOT_REQUIRED: {
-          strcpy(tmp, PSTR("NOTKEY"));
+          strlcpy(tmp, PSTR("NOTKEY"), sizeof(tmp));
           //showkey = true;
         } break;
         case KEY_REQUIRED_BUT_NOT_FOUND: {
-          strcpy(tmp, PSTR("NoKey"));
+          strlcpy(tmp, PSTR("NoKey"), sizeof(tmp));
           showkey = true;
         } break;
         case KEY_REQUIRED_AND_FOUND: {
-          strcpy(tmp, PSTR("KeyOk"));
+          strlcpy(tmp, PSTR("KeyOk"), sizeof(tmp));
           showkey = true;
         } break;
         case KEY_REQUIRED_AND_INVALID: {
-          strcpy(tmp, PSTR("KeyInv"));
+          strlcpy(tmp, PSTR("KeyInv"), sizeof(tmp));
           showkey = true;
         } break;
       }


### PR DESCRIPTION
## Description:

Systematic code hardening:
- replace `strcat` with safer `strlcat`
- replace `strcpy` with safer `strlcpy`
- replace `malloc`/`strcpy` with `strdup`

Although most of the code was already safe, it is good practice to use safer alternatives that prevent vulnerabilities if the same code is edited in the future.
No functional change.

Initiated by Claude Sonnet 4.6 but carefully reviewed by human (me).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
