### PR TITLE
backlog: fix timer reset during drain; preserve CmndDelay value

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -312,6 +312,7 @@ struct TasmotaGlobal_t {
   bool no_mqtt_response;                    // Respond with rule processing only
   bool backlog_nodelay;                     // Execute all backlog commands with no delay
   bool backlog_mutex;                       // Command backlog pending
+  bool backlog_delay_guard;                 // CmndDelay set timer during drain; BacklogLoop preserves it
   bool backlog_no_mqtt_response;            // Set respond with rule processing only
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
@@ -760,6 +761,10 @@ void BacklogLoop(void) {
           free(cmd);
           if (nodelay || TasmotaGlobal.backlog_nodelay) {
             TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
+          } else if (TasmotaGlobal.backlog_delay_guard) {
+            TasmotaGlobal.backlog_delay_guard = false;
+          } else {
+            TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];
           }
           break;
         }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -657,6 +657,7 @@ void CmndDelay(void) {
   else if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
     TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
   }
+  if (TasmotaGlobal.backlog_mutex) { TasmotaGlobal.backlog_delay_guard = true; }
   uint32_t bl_delay = 0;
   long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
   if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }


### PR DESCRIPTION
## Description

### Problem

`BacklogLoop` left `backlog_timer` at whatever value `CommandHandler` had
written at the start of `ExecuteCommand`: `millis()` at command start time
plus `P_BACKLOG_DELAY` (SetOption34). After a long execution -- a rule-trigger
chain, for example -- that point was already in the past. `TimeReached()`
returned true immediately on the next iteration, and the queue drained without
pause regardless of SetOption34.

A nested `CmndBacklog` invoked during execution reset the timer to `millis()`
from within `ExecuteCommand`. That made `TimeReached()` true immediately for
every subsequent entry: the queue drained as fast as commands were enqueued,
turning SetOption34 into a dead letter under rule-driven Backlog activity.

This was observable as unbounded queue growth and free-heap decline under
sustained rule activity. Issuing `Backlog` with no arguments (which clears the
queue) immediately restored heap.

---

### Fix

`BacklogLoop` now unconditionally sets `backlog_timer` after each timed drain
step. The inter-command interval is deterministic: exactly `P_BACKLOG_DELAY`
between drain steps, regardless of what `CommandHandler` or nested `Backlog`
commands wrote during `ExecuteCommand`.

One exception: `CmndDelay` called from within a drain sets `backlog_delay_guard`
(detected via `backlog_mutex == true`). `BacklogLoop` then preserves the timer
value for that one step and clears the guard. This keeps `Delay` functional
inside Backlog sequences. External commands can still shorten an active delay --
that matches original Tasmota behaviour and is intentional.

**Invariant established:** `backlog_timer` is always set by `BacklogLoop` after each drain step. `CmndDelay` is the one permitted exception, signaled via `backlog_delay_guard`.

### Changes

- `TasmotaGlobal_t`: new `bool backlog_delay_guard` field (1 byte)
- `BacklogLoop()` in `tasmota.ino`: 4-line addition -- the existing
  nodelay branch is unchanged; two new branches handle the guard and
  the normal timed reset
- `CmndDelay()` in `support_command.ino`: 1-line addition sets the guard

---

### Memory impact (measured: ESP8266 tasmota-4M, ESP32 tasmota32)

| | Flash | RAM | IRAM |
|---|---|---|---|
| Code change | +16 B | 0 | 0 |

`backlog_delay_guard` (1 byte) is packed into existing padding in
`TasmotaGlobal_t`; net static RAM delta is 0 on both targets.

---

### Tested

Build-tested on ESP8266 (all 37 targets) and ESP32 Xtensa and RISC-V
(all standard targets). Target-tested on ESP8266 (ESP-12F) with two
nearly-full rule sets generating frequent Backlog sequences: queue now
drains at the expected SetOption34 interval under sustained load.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

