### PR TITLE
Update tasmota_globals.h - WebColor consistency

### DIFF
--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -493,7 +493,7 @@ const char WIFI_HOSTNAME[] = WIFI_DEFAULT_HOSTNAME;    // Override by user_confi
 #define COLOR_TITLE_TEXT			      COLOR_TEXT // Title text color defaults to global text color either dark or light
 #endif
 #ifndef COLOR_BUTTON_OFF
-#define COLOR_BUTTON_OFF			      "#08405e"  // Button color when off - Darkest blueish
+#define COLOR_BUTTON_OFF			      "#a1d9f7"  // Button color when off - Light blue
 #endif
 
 enum WebColors {


### PR DESCRIPTION
Noticed a small inconsistency of the default light WebColor palette not fully matching the light palette example in my_user_config.h and the docs WebUI page. The color for COLOR_BUTTON_OFF was a long time ago changed from dark blue #08405e to the better-working pale blue #a1d9f7 without this being reflected in the defaults used in the absence of another #define value.

Of course, this normally makes no difference as the standard my_user_config.h defines a full dark palette anyway, but still....

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
