### PR TITLE
Fix Matter On/Off metadata advertised to strict controllers

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -441,7 +441,7 @@ matter_device.events.dump()
     elif attribute == 0xFFFB            # AttributeList
       var acli = TLV.Matter_TLV_array()
       var attr_list_bytes = self.get_attribute_list_bytes(cluster)
-      var attr_list_bytes_sz = (attr_list_bytes != nil) ? size(attr_list_bytes) : 0
+      var attr_list_bytes_sz = (attr_list_bytes != nil) ? size(attr_list_bytes) / 2 : 0
       var idx = 0
       while idx < attr_list_bytes_sz
         acli.add_TLV(nil, 0x05 #-TLV.U2-#, attr_list_bytes.get(idx * 2, -2))
@@ -453,6 +453,16 @@ matter_device.events.dump()
       return el                         # return empty list
     elif attribute == 0xFFF9            # AcceptedCommandList
       var al = TLV.Matter_TLV_array()
+      if cluster == 0x0006              # On/Off
+        al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0000)    # Off
+        al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0001)    # On
+        al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0002)    # Toggle
+        if (self.FEATURE_MAPS.find(cluster, 0) & 0x01) != 0
+          al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0040)  # OffWithEffect
+          al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0041)  # OnWithRecallGlobalScene
+          al.add_TLV(nil, 0x06 #-TLV.U4-#, 0x0042)  # OnWithTimedOff
+        end
+      end
       return al                         # TODO
     elif attribute == 0xFFFC            # FeatureMap
       var featuremap = self.FEATURE_MAPS.find(cluster, 0)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
@@ -126,7 +126,7 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
     # 0x0003: inherited                             # Identify 1.2 p.16
     # 0x0004: inherited                             # Groups 1.3 p.21
     # 0x0062: inherited                             # Scenes Management 1.4 (PROVISIONAL) - replaces 0x0005
-    0x0006: [0],                                    # On/Off 1.5 p.48
+    0x0006: [0,0x4000,0x4001,0x4002,0x4003],        # On/Off 1.5 p.48
   })
   static var UPDATE_COMMANDS = matter.UC_LIST(_class, "Power")
   static var TYPES = { 0x0100: 3 }                  # OnOff Light - Matter 1.4.1 Device Library Rev 3
@@ -217,6 +217,14 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
       self.update_shadow_lazy()
       if   attribute == 0x0000          #  ---------- OnOff / bool ----------
         return tlv_solo.set(0x08 #-TLV.BOOL-#, self.shadow_onoff)
+      elif attribute == 0x4000          #  ---------- GlobalSceneControl / bool ----------
+        return tlv_solo.set(0x08 #-TLV.BOOL-#, true)
+      elif attribute == 0x4001          #  ---------- OnTime / u2 ----------
+        return tlv_solo.set(0x05 #-TLV.U2-#, 0)
+      elif attribute == 0x4002          #  ---------- OffWaitTime / u2 ----------
+        return tlv_solo.set(0x05 #-TLV.U2-#, 0)
+      elif attribute == 0x4003          #  ---------- StartUpOnOff / enum8 nullable ----------
+        return tlv_solo.set(0x14 #-TLV.NULL-#, nil)
       end
 
     end
@@ -247,6 +255,18 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
       elif command == 0x0002            # ---------- Toggle ----------
         self.set_onoff(!self.shadow_onoff)
         self.publish_command('Power', self.shadow_onoff ? 1 : 0)
+        return true
+      elif command == 0x0040            # ---------- OffWithEffect ----------
+        self.set_onoff(false)
+        self.publish_command('Power', 0)
+        return true
+      elif command == 0x0041            # ---------- OnWithRecallGlobalScene ----------
+        self.set_onoff(true)
+        self.publish_command('Power', 1)
+        return true
+      elif command == 0x0042            # ---------- OnWithTimedOff ----------
+        self.set_onoff(true)
+        self.publish_command('Power', 1)
         return true
       end
     end


### PR DESCRIPTION
**Disclaimer**
Fully AI crafted, I am not expert in this topic but it fixes my issue. I cannot recommended merging but only try to understand the root cause.

**Problem**
Google Home on iOS crashed when opening device details or trying to toggle a Tasmota ESP32-C3 Matter light/switch. The device never received the On/Off command, so the failure was happening client-side while Google Home was reading/parsing Matter metadata.

Two inconsistencies were present:

AttributeList was generated from a packed byte array of 16-bit attribute IDs, but the loop used the raw byte length as the element count. This could advertise invalid extra attributes.
In [Matter_Plugin_0.be](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), each attribute ID is read with attr_list_bytes.get(idx * 2, -2), so the loop count must be size(attr_list_bytes) / 2.

The On/Off cluster advertised the Lighting feature through FeatureMap, but did not expose the Lighting-feature attributes and returned an empty AcceptedCommandList.
FeatureMap for cluster 0x0006 is 0x01, meaning LT / Lighting. With that feature set, controllers can expect the related On/Off attributes and commands to exist. Before the fix, [Matter_Plugin_2_Light0.be](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) only advertised/read attribute 0x0000 (OnOff), while [Matter_Plugin_0.be](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) always returned an empty AcceptedCommandList.

**Fix**
The working fix makes the advertised metadata match the implementation:

Fix AttributeList iteration count:
Report accepted On/Off commands for cluster 0x0006:
The command IDs are encoded as U4, matching Matter command-id width.

Add the Lighting-feature On/Off attributes to the cluster:
Add simple handlers for those attributes:
Add simple command handling for the Lighting-feature commands:
**Why This Fixes Google Home**
Google Home appears to read FeatureMap, AttributeList, and AcceptedCommandList before rendering the details or control UI. Before the patch, those values contradicted each other:

FeatureMap said the On/Off cluster supports Lighting behavior.
AttributeList did not include the Lighting attributes.
AcceptedCommandList said no commands were accepted.
In one path, AttributeList could also contain bogus entries due to the byte-count bug.
After the fix, Google Home receives a self-consistent On/Off cluster description and no longer crashes.

**Tested**
On ESP32-C3 running Tasmota over Matter with Google Home app on iPhone:

Before fix: Google Home crashed when opening device details or toggling the device; Tasmota did not receive the command.
Force Static Endpoints did not help.
AttributeList count fix alone did not help.
Adding the On/Off metadata/command consistency fix resolved the crash and allowed control.