### PR TITLE
backlog: Contain flag mutation side-effects

### DIFF
--- a/tasmota/include/support_backlog.h
+++ b/tasmota/include/support_backlog.h
@@ -1,0 +1,46 @@
+/*
+  support_backlog.h - Public interface for the Backlog command queue
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _SUPPORT_BACKLOG_H_
+#define _SUPPORT_BACKLOG_H_
+
+namespace Backlog {
+  void Init();
+
+  bool     IsEmpty();
+  bool     IsNodelay();
+  uint32_t GetRemainingDelay_ms();
+
+  void SetNodelay(bool val);
+  void SetNoMqttResponse(bool val);
+
+  void OnCommandExecuted();
+  void ScheduleNow();
+  void ScheduleDelay(uint32_t ms);
+
+  void EnqueueCmd(const char* cmd);
+  void InsertCmd(const char* cmd, uint32_t position);
+  void Clear();
+
+  void Loop();
+}
+
+void BacklogLoop(void);
+
+#endif  // _SUPPORT_BACKLOG_H_

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -260,7 +260,7 @@ struct TasmotaGlobal_t {
   uint32_t baudrate;                        // Current Serial baudrate
   uint32_t pulse_timer[MAX_PULSETIMERS];    // Power off timer
   uint32_t blink_timer;                     // Power cycle timer
-  uint32_t backlog_timer;                   // Timer for next command in backlog
+  // backlog_timer moved to Backlog namespace (support_backlog.cpp)
   uint32_t loop_load_avg;                   // Indicative loop load average
   uint32_t log_buffer_pointer;              // Index in log buffer
   uint32_t uptime;                          // Counting every second until 4294967295 = 130 year
@@ -310,10 +310,7 @@ struct TasmotaGlobal_t {
   bool serial_local;                        // Handle serial locally
   bool fallback_topic_flag;                 // Use Topic or FallbackTopic
   bool no_mqtt_response;                    // Respond with rule processing only
-  bool backlog_nodelay;                     // Execute all backlog commands with no delay
-  bool backlog_mutex;                       // Command backlog pending
-  bool backlog_delay_guard;                 // CmndDelay set timer during drain; BacklogLoop preserves it
-  bool backlog_no_mqtt_response;            // Set respond with rule processing only
+  // backlog_nodelay, backlog_mutex, backlog_delay_guard, backlog_no_mqtt_response moved to Backlog namespace (support_backlog.cpp)
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
   bool pwm_present;                         // Any PWM channel configured with SetOption15 0
@@ -397,8 +394,8 @@ struct TasmotaGlobal_t {
 
 TSettings* Settings = nullptr;
 
-LList<char*> backlog;                       // Command backlog implemented with TasmotaLList
-#define BACKLOG_EMPTY (backlog.isEmpty())
+#include "include/support_backlog.h"
+#define BACKLOG_EMPTY (Backlog::IsEmpty())
 
 /*********************************************************************************************\
  * Main
@@ -707,6 +704,7 @@ void setup(void) {
 #ifdef ROTARY_V1
   RotaryInit();
 #endif  // ROTARY_V1
+  Backlog::Init();               // Set timer to millis() before Berry or drivers may enqueue commands
 #ifdef USE_BERRY
   if (!TasmotaGlobal.no_autoexec) {
     BerryInit();                 // Load preinit.be
@@ -740,49 +738,14 @@ void setup(void) {
   TasmotaGlobal.rules_flag.system_init = 1;
 }
 
-void BacklogLoop(void) {
-  if (TimeReached(TasmotaGlobal.backlog_timer)) {
-    if (!BACKLOG_EMPTY && !TasmotaGlobal.backlog_mutex) {
-      TasmotaGlobal.backlog_mutex = true;
-      bool nodelay = false;
-      do {
-        char* cmd = *backlog.head();
-        backlog.removeHead();
-/*
-        // This adds 32 bytes
-        char* cmd = *backlog.removeHead();
-*/
-        if (!strncasecmp_P(cmd, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
-          free(cmd);
-          nodelay = true;
-        } else {
-          TasmotaGlobal.no_mqtt_response = TasmotaGlobal.backlog_no_mqtt_response;
-          ExecuteCommand(cmd, SRC_BACKLOG);
-          free(cmd);
-          if (nodelay || TasmotaGlobal.backlog_nodelay) {
-            TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
-          } else if (TasmotaGlobal.backlog_delay_guard) {
-            TasmotaGlobal.backlog_delay_guard = false;
-          } else {
-            TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];
-          }
-          break;
-        }
-      } while (!BACKLOG_EMPTY);
-      TasmotaGlobal.backlog_mutex = false;
-    }
-    if (BACKLOG_EMPTY) {
-      TasmotaGlobal.backlog_nodelay = false;
-    }
-  }
-}
+// BacklogLoop() is defined in support_backlog.ino (Backlog::Loop() + thin wrapper)
 
 void SleepSkip(void) {
   TasmotaGlobal.skip_sleep = 250;     // Skip sleep for 250 loops;
 }
 
 void SleepDelay(uint32_t mseconds) {
-  if (!TasmotaGlobal.backlog_nodelay && mseconds) {
+  if (!Backlog::IsNodelay() && mseconds) {
     uint32_t wait = millis() + mseconds;
     while (!TasmotaGlobal.skip_sleep &&  // We need to service imminent interrupts ASAP
            !TimeReached(wait) &&

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -312,6 +312,7 @@ struct TasmotaGlobal_t {
   bool no_mqtt_response;                    // Respond with rule processing only
   bool backlog_nodelay;                     // Execute all backlog commands with no delay
   bool backlog_mutex;                       // Command backlog pending
+  bool backlog_delay_guard;                 // CmndDelay set timer during drain; BacklogLoop preserves it
   bool backlog_no_mqtt_response;            // Set respond with rule processing only
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
@@ -760,6 +761,10 @@ void BacklogLoop(void) {
           free(cmd);
           if (nodelay || TasmotaGlobal.backlog_nodelay) {
             TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
+          } else if (TasmotaGlobal.backlog_delay_guard) {
+            TasmotaGlobal.backlog_delay_guard = false;
+          } else {
+            TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];
           }
           break;
         }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -3075,6 +3075,11 @@ String Decompress(const char * compressed, size_t uncompressed_size) {
  * Bridge functions - isolate peripheral code from TasmotaGlobal and Settings internals
 \*********************************************************************************************/
 
+// MQTT-response suppression for the underscore-prefix command feature and Backlog.
+void SuppressMqttResponse() {
+  TasmotaGlobal.no_mqtt_response = true;
+}
+
 uint8_t& SettingsParam(uint32_t index) {
   static uint8_t _oob = 0;
   if (index >= PARAM8_SIZE) { _oob = 0; return _oob; }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -3070,3 +3070,13 @@ String Decompress(const char * compressed, size_t uncompressed_size) {
 }
 
 #endif // USE_UNISHOX_COMPRESSION
+
+/*********************************************************************************************\
+ * Bridge functions - isolate peripheral code from TasmotaGlobal and Settings internals
+\*********************************************************************************************/
+
+uint8_t& SettingsParam(uint32_t index) {
+  static uint8_t _oob = 0;
+  if (index >= PARAM8_SIZE) { _oob = 0; return _oob; }
+  return Settings->param[index];
+}

--- a/tasmota/tasmota_support/support_backlog.cpp
+++ b/tasmota/tasmota_support/support_backlog.cpp
@@ -1,0 +1,161 @@
+/*
+  support_backlog.cpp - Backlog command queue implementation
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#include <LList.h>
+#include "my_user_config.h"
+#include "include/tasmota_compat.h"
+#include "include/tasmota.h"
+#include "include/i18n.h"
+#include "include/support_backlog.h"
+
+// Prototype duplicates for symbols defined in the unity build (no header available)
+bool     TimeReached(uint32_t timer);
+int32_t  TimePassedSince(uint32_t timestamp);
+void     ExecuteCommand(const char *cmnd, uint32_t source);
+void     SuppressMqttResponse();
+uint8_t& SettingsParam(uint32_t index);
+
+/*********************************************************************************************\
+ * Backlog - command queue with configurable inter-command timing
+ *
+ * Variants:
+ *   Backlog  / Backlog1 - commands separated by SetOption34 delay, MQTT responses on
+ *   Backlog0 / Backlog2 - no delay (D_CMND_NODELAY inserted), MQTT responses on/off
+ *   Backlog3            - SetOption34 delay, MQTT responses off
+\*********************************************************************************************/
+
+namespace Backlog {
+
+/*********************************************************************************************\
+ * Private state - inaccessible outside this translation unit
+\*********************************************************************************************/
+namespace {
+  LList<char*> _queue;
+  uint32_t     _timer        = 0;
+  bool         _nodelay      = false;
+  bool         _mutex        = false;
+  bool         _delay_guard  = false;  // set by ScheduleDelay() inside a timed drain; prevents Loop() from overwriting _timer
+  bool         _no_mqtt_resp = false;
+}
+
+/*********************************************************************************************\
+ * Public interface
+\*********************************************************************************************/
+
+void Init() { _timer = millis(); }
+
+bool IsEmpty()   { return _queue.isEmpty(); }
+bool IsNodelay() { return _nodelay; }
+
+uint32_t GetRemainingDelay_ms() {
+  if (TimeReached(_timer)) { return 0; }
+  return (uint32_t)(-TimePassedSince(_timer));
+}
+
+void SetNodelay(bool val)        { _nodelay      = val; }
+void SetNoMqttResponse(bool val) { _no_mqtt_resp = val; }
+
+// Called by CommandHandler for every dispatched command so that normal
+// command processing schedules a new backlog drain window.
+void OnCommandExecuted() {
+  _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+}
+
+// Schedule the next drain to happen immediately (used after Backlog enqueue).
+void ScheduleNow() {
+  _timer = millis();
+}
+
+// Schedule the next drain after an explicit delay (used by CmndDelay).
+// When called from within a timed drain (_mutex=true): sets _delay_guard so Loop() preserves
+// the timer instead of overwriting it with the standard inter-command delay.
+void ScheduleDelay(uint32_t ms) {
+  _timer = millis() + ms;
+  if (_mutex) { _delay_guard = true; }
+}
+
+// Append a single command string to the queue (called once per parsed token
+// inside CmndBacklog's tokenisation loop).
+void EnqueueCmd(const char* cmd) {
+  char* temp = (char*)malloc(strlen(cmd) + 1);
+  if (temp != nullptr) {
+    strcpy(temp, cmd);
+    char* &elem = _queue.addToLast();
+    elem = temp;
+  }
+}
+
+// Insert a command at a specific position (used by the rules IF/ENDIF engine
+// to prepend a command block in-order at the head of the queue).
+void InsertCmd(const char* cmd, uint32_t position) {
+  char* temp = (char*)malloc(strlen(cmd) + 1);
+  if (temp != nullptr) {
+    strcpy(temp, cmd);
+    char* &elem = _queue.insertAt(position);
+    elem = temp;
+  }
+}
+
+// Discard all queued commands (called when Backlog is invoked with no data).
+void Clear() {
+  for (auto &elem : _queue) {
+    free(elem);
+    _queue.remove(&elem);
+  }
+}
+
+// Main drain loop - called every iteration from BacklogLoop().
+void Loop() {
+  if (TimeReached(_timer)) {
+    if (!_queue.isEmpty() && !_mutex) {
+      _mutex = true;
+      bool nodelay = false;
+      do {
+        char* cmd = *_queue.head();
+        _queue.removeHead();
+        if (!strncasecmp_P(cmd, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
+          free(cmd);
+          nodelay = true;
+        } else {
+          if (_no_mqtt_resp) { SuppressMqttResponse(); }
+          ExecuteCommand(cmd, SRC_BACKLOG);
+          free(cmd);
+          // Loop() owns the timer after each timed drain step.
+          // Exception: when CmndDelay ran during the drain it sets _delay_guard via
+          // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
+          if (nodelay || _nodelay) {
+            _timer = millis();
+          } else if (_delay_guard) {
+            _delay_guard = false;
+          } else {
+            _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+          }
+          break;
+        }
+      } while (!_queue.isEmpty());
+      _mutex = false;
+    }
+    if (_queue.isEmpty()) {
+      _nodelay = false;
+    }
+  }
+}
+
+} // namespace Backlog

--- a/tasmota/tasmota_support/support_backlog.ino
+++ b/tasmota/tasmota_support/support_backlog.ino
@@ -1,0 +1,25 @@
+/*
+  support_backlog.ino - Backlog queue bridge for Tasmota
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*********************************************************************************************\
+ * Scheduler entry point - called from the main loop in tasmota.ino.
+ * Implementation lives in support_backlog.cpp (separate translation unit).
+\*********************************************************************************************/
+
+void BacklogLoop(void) { Backlog::Loop(); }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1589,7 +1589,7 @@ void CmndSetoption(void) {
         for (uint32_t i = 0; i < PARAM8_SIZE; i++) {
           ResponseAppend_P(PSTR("%s%d"),
             (i) ? "," : "",
-            Settings->param[i]);                   // SetOption32 .. 49
+            SettingsParam(i));                     // SetOption32 .. 49
         }
         ResponseAppend_P(PSTR("]"));
       }
@@ -1642,7 +1642,7 @@ uint32_t GetOption(uint32_t index) {
   uint32_t pindex;
   if (SetoptionDecode(index, &ptype, &pindex)) {
     if (1 == ptype) {
-      return Settings->param[pindex];
+      return SettingsParam(pindex);
     } else {
       uint32_t flag = Settings->flag.data;
       if (3 == ptype) {
@@ -1687,7 +1687,7 @@ void CmndSetoptionBase(bool indexed) {
             break;
         }
         if ((XdrvMailbox.payload >= param_low) && (XdrvMailbox.payload <= param_high)) {
-          Settings->param[pindex] = XdrvMailbox.payload;
+          SettingsParam(pindex) = XdrvMailbox.payload;
 #ifdef USE_LIGHT
           if (P_RGB_REMAP == pindex) {
             LightUpdateColorMapping();

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -466,8 +466,8 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len) {
   if (strlen(type)) {
     if (Settings->ledstate &0x02) { TasmotaGlobal.blinks++; }
 
-//    TasmotaGlobal.backlog_timer = millis() + (100 * MIN_BACKLOG_DELAY);
-    TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];  // SetOption34
+//    Backlog::ScheduleDelay(100 * MIN_BACKLOG_DELAY);
+    Backlog::OnCommandExecuted();  // SetOption34 - keeps drain window open during burst
 
     char command[CMDSZ] = { 0 };
     XdrvMailbox.command = command;
@@ -528,8 +528,8 @@ void CmndBacklog(void) {
   // Backlog3 command1;command2;..  Execute commands in sequence with a delay but no response but rule processing only
 
   if (XdrvMailbox.data_len) {
-    TasmotaGlobal.backlog_nodelay = (0 == (XdrvMailbox.index & 0x01));           // Backlog0, Backlog2
-    TasmotaGlobal.backlog_no_mqtt_response = (2 == (XdrvMailbox.index & 0x02));  // Backlog2, Backlog3
+    Backlog::SetNodelay(0 == (XdrvMailbox.index & 0x01));           // Backlog0, Backlog2
+    Backlog::SetNoMqttResponse(2 == (XdrvMailbox.index & 0x02));    // Backlog2, Backlog3
 
     char *blcommand = strtok(XdrvMailbox.data, ";");
     while (blcommand != nullptr) {
@@ -550,24 +550,17 @@ void CmndBacklog(void) {
         }
       }
       // Do not allow command Reset in backlog
-      if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0))  {
-        char* temp = strdup(blcommand);
-        if (temp != nullptr) {
-          char* &elem = backlog.addToLast();
-          elem = temp;
-        }
+      if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0)) {
+        Backlog::EnqueueCmd(blcommand);
       }
       blcommand = strtok(nullptr, ";");
     }
 //    ResponseCmndChar(D_JSON_APPENDED);
     ResponseClear();
-    TasmotaGlobal.backlog_timer = millis();
+    Backlog::ScheduleNow();
   } else {
-    bool blflag = BACKLOG_EMPTY;
-    for (auto &elem : backlog) {
-      free(elem);
-      backlog.remove(&elem);
-    }
+    bool blflag = Backlog::IsEmpty();
+    Backlog::Clear();
     ResponseCmndChar(blflag ? PSTR(D_JSON_EMPTY) : PSTR(D_JSON_ABORTED));
   }
 }
@@ -652,16 +645,12 @@ void CmndDelay(void) {
   // Delay 2   - Wait 2 x 100ms
   // Delay 10  - Wait 10 x 100ms
   if (XdrvMailbox.payload == -1) {
-    TasmotaGlobal.backlog_timer = millis() + (1000 - RtcMillis());  // Next second (#18984)
+    Backlog::ScheduleDelay(1000 - RtcMillis());  // Next second (#18984)
   }
   else if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
-    TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
+    Backlog::ScheduleDelay(100 * XdrvMailbox.payload);
   }
-  if (TasmotaGlobal.backlog_mutex) { TasmotaGlobal.backlog_delay_guard = true; }
-  uint32_t bl_delay = 0;
-  long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
-  if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }
-  ResponseCmndNumber(bl_delay);
+  ResponseCmndNumber(Backlog::GetRemainingDelay_ms() / 100);
 }
 
 void CmndJsonPP(void) {

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -657,6 +657,7 @@ void CmndDelay(void) {
   else if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
     TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
   }
+  if (TasmotaGlobal.backlog_mutex) { TasmotaGlobal.backlog_delay_guard = true; }
   uint32_t bl_delay = 0;
   long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
   if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -2008,11 +2008,7 @@ void ExecuteCommandBlock(const char * commands, int len)
 
     if (strlen(blcommand)) {
       //Insert into backlog
-      char* temp = strdup(blcommand);
-      if (temp != nullptr) {
-        char* &elem = backlog.insertAt(insertPosition++);
-        elem = temp;
-      }
+      Backlog::InsertCmd(blcommand, insertPosition++);
     }
   }
   return;


### PR DESCRIPTION
## Description

Part of the backlog improvement series documented in discussion #24776. 

Implementation choices are open to discussion. If you'd prefer a different approach, please comment -- I'll revise.

### Context

The previous PR fixed the backlog timer: `BacklogLoop` now unconditionally
owns `backlog_timer` after each drain step. That fix depends on one invariant:
`backlog_mutex` is set and cleared exclusively by `BacklogLoop`.

That invariant currently has no enforcement mechanism -- it holds by
convention. `backlog_mutex`, `backlog_timer`, and `backlog_nodelay` sit in
`TasmotaGlobal_t`, writable from any `.ino` file without restriction. A 
driver or rule handler that touches these fields will silently break the
previous fix without any compiler or linker feedback.

This PR removes that exposure by making the fields inaccessible outside their
translation unit. All mutation now goes through explicit entry points; accidental
modification from unrelated code paths is structurally impossible.

---

### Changes

#### Protection boundary
`backlog_mutex`, `backlog_timer`, `backlog_nodelay`, `backlog_delay_guard`,
`backlog_no_mqtt_response`, and the backlog queue are no longer reachable from
`.ino` scope. All mutation goes through explicit entry points in a new
`Backlog::` API.

#### Implementation
- `tasmota/tasmota_support/support_backlog.cpp` -- state in anonymous
  namespace
- `tasmota/include/support_backlog.h` -- public API declarations
- `tasmota/tasmota_support/support_backlog.ino` -- one-line adapter:
  `BacklogLoop()` forwards to `Backlog::Loop()`

`SuppressMqttResponse()` added to `support.ino` as designated mutation path
for `no_mqtt_response` from backlog context (replaces direct field access).
`SettingsParam(index)` added as bounds-checked reference getter for
`Settings->param[]` - a small bonus for the whole system.

All callers in `support_command.ino` and `xdrv_10_rules.ino` mechanically
converted to the `Backlog::` API. No logic changed.

---

### Memory impact (measured, this PR only)

| Target     | Flash  | RAM | IRAM |
|------------|--------|-----|------|
| tasmota32  | +88 B  | +8  | 0    |
| tasmota-4M | +312 B | +8  | 0    |

The flash delta is the cost of the enforcement boundary. Without it, the
invariant from the previous PR remains advisory. The RAM delta reflects
alignment differences between anonymous-namespace variables in a `.cpp`
translation unit and packed fields in `TasmotaGlobal_t`.

---

**No logic changed.**

**Requires pr/backlog-timer-fix:** this PR enforces at module level the timer-ownership invariant established by the previous fix.

**Tested:**
Build-tested on ESP8266 (tasmota-4M) and ESP32 (tasmota32). Target-tested on ESP32: completed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

