### PR TITLE
Berry fix rare GC bug in deinit

### DIFF
--- a/lib/libesp32/berry/src/be_gc.c
+++ b/lib/libesp32/berry/src/be_gc.c
@@ -492,6 +492,7 @@ static void destruct_object(bvm *vm, bgcobject *obj)
     }
     if (obj->type == BE_INSTANCE) {
         int type;
+        int slot = cast_int(vm->top - vm->stack); /* remember the scratch slot offset (stack may be reallocated) */
         binstance *ins = cast_instance(obj);
         /* does not GC when creating the string "deinit". */
         type = be_instance_member_simple(vm, ins, str_literal(vm, "deinit"), vm->top);
@@ -501,8 +502,14 @@ static void destruct_object(bvm *vm, bgcobject *obj)
             be_incrtop(vm);
             be_dofunc(vm, vm->top - 2, 1);  /* warning, there shoudln't be any exception raised here, or the gc stops */
             be_stackpop(vm, 1);
+            var_setnil(vm->stack + slot + 1); /* clear the arg slot which held 'ins' (about to be freed) */
         }
         be_stackpop(vm, 1);
+        /* Clear the scratch slot that held the 'deinit' lookup / instance.
+         * The instance is about to be freed by delete_white; leaving a pointer
+         * to it in a stack slot above vm->top would become a dangling reference
+         * if a later GC runs with a higher vm->top and scans this slot (UAF). */
+        var_setnil(vm->stack + slot);
     }
 }
 


### PR DESCRIPTION
## Description:

Berry fix rare bug when a GC occurs while an instance is deleted during `deinit()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
