### PR TITLE
Fix *float* output in eQ-3 mqtt messages

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -461,7 +461,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
   if ((statlen >= 6) && (status[0] == 2) && (status[1] == 1)) {
     ResponseAppend_P(PSTR(",\"stattime\":%u"), stattime);
     eq3->TargetTemp = (float)status[5] / 2;
-    ResponseAppend_P(PSTR(",\"temp\":%2.1f"), eq3->TargetTemp);
+    ResponseAppend_P(PSTR(",\"temp\":%1_f"), &(eq3->TargetTemp));
     eq3->DutyCycle = status[3];
     ResponseAppend_P(PSTR(",\"posn\":%d"), eq3->DutyCycle);
     int stat = status[2];
@@ -518,11 +518,16 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
       );
 
     if (statlen >= 15) {
-      ResponseAppend_P(PSTR(",\"windowtemp\":%2.1f"), ((float)status[10]) /  2);
+      float f_temp;
+      f_temp = ((float)status[10]) /  2;
+      ResponseAppend_P(PSTR(",\"windowtemp\":%1_f"), &f_temp);
       ResponseAppend_P(PSTR(",\"windowdur\":%d"), ((int)status[11]) * 5);
-      ResponseAppend_P(PSTR(",\"day\":%2.1f"), ((float)status[12]) / 2);
-      ResponseAppend_P(PSTR(",\"night\":%2.1f"), ((float)status[13]) / 2);
-      ResponseAppend_P(PSTR(",\"offset\":%2.1f"), ((float)status[14] - 7) / 2);
+      f_temp = ((float)status[12]) / 2;
+      ResponseAppend_P(PSTR(",\"day\":%1_f"), &f_temp);
+      f_temp = ((float)status[13]) / 2;
+      ResponseAppend_P(PSTR(",\"night\":%1_f"), &f_temp);
+      f_temp = ((float)status[14] - 7) / 2;
+      ResponseAppend_P(PSTR(",\"offset\":%1_f"), &f_temp);
     }
 
   }
@@ -554,7 +559,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
         mm *= 10;
         int hh = mm / 60;
         mm = mm % 60;
-        ResponseAppend_P(PSTR("%2.1f-%02d:%02d"), t, hh, mm);
+        ResponseAppend_P(PSTR("%1_f-%02d:%02d"), &t, hh, mm);
         // stop if the last one is 24.
         if (hh == 24){
           break;


### PR DESCRIPTION
Recent core refactoring removed standard support for float variables in printf family functions, resulting in eQ-3 telemetry messages showing '*float' instead of actual float values. Updated the formatting specifier to %1_f and passed the reference to the float parameter to ResponseAppend_P function

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
