### PR TITLE
Fix default button/switch actions on builds without USE_RULES/USE_SCRIPT

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_system_events.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_system_events.ino
@@ -403,7 +403,11 @@ bool RulesProcessEvent(const char *json_event) {
   // (allocation/toUpperCase) and keeps a documented hook for future consumers.
 
   SystemEvents.busy = false;
-  return true;
+  // Return false ("not serviced"), mirroring xdrv_10_rules.ino's `serviced` semantics where
+  // true means a rule actually consumed the event. There are no rule sets in this build mode,
+  // so returning true made SendKey() consider every button/switch event handled and the
+  // default ButtonN -> ExecuteCommandPower action never ran (button press logged, no toggle).
+  return false;
 }
 
 // Local `RulesProcess` stub — mirrors xdrv_10_rules.ino's `RulesProcess` shape so the


### PR DESCRIPTION
## Description

On builds compiled **without `USE_RULES` and without `USE_SCRIPT`**, `xdrv_10_system_events.ino` owns the Xdrv10 slot and its local `RulesProcessEvent()` stub is called for `FUNC_RULES_PROCESS`. That stub **returned `true` unconditionally**, even though (as its own comment notes) "there are no rule sets to evaluate in this build mode".

`SendKey()` (support_tasmota.ino) uses that return value as "event was serviced" — so every button/switch key event was reported as handled, and the **default `ButtonN` → `ExecuteCommandPower` action never ran**. Symptom: pressing a button logs `BTN: Button5 multi-press 1` and then nothing happens; relays never toggle. Power commands via web/MQTT work normally, only the physical button/switch default actions are dead.

Builds that include rules are unaffected (xdrv_10_rules.ino owns the slot there and returns its `serviced` flag correctly), which is why stock binaries don't show this.

## Fix

Return `false` from the stub, mirroring `xdrv_10_rules.ino`'s `serviced` semantics where `true` means a rule actually consumed the event. The empty-event early return (`true`) is left unchanged to match the rules driver.

## Verified

- Reproduced on ESP32-S2 (custom build, `#undef USE_RULES`, 5 buttons + 5 relays template): buttons logged presses but never toggled power after upgrading from 15.2 (which predates xdrv_10_system_events.ino) to 15.5.0.
- With this fix the same device's buttons toggle power normally again.
- Also built/tested on ESP8266 (D1 mini) no-rules configs.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works on Tasmota core ESP32 V.3.3.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla)