### PR TITLE
Berry fix warnings when running unit tests

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -429,7 +429,7 @@ static bint scan_hexadecimal(blexer *lexer)
     bint res = 0;
     int dig, num = 0;
     while ((dig = be_char2hex(lgetc(lexer))) >= 0) {
-        res = ((bint)res << 4) + dig;
+        res = (bint)(((buint)res << 4) + (buint)dig);
         next(lexer);
         ++num;
     }

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -387,7 +387,7 @@ BERRY_API bint be_str2int(const char *str, const char **endstr)
         /* hex literal */
         str += 2;       /* skip 0x or 0X */
         while ((c = be_char2hex(*str++)) >= 0) {
-            sum = sum * 16 + c;
+            sum = (bint)((buint)sum * 16 + (buint)c);
         }
         if (endstr) {
             *endstr = str - 1;

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -48,8 +48,9 @@ extern "C" {
 #endif
 #define BE_INT_FORMAT           "%" BE_INT_FMTLEN "d" /**< BE_INT_FORMAT */
 
-typedef uint8_t bbyte;   /**< bbyte */
-typedef BE_INTEGER bint; /**< bint */
+typedef uint8_t bbyte;            /**< bbyte */
+typedef BE_INTEGER bint;          /**< bint */
+typedef unsigned BE_INTEGER buint; /**< buint (unsigned bint, for well-defined wrap-around arithmetic) */
 
 #if BE_USE_SINGLE_FLOAT != 0
   typedef float                 breal; /**< breal */

--- a/lib/libesp32/berry_int64/src/be_int64_class.c
+++ b/lib/libesp32/berry_int64/src/be_int64_class.c
@@ -28,7 +28,7 @@
 static void int64_toa(int64_t num, uint8_t* str) {
   uint64_t sum = num;
   if (num < 0) {
-    sum = -num;
+    sum = -(uint64_t)num;   /* negate in unsigned domain to avoid UB on INT64_MIN */
     str[0] = '-';
     str++;
   }
@@ -226,7 +226,7 @@ static int int64_fromu32(bvm *vm) {
   int argc = be_top(vm);
   uint32_t low = (uint32_t)be_toint(vm, 1);
   uint32_t high = (argc > 1) ? (uint32_t)be_toint(vm, 2) : 0;
-  int64_t val = (int64_t)low | (((int64_t)high) << 32);
+  int64_t val = (int64_t)((uint64_t)low | ((uint64_t)high << 32));
   push_int64_instance(vm, val);
   be_return(vm);
 }
@@ -347,7 +347,7 @@ static int int64_mod(bvm *vm) {
 static int int64_shiftleft(bvm *vm) {
   int64_t *i64 = self_get_p(vm);
   int32_t j32 = be_toint(vm, 2) & 63;
-  push_int64_instance(vm, *i64 << j32);
+  push_int64_instance(vm, (int64_t)((uint64_t)*i64 << j32));
   be_return(vm);
 }
 


### PR DESCRIPTION
## Description:

Berry fix warnings when running unit tests in extensive warning mode `make test`.

No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
