### PR TITLE
backlog: queue diagnostics and byte-limit safety net

### DIFF
--- a/lib/default/TasmotaLList/src/LList.h
+++ b/lib/default/TasmotaLList/src/LList.h
@@ -58,6 +58,13 @@ public:
   LList() : _head(nullptr) {}
   ~LList() { reset(); }
 
+  // Structural size of one list node (sizeof LList_elt<T>, excluding heap-allocator bookkeeping).
+  // Callers that account for queue memory must not compute this from LList_elt<T> directly:
+  // the node layout is an implementation detail of LList and may change independently of T.
+  // Exposing it here keeps the per-element cost contract stable while enforcing the principle
+  // that only LList owns — and therefore discloses — the size of its own internal nodes.
+  static constexpr size_t element_size = sizeof(LList_elt<T>);
+
   // remove elements
   T * removeHead(void);      // remove first element
   void reset(void);           // remove all elements

--- a/tasmota/include/support_backlog.h
+++ b/tasmota/include/support_backlog.h
@@ -1,0 +1,46 @@
+/*
+  support_backlog.h - Public interface for the Backlog command queue
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _SUPPORT_BACKLOG_H_
+#define _SUPPORT_BACKLOG_H_
+
+namespace Backlog {
+  void Init();
+
+  bool     IsEmpty();
+  bool     IsNodelay();
+  uint32_t GetRemainingDelay_ms();
+
+  void SetNodelay(bool val);
+  void SetNoMqttResponse(bool val);
+
+  void OnCommandExecuted();
+  void ScheduleNow();
+  void ScheduleDelay(uint32_t ms);
+
+  void EnqueueCmd(const char* cmd);
+  void InsertCmd(const char* cmd, uint32_t position);
+  void Clear();
+
+  void Loop();
+}
+
+void BacklogLoop(void);
+
+#endif  // _SUPPORT_BACKLOG_H_

--- a/tasmota/include/support_backlog.h
+++ b/tasmota/include/support_backlog.h
@@ -21,6 +21,19 @@
 #define _SUPPORT_BACKLOG_H_
 
 namespace Backlog {
+
+  enum class NoDelay : uint8_t {
+    OFF,
+    ON,
+    NoChange
+  };
+
+  enum class NoMqttResponse : uint8_t {
+    OFF,
+    ON,
+    NoChange
+  };
+
   void Init();
 
   bool     IsEmpty();
@@ -30,15 +43,25 @@ namespace Backlog {
   void SetNodelay(bool val);
   void SetNoMqttResponse(bool val);
 
+  // Call from command handlers that are unsafe when the current drain step is NoDelay --
+  // e.g. commands controlling hardware with settling-time requirements, interlock logic,
+  // or state-machine dependencies. Logs an error if _nodelay_current is set.
+  // Handlers without this call have not yet been evaluated for NoDelay safety.
+  void WarnIfNoDelay(PGM_P cmd_name_P);
+
   void OnCommandExecuted();
   void ScheduleNow();
   void ScheduleDelay(uint32_t ms);
 
-  void EnqueueCmd(const char* cmd);
-  void InsertCmd(const char* cmd, uint32_t position);
+  void EnqueueCmd(const char* cmd, NoDelay noDelay = NoDelay::NoChange, NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
+  void InsertCmd(const char* cmd, uint32_t position, NoDelay noDelay = NoDelay::NoChange, NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
   void Clear();
 
   void Loop();
+
+  inline void EnqueueCmd(const char* cmd, NoMqttResponse noMqttResponse, NoDelay noDelay) { EnqueueCmd(cmd, noDelay, noMqttResponse); }
+  inline void EnqueueCmd(const char* cmd, NoDelay noDelay)                                { EnqueueCmd(cmd, noDelay, NoMqttResponse::NoChange); }
+  inline void EnqueueCmd(const char* cmd, NoMqttResponse noMqttResponse)                 { EnqueueCmd(cmd, NoDelay::NoChange, noMqttResponse); }
 }
 
 void BacklogLoop(void);

--- a/tasmota/include/support_backlog.h
+++ b/tasmota/include/support_backlog.h
@@ -49,6 +49,9 @@ namespace Backlog {
   void SetNoMqttResponse(bool val);
   void SetChunkSize(uint32_t n);
   void SetTraceDrain(bool val);
+  uint32_t GetMaxBytes();
+  void     SetMaxBytes(uint32_t limit);  // 0 = reset to compile-time default; clamped to BACKLOG_QUEUE_MIN_BYTES
+
   // Call from command handlers that are unsafe when the current drain step is NoDelay --
   // e.g. commands controlling hardware with settling-time requirements, interlock logic,
   // or state-machine dependencies. Logs an error if _nodelay_current is set.
@@ -58,6 +61,7 @@ namespace Backlog {
   void OnCommandExecuted();
   void ScheduleNow();
   void ScheduleDelay(uint32_t ms);
+  bool TryReserveSequence(uint32_t total_str_len, uint32_t cmd_count);
 
   void DumpStats();
   void DumpQueue(uint32_t page);

--- a/tasmota/include/support_backlog.h
+++ b/tasmota/include/support_backlog.h
@@ -34,15 +34,21 @@ namespace Backlog {
     NoChange
   };
 
+  // Value stored in the source byte of a queue entry when the caller did not annotate.
+  static constexpr uint8_t kSourceUnknown = 255;
+
   void Init();
 
   bool     IsEmpty();
   bool     IsNodelay();
   uint32_t GetRemainingDelay_ms();
+  uint32_t GetChunkSize();
+  bool     IsTraceDrain();
 
   void SetNodelay(bool val);
   void SetNoMqttResponse(bool val);
-
+  void SetChunkSize(uint32_t n);
+  void SetTraceDrain(bool val);
   // Call from command handlers that are unsafe when the current drain step is NoDelay --
   // e.g. commands controlling hardware with settling-time requirements, interlock logic,
   // or state-machine dependencies. Logs an error if _nodelay_current is set.
@@ -53,15 +59,22 @@ namespace Backlog {
   void ScheduleNow();
   void ScheduleDelay(uint32_t ms);
 
-  void EnqueueCmd(const char* cmd, NoDelay noDelay = NoDelay::NoChange, NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
-  void InsertCmd(const char* cmd, uint32_t position, NoDelay noDelay = NoDelay::NoChange, NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
-  void Clear();
+  void DumpStats();
+  void DumpQueue(uint32_t page);
 
+  void Clear();
   void Loop();
 
-  inline void EnqueueCmd(const char* cmd, NoMqttResponse noMqttResponse, NoDelay noDelay) { EnqueueCmd(cmd, noDelay, noMqttResponse); }
-  inline void EnqueueCmd(const char* cmd, NoDelay noDelay)                                { EnqueueCmd(cmd, noDelay, NoMqttResponse::NoChange); }
-  inline void EnqueueCmd(const char* cmd, NoMqttResponse noMqttResponse)                 { EnqueueCmd(cmd, NoDelay::NoChange, noMqttResponse); }
+  void EnqueueCmd(const char* cmd, uint8_t source = kSourceUnknown,
+                  NoDelay noDelay = NoDelay::NoChange,
+                  NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
+  void InsertCmd(const char* cmd, uint32_t position, uint8_t source = kSourceUnknown,
+                 NoDelay noDelay = NoDelay::NoChange,
+                 NoMqttResponse noMqttResponse = NoMqttResponse::NoChange);
+  // helper overloads -- source defaults to kSourceUnknown
+  inline void EnqueueCmd(const char* cmd, uint8_t source, NoMqttResponse noMqttResponse, NoDelay noDelay) { EnqueueCmd(cmd, source, noDelay, noMqttResponse); }
+  inline void EnqueueCmd(const char* cmd, uint8_t source, NoDelay noDelay)                                { EnqueueCmd(cmd, source, noDelay, NoMqttResponse::NoChange); }
+  inline void EnqueueCmd(const char* cmd, uint8_t source, NoMqttResponse noMqttResponse)                 { EnqueueCmd(cmd, source, NoDelay::NoChange, noMqttResponse); }
 }
 
 void BacklogLoop(void);

--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -218,6 +218,11 @@ const uint8_t SENSOR_MAX_MISS = 5;          // Max number of missed sensor reads
 
 const uint32_t MIN_BACKLOG_DELAY = 200;     // Minimal backlog delay in mSeconds
 
+#ifndef BACKLOG_EXT_DELAY
+#define BACKLOG_EXT_DELAY  100              // Post-external-command drain window in ms (user_config_override.h: 0 = always off)
+#endif
+#define SO_BACKLOG_EXT_DELAY_DISABLE  166   // SetOption166: disable post-external-command drain window (1=disable, 0=enable)
+
 const uint32_t SOFT_BAUDRATE = 9600;        // Default software serial baudrate
 const uint32_t APP_BAUDRATE = 115200;       // Default serial baudrate
 const uint32_t SERIAL_POLLING = 100;        // Serial receive polling in ms

--- a/tasmota/include/tasmota.h
+++ b/tasmota/include/tasmota.h
@@ -223,6 +223,24 @@ const uint32_t MIN_BACKLOG_DELAY = 200;     // Minimal backlog delay in mSeconds
 #endif
 #define SO_BACKLOG_EXT_DELAY_DISABLE  166   // SetOption166: disable post-external-command drain window (1=disable, 0=enable)
 
+// Backlog queue byte limit - controls how much heap the queue may consume.
+// Per-command heap cost: ~15 B payload (typical short command) + ~27 B fixed overhead
+// (LList node, allocator bookkeeping per malloc/new, entry header bytes) = ~42 B/cmd.
+// Overhead breakdown is in support_backlog.cpp (kPerCmdAcctOverhead, kEntryFixedOverhead).
+// Capacity examples:  1024 B ~= 24 short cmds   4096 B ~= 97   32768 B ~= 780
+// Override at build time via user_config_override.h; adjust at runtime via Backlog18 N.
+#ifndef BACKLOG_QUEUE_MAX_BYTES
+#  ifdef ESP32
+#    define BACKLOG_QUEUE_MAX_BYTES  32768  // ~1/5 of typical free heap on tightest ESP32 target
+#  else
+#    define BACKLOG_QUEUE_MAX_BYTES  4096   // ~1/5 of typical free heap on ESP8266
+#  endif
+#endif
+#ifndef BACKLOG_QUEUE_MIN_BYTES
+// Minimum value accepted by Backlog18; empirically stable on ESP8266 under sustained load.
+#  define BACKLOG_QUEUE_MIN_BYTES  1024     // ~24 short commands
+#endif
+
 const uint32_t SOFT_BAUDRATE = 9600;        // Default software serial baudrate
 const uint32_t APP_BAUDRATE = 115200;       // Default serial baudrate
 const uint32_t SERIAL_POLLING = 100;        // Serial receive polling in ms

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -200,7 +200,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t gui_device_name : 1;          // bit 17 (v14.4.1.1) - SetOption163 - GUI_NOSHOW_DEVICENAME - (GUI) Disable display of GUI device name (1)
     uint32_t wizmote_enabled : 1;          // bit 18 (v14.4.1.4) - SetOption164 - (WizMote) Enable WiZ Smart Remote support (1)
     uint32_t tls_use_ecdsa : 1;            // bit 19 (v15.0.1.0) - SetOption165 - (TLS) Enable ECDSA validation in addition to RSA
-    uint32_t spare20 : 1;                  // bit 20
+    uint32_t backlog_ext_delay_disable : 1; // bit 20             - SetOption166 - (Backlog) Disable post-external-command drain window; see SO34 and BACKLOG_EXT_DELAY (1)
     uint32_t spare21 : 1;                  // bit 21
     uint32_t spare22 : 1;                  // bit 22
     uint32_t spare23 : 1;                  // bit 23
@@ -215,7 +215,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   };
 } SOBitfield6;
 
-const uint8_t MAX_SETOPTION_USED = 165;    // Max number of SetOption. Used by command SetOption to display all states
+const uint8_t MAX_SETOPTION_USED = 166;    // Max number of SetOption. Used by command SetOption to display all states
 
 // Bitfield to be used for persistent multi bit
 typedef union {

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -260,7 +260,7 @@ struct TasmotaGlobal_t {
   uint32_t baudrate;                        // Current Serial baudrate
   uint32_t pulse_timer[MAX_PULSETIMERS];    // Power off timer
   uint32_t blink_timer;                     // Power cycle timer
-  uint32_t backlog_timer;                   // Timer for next command in backlog
+  // backlog_timer moved to Backlog namespace (support_backlog.cpp)
   uint32_t loop_load_avg;                   // Indicative loop load average
   uint32_t log_buffer_pointer;              // Index in log buffer
   uint32_t uptime;                          // Counting every second until 4294967295 = 130 year
@@ -310,10 +310,7 @@ struct TasmotaGlobal_t {
   bool serial_local;                        // Handle serial locally
   bool fallback_topic_flag;                 // Use Topic or FallbackTopic
   bool no_mqtt_response;                    // Respond with rule processing only
-  bool backlog_nodelay;                     // Execute all backlog commands with no delay
-  bool backlog_mutex;                       // Command backlog pending
-  bool backlog_delay_guard;                 // CmndDelay set timer during drain; BacklogLoop preserves it
-  bool backlog_no_mqtt_response;            // Set respond with rule processing only
+  // backlog_nodelay, backlog_mutex, backlog_delay_guard, backlog_no_mqtt_response moved to Backlog namespace (support_backlog.cpp)
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
   bool pwm_present;                         // Any PWM channel configured with SetOption15 0
@@ -397,8 +394,8 @@ struct TasmotaGlobal_t {
 
 TSettings* Settings = nullptr;
 
-LList<char*> backlog;                       // Command backlog implemented with TasmotaLList
-#define BACKLOG_EMPTY (backlog.isEmpty())
+#include "include/support_backlog.h"
+#define BACKLOG_EMPTY (Backlog::IsEmpty())
 
 /*********************************************************************************************\
  * Main
@@ -707,6 +704,7 @@ void setup(void) {
 #ifdef ROTARY_V1
   RotaryInit();
 #endif  // ROTARY_V1
+  Backlog::Init();               // Set timer to millis() before Berry or drivers may enqueue commands
 #ifdef USE_BERRY
   if (!TasmotaGlobal.no_autoexec) {
     BerryInit();                 // Load preinit.be
@@ -740,49 +738,14 @@ void setup(void) {
   TasmotaGlobal.rules_flag.system_init = 1;
 }
 
-void BacklogLoop(void) {
-  if (TimeReached(TasmotaGlobal.backlog_timer)) {
-    if (!BACKLOG_EMPTY && !TasmotaGlobal.backlog_mutex) {
-      TasmotaGlobal.backlog_mutex = true;
-      bool nodelay = false;
-      do {
-        char* cmd = *backlog.head();
-        backlog.removeHead();
-/*
-        // This adds 32 bytes
-        char* cmd = *backlog.removeHead();
-*/
-        if (!strncasecmp_P(cmd, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
-          free(cmd);
-          nodelay = true;
-        } else {
-          TasmotaGlobal.no_mqtt_response = TasmotaGlobal.backlog_no_mqtt_response;
-          ExecuteCommand(cmd, SRC_BACKLOG);
-          free(cmd);
-          if (nodelay || TasmotaGlobal.backlog_nodelay) {
-            TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
-          } else if (TasmotaGlobal.backlog_delay_guard) {
-            TasmotaGlobal.backlog_delay_guard = false;
-          } else {
-            TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];
-          }
-          break;
-        }
-      } while (!BACKLOG_EMPTY);
-      TasmotaGlobal.backlog_mutex = false;
-    }
-    if (BACKLOG_EMPTY) {
-      TasmotaGlobal.backlog_nodelay = false;
-    }
-  }
-}
+// BacklogLoop() is defined in support_backlog.ino (Backlog::Loop() + thin wrapper)
 
 void SleepSkip(void) {
   TasmotaGlobal.skip_sleep = 250;     // Skip sleep for 250 loops;
 }
 
 void SleepDelay(uint32_t mseconds) {
-  if (!TasmotaGlobal.backlog_nodelay && mseconds) {
+  if (!Backlog::IsNodelay() && mseconds) {
     uint32_t wait = millis() + mseconds;
     while (!TasmotaGlobal.skip_sleep &&  // We need to service imminent interrupts ASAP
            !TimeReached(wait) &&

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -312,6 +312,7 @@ struct TasmotaGlobal_t {
   bool no_mqtt_response;                    // Respond with rule processing only
   bool backlog_nodelay;                     // Execute all backlog commands with no delay
   bool backlog_mutex;                       // Command backlog pending
+  bool backlog_delay_guard;                 // CmndDelay set timer during drain; BacklogLoop preserves it
   bool backlog_no_mqtt_response;            // Set respond with rule processing only
   bool stop_flash_rotate;                   // Allow flash configuration rotation
   bool blinkstate;                          // LED state
@@ -760,6 +761,10 @@ void BacklogLoop(void) {
           free(cmd);
           if (nodelay || TasmotaGlobal.backlog_nodelay) {
             TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
+          } else if (TasmotaGlobal.backlog_delay_guard) {
+            TasmotaGlobal.backlog_delay_guard = false;
+          } else {
+            TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];
           }
           break;
         }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -3075,6 +3075,11 @@ String Decompress(const char * compressed, size_t uncompressed_size) {
  * Bridge functions - isolate peripheral code from TasmotaGlobal and Settings internals
 \*********************************************************************************************/
 
+// MQTT-response suppression for the underscore-prefix command feature and Backlog.
+void SuppressMqttResponse() {
+  TasmotaGlobal.no_mqtt_response = true;
+}
+
 uint8_t& SettingsParam(uint32_t index) {
   static uint8_t _oob = 0;
   if (index >= PARAM8_SIZE) { _oob = 0; return _oob; }

--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -3070,3 +3070,13 @@ String Decompress(const char * compressed, size_t uncompressed_size) {
 }
 
 #endif // USE_UNISHOX_COMPRESSION
+
+/*********************************************************************************************\
+ * Bridge functions - isolate peripheral code from TasmotaGlobal and Settings internals
+\*********************************************************************************************/
+
+uint8_t& SettingsParam(uint32_t index) {
+  static uint8_t _oob = 0;
+  if (index >= PARAM8_SIZE) { _oob = 0; return _oob; }
+  return Settings->param[index];
+}

--- a/tasmota/tasmota_support/support_backlog.cpp
+++ b/tasmota/tasmota_support/support_backlog.cpp
@@ -33,6 +33,8 @@ void      SuppressMqttResponse();
 uint8_t&  SettingsParam(uint32_t index);
 uint32_t  GetOption(uint32_t index);
 void      AddLog(uint32_t loglevel, PGM_P formatP, ...);
+int       Response_P(PGM_P formatP, ...);
+int       ResponseAppend_P(PGM_P formatP, ...);
 
 /*********************************************************************************************\
  * Backlog - command queue with configurable inter-command timing
@@ -41,6 +43,12 @@ void      AddLog(uint32_t loglevel, PGM_P formatP, ...);
  *   Backlog  / Backlog1 - commands separated by SetOption34 delay, MQTT responses on
  *   Backlog0 / Backlog2 - no delay, MQTT responses on/off
  *   Backlog3            - SetOption34 delay, MQTT responses off
+ *
+ * Queue entry layout:
+ *   Without BACKLOG_TRACE_SOURCE: [flavor_byte][cmd\0]           - malloc(strlen+2)
+ *   With    BACKLOG_TRACE_SOURCE: [flavor_byte][source][cmd\0]   - malloc(strlen+3)
+ *   flavor_byte: bit0=nodelay, bit1=no_mqtt_resp
+ *   source:      CommandSource enum value, 255 = not annotated
 \*********************************************************************************************/
 
 namespace Backlog {
@@ -57,6 +65,25 @@ namespace {
   bool         _delay_guard          = false;   // set by ScheduleDelay() inside a timed drain; prevents Loop() from overwriting _timer
   bool         _no_mqtt_resp_staged  = false;   // set by CmndBacklog / ExecuteCommandBlock
   bool         _no_mqtt_resp_current = false;   // set per drain step from flavor byte
+
+  // Phase H: diagnostics and runtime config
+  uint32_t     _drain_count           = 0;
+  uint32_t     _enqueue_count         = 0;
+  uint32_t     _insert_count          = 0;
+  uint32_t     _mutex_skip            = 0;
+  uint32_t     _depth                 = 0;  // running counter: +1 on enqueue/insert, -1 on drain, 0 on clear
+  uint32_t     _max_depth             = 0;
+  uint32_t     _max_bytes             = 0;  // Phase S: always 0 until then
+  uint32_t     _max_entry_len         = 0;
+  uint32_t     _chunk_size            = 20;
+  bool         _trace_drain           = false;
+
+  // Byte offset from start of a queue entry to the command string.
+#ifdef BACKLOG_TRACE_SOURCE
+  static constexpr uint8_t kCmdOffset = 2;
+#else
+  static constexpr uint8_t kCmdOffset = 1;
+#endif
 }
 
 /*********************************************************************************************\
@@ -65,8 +92,10 @@ namespace {
 
 void Init() { _timer = millis(); }
 
-bool IsEmpty()   { return _queue.isEmpty(); }
-bool IsNodelay() { return _nodelay_current; }
+bool IsEmpty()     { return _queue.isEmpty(); }
+bool IsNodelay()   { return _nodelay_current; }
+uint32_t GetChunkSize() { return _chunk_size; }
+bool     IsTraceDrain() { return _trace_drain; }
 
 uint32_t GetRemainingDelay_ms() {
   if (TimeReached(_timer)) { return 0; }
@@ -75,6 +104,8 @@ uint32_t GetRemainingDelay_ms() {
 
 void SetNodelay(bool val)        { _nodelay_staged      = val; }
 void SetNoMqttResponse(bool val) { _no_mqtt_resp_staged = val; }
+void SetChunkSize(uint32_t n)    { if (n > 0) _chunk_size = n; }
+void SetTraceDrain(bool val)     { _trace_drain = val; }
 
 // Log a warning when a command that requires inter-command settling time is called
 // inside a NoDelay drain step. Call from handlers with hardware or state-machine
@@ -85,10 +116,10 @@ void WarnIfNoDelay(PGM_P cmd_name_P) {
 }
 
 // Flavor-byte accessors - bit0=nodelay, bit1=no_mqtt_resp
-static bool _NoDelayOf(const char* head)       { return !!(*head & (1 << 0)); }
-static bool _NoMqttOf(const char* head)        { return !!(*head & (1 << 1)); }
-static void _SetNoDelayIn(char* val, bool flag) { *val |= (flag ? 1 : 0) << 0; }
-static void _SetNoMqttIn(char* val, bool flag)  { *val |= (flag ? 1 : 0) << 1; }
+static bool _NoDelayOf(const char* head)        { return !!(*head & (1 << 0)); }
+static bool _NoMqttOf(const char* head)         { return !!(*head & (1 << 1)); }
+static void _SetNoDelayIn(char* val, bool flag)  { *val |= (flag ? 1 : 0) << 0; }
+static void _SetNoMqttIn(char* val, bool flag)   { *val |= (flag ? 1 : 0) << 1; }
 
 // Returns the configured post-external-command drain window in ms, or 0 if disabled.
 // SO166=0 (default): window active, value from BACKLOG_EXT_DELAY compile constant.
@@ -127,41 +158,59 @@ void ScheduleDelay(uint32_t ms) {
 // inside CmndBacklog's tokenisation loop).
 // Each entry is prefixed with a flavor byte (bit0=nodelay, bit1=no_mqtt_resp)
 // baked in from the staged flags at enqueue time.
-void EnqueueCmd(const char* cmd, NoDelay noDelay, NoMqttResponse noMqttResponse) {
+void EnqueueCmd(const char* cmd, uint8_t source, NoDelay noDelay, NoMqttResponse noMqttResponse) {
   if (NoDelay::NoChange != noDelay)
     _nodelay_staged = NoDelay::ON == noDelay;
 
   if (NoMqttResponse::NoChange != noMqttResponse)
     _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
 
-  char* temp = (char*)malloc(strlen(cmd) + 2);
+  uint32_t cmd_len = strlen(cmd);
+  char* temp = (char*)malloc(cmd_len + 1 + kCmdOffset);
   if (temp != nullptr) {
     *temp = 0;
     _SetNoDelayIn(temp, _nodelay_staged);
     _SetNoMqttIn(temp, _no_mqtt_resp_staged);
-    strcpy(temp + 1, cmd);
+#ifdef BACKLOG_TRACE_SOURCE
+    *(temp + 1) = (char)source;
+#endif
+    strcpy(temp + kCmdOffset, cmd);
     char* &elem = _queue.addToLast();
     elem = temp;
+    _enqueue_count++;
+    _depth++;
+    if (cmd_len > _max_entry_len) { _max_entry_len = cmd_len; }
+    uint32_t d = _queue.length();
+    if (d > _max_depth) { _max_depth = d; }
   }
 }
 
 // Insert a command at a specific position (used by the rules IF/ENDIF engine
 // to prepend a command block in-order at the head of the queue).
-void InsertCmd(const char* cmd, uint32_t position, NoDelay noDelay, NoMqttResponse noMqttResponse) {
+void InsertCmd(const char* cmd, uint32_t position, uint8_t source, NoDelay noDelay, NoMqttResponse noMqttResponse) {
   if (NoDelay::NoChange != noDelay)
     _nodelay_staged = NoDelay::ON == noDelay;
 
   if (NoMqttResponse::NoChange != noMqttResponse)
     _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
 
-  char* temp = (char*)malloc(strlen(cmd) + 2);
+  uint32_t cmd_len = strlen(cmd);
+  char* temp = (char*)malloc(cmd_len + 1 + kCmdOffset);
   if (temp != nullptr) {
     *temp = 0;
     _SetNoDelayIn(temp, _nodelay_staged);
     _SetNoMqttIn(temp, _no_mqtt_resp_staged);
-    strcpy(temp + 1, cmd);
+#ifdef BACKLOG_TRACE_SOURCE
+    *(temp + 1) = (char)source;
+#endif
+    strcpy(temp + kCmdOffset, cmd);
     char* &elem = _queue.insertAt(position);
     elem = temp;
+    _insert_count++;
+    _depth++;
+    if (cmd_len > _max_entry_len) { _max_entry_len = cmd_len; }
+    uint32_t d = _queue.length();
+    if (d > _max_depth) { _max_depth = d; }
   }
 }
 
@@ -171,6 +220,7 @@ void Clear() {
     free(elem);
     _queue.remove(&elem);
   }
+  _depth = 0;
 }
 
 // Main drain loop - called every iteration from BacklogLoop().
@@ -182,10 +232,24 @@ void Loop() {
       _queue.removeHead();
       _nodelay_current      = _NoDelayOf(head);
       _no_mqtt_resp_current = _NoMqttOf(head);
-      char* cmd = head + 1;
+      char* cmd = head + kCmdOffset;
+      if (_trace_drain) {
+        // D= shows depth before this drain step (pre-decrement): last entry logs D=1, not D=0.
+        // Semantics: "queue held D entries when this command was taken."
+#ifdef BACKLOG_TRACE_SOURCE
+        AddLog(LOG_LEVEL_INFO, PSTR("BLG: D=%u T=%u Src=%u Cmd=\"%s\""),
+               _depth, (uint8_t)*head, (uint8_t)*(head + 1), cmd);
+#else
+        AddLog(LOG_LEVEL_INFO, PSTR("BLG: D=%u T=%u Cmd=\"%s\""),
+               _depth, (uint8_t)*head, cmd);
+#endif
+      }
+      if (_depth > 0) { _depth--; }
+      else { AddLog(LOG_LEVEL_ERROR, PSTR("BLG: depth counter underflow")); }
       if (_no_mqtt_resp_current) { SuppressMqttResponse(); }
       ExecuteCommand(cmd, SRC_BACKLOG);
       free(head);
+      _drain_count++;
       // Loop() is the sole owner of _timer after each drain step.
       // Exception: when CmndDelay ran during the drain it sets _delay_guard via
       // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
@@ -197,12 +261,84 @@ void Loop() {
         _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
       }
       _mutex = false;
+    } else if (!_queue.isEmpty() && _mutex) {
+      _mutex_skip++;
     }
     if (_queue.isEmpty()) {
       _nodelay_current      = false;
       _no_mqtt_resp_current = false;
     }
   }
+}
+
+// Backlog20 - Queue statistics snapshot
+void DumpStats() {
+  uint32_t depth       = _queue.length();
+  int32_t  timer_delta = (int32_t)(_timer - millis());
+
+  Response_P(PSTR("{\"BacklogStat\":{"));
+  ResponseAppend_P(PSTR("\"Depth\":%u,\"DepthCounter\":%u,\"Bytes\":0,"), depth, _depth);
+  ResponseAppend_P(PSTR("\"TimerMs\":%d,\"Ready\":%u,\"Mutex\":%u,"),
+                   timer_delta, TimeReached(_timer) ? 1 : 0, _mutex ? 1 : 0);
+  ResponseAppend_P(PSTR("\"StagedNodelay\":%u,\"StagedNoMqtt\":%u,"),
+                   _nodelay_staged ? 1 : 0, _no_mqtt_resp_staged ? 1 : 0);
+  ResponseAppend_P(PSTR("\"CurrentNodelay\":%u,\"TraceDrain\":%u,"),
+                   _nodelay_current ? 1 : 0, _trace_drain ? 1 : 0);
+  ResponseAppend_P(PSTR("\"Drained\":%u,\"Enqueued\":%u,\"Inserted\":%u,"),
+                   _drain_count, _enqueue_count, _insert_count);
+  ResponseAppend_P(PSTR("\"Discarded\":0,\"MutexSkipped\":%u,"), _mutex_skip);
+  ResponseAppend_P(PSTR("\"MaxDepth\":%u,\"MaxBytes\":0,\"MaxEntryLen\":%u,"),
+                   _max_depth, _max_entry_len);
+  ResponseAppend_P(PSTR("\"SO34\":%u,\"SO166\":%u,\"ExtDelayMs\":%u,"),
+                   SettingsParam(P_BACKLOG_DELAY),
+                   GetOption(SO_BACKLOG_EXT_DELAY_DISABLE),
+                   _ExtDelayMs());
+  ResponseAppend_P(PSTR("\"ChunkSize\":%u}}"), _chunk_size);
+}
+
+// Backlog21..29 - Queue content, paged
+// page = BacklogIndex - 21; entries [page*_chunk_size .. (page+1)*_chunk_size - 1]
+// All output channels (Serial/log via AddLog, Web-Console/MQTT via Response) use
+// identical JSON format - one entry object per AddLog line, assembled response for the rest.
+void DumpQueue(uint32_t page) {
+  uint32_t depth     = _queue.length();
+  uint32_t start_idx = page * _chunk_size;
+
+  AddLog(LOG_LEVEL_INFO, PSTR("BLQ: {\"BacklogQueue\":{\"Depth\":%u,\"StartIdx\":%u,\"ChunkSize\":%u,\"Entry\":["),
+         depth, start_idx, _chunk_size);
+  Response_P(PSTR("{\"BacklogQueue\":{\"Depth\":%u,\"StartIdx\":%u,\"ChunkSize\":%u,\"Entry\":["),
+             depth, start_idx, _chunk_size);
+
+  uint32_t idx   = 0;
+  uint32_t count = 0;
+  bool     first = true;
+  for (auto &entry : _queue) {
+    if (idx >= start_idx) {
+      if (count >= _chunk_size) { break; }
+      char*   head   = entry;
+      uint8_t flavor = (uint8_t)*head;
+      char*   cmd    = head + kCmdOffset;
+
+      if (!first) { ResponseAppend_P(PSTR(",")); }
+      first = false;
+#ifdef BACKLOG_TRACE_SOURCE
+      uint8_t src = (uint8_t)*(head + 1);
+      AddLog(LOG_LEVEL_INFO, PSTR("BLQ: {\"Idx\":%u,\"T\":%u,\"Src\":%u,\"Cmd\":\"%s\"}"),
+             idx, flavor, src, cmd);
+      ResponseAppend_P(PSTR("{\"Idx\":%u,\"T\":%u,\"Src\":%u,\"Cmd\":\"%s\"}"),
+                       idx, flavor, src, cmd);
+#else
+      AddLog(LOG_LEVEL_INFO, PSTR("BLQ: {\"Idx\":%u,\"T\":%u,\"Cmd\":\"%s\"}"),
+             idx, flavor, cmd);
+      ResponseAppend_P(PSTR("{\"Idx\":%u,\"T\":%u,\"Cmd\":\"%s\"}"), idx, flavor, cmd);
+#endif
+      count++;
+    }
+    idx++;
+  }
+
+  AddLog(LOG_LEVEL_INFO, PSTR("BLQ: ]}}"));
+  ResponseAppend_P(PSTR("]}}"));
 }
 
 } // namespace Backlog

--- a/tasmota/tasmota_support/support_backlog.cpp
+++ b/tasmota/tasmota_support/support_backlog.cpp
@@ -1,0 +1,161 @@
+/*
+  support_backlog.cpp - Backlog command queue implementation
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#include <LList.h>
+#include "my_user_config.h"
+#include "include/tasmota_compat.h"
+#include "include/tasmota.h"
+#include "include/i18n.h"
+#include "include/support_backlog.h"
+
+// Prototype duplicates for symbols defined in the unity build (no header available)
+bool     TimeReached(uint32_t timer);
+int32_t  TimePassedSince(uint32_t timestamp);
+void     ExecuteCommand(const char *cmnd, uint32_t source);
+void     SuppressMqttResponse();
+uint8_t& SettingsParam(uint32_t index);
+
+/*********************************************************************************************\
+ * Backlog - command queue with configurable inter-command timing
+ *
+ * Variants:
+ *   Backlog  / Backlog1 - commands separated by SetOption34 delay, MQTT responses on
+ *   Backlog0 / Backlog2 - no delay (D_CMND_NODELAY inserted), MQTT responses on/off
+ *   Backlog3            - SetOption34 delay, MQTT responses off
+\*********************************************************************************************/
+
+namespace Backlog {
+
+/*********************************************************************************************\
+ * Private state - inaccessible outside this translation unit
+\*********************************************************************************************/
+namespace {
+  LList<char*> _queue;
+  uint32_t     _timer        = 0;
+  bool         _nodelay      = false;
+  bool         _mutex        = false;
+  bool         _delay_guard  = false;  // set by ScheduleDelay() inside a timed drain; prevents Loop() from overwriting _timer
+  bool         _no_mqtt_resp = false;
+}
+
+/*********************************************************************************************\
+ * Public interface
+\*********************************************************************************************/
+
+void Init() { _timer = millis(); }
+
+bool IsEmpty()   { return _queue.isEmpty(); }
+bool IsNodelay() { return _nodelay; }
+
+uint32_t GetRemainingDelay_ms() {
+  if (TimeReached(_timer)) { return 0; }
+  return (uint32_t)(-TimePassedSince(_timer));
+}
+
+void SetNodelay(bool val)        { _nodelay      = val; }
+void SetNoMqttResponse(bool val) { _no_mqtt_resp = val; }
+
+// Called by CommandHandler for every dispatched command so that normal
+// command processing schedules a new backlog drain window.
+void OnCommandExecuted() {
+  _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+}
+
+// Schedule the next drain to happen immediately (used after Backlog enqueue).
+void ScheduleNow() {
+  _timer = millis();
+}
+
+// Schedule the next drain after an explicit delay (used by CmndDelay).
+// When called from within a timed drain (_mutex=true): sets _delay_guard so Loop() preserves
+// the timer instead of overwriting it with the standard inter-command delay.
+void ScheduleDelay(uint32_t ms) {
+  _timer = millis() + ms;
+  if (_mutex) { _delay_guard = true; }
+}
+
+// Append a single command string to the queue (called once per parsed token
+// inside CmndBacklog's tokenisation loop).
+void EnqueueCmd(const char* cmd) {
+  char* temp = (char*)malloc(strlen(cmd) + 1);
+  if (temp != nullptr) {
+    strcpy(temp, cmd);
+    char* &elem = _queue.addToLast();
+    elem = temp;
+  }
+}
+
+// Insert a command at a specific position (used by the rules IF/ENDIF engine
+// to prepend a command block in-order at the head of the queue).
+void InsertCmd(const char* cmd, uint32_t position) {
+  char* temp = (char*)malloc(strlen(cmd) + 1);
+  if (temp != nullptr) {
+    strcpy(temp, cmd);
+    char* &elem = _queue.insertAt(position);
+    elem = temp;
+  }
+}
+
+// Discard all queued commands (called when Backlog is invoked with no data).
+void Clear() {
+  for (auto &elem : _queue) {
+    free(elem);
+    _queue.remove(&elem);
+  }
+}
+
+// Main drain loop - called every iteration from BacklogLoop().
+void Loop() {
+  if (TimeReached(_timer)) {
+    if (!_queue.isEmpty() && !_mutex) {
+      _mutex = true;
+      bool nodelay = false;
+      do {
+        char* cmd = *_queue.head();
+        _queue.removeHead();
+        if (!strncasecmp_P(cmd, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
+          free(cmd);
+          nodelay = true;
+        } else {
+          if (_no_mqtt_resp) { SuppressMqttResponse(); }
+          ExecuteCommand(cmd, SRC_BACKLOG);
+          free(cmd);
+          // Loop() owns the timer after each timed drain step.
+          // Exception: when CmndDelay ran during the drain it sets _delay_guard via
+          // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
+          if (nodelay || _nodelay) {
+            _timer = millis();
+          } else if (_delay_guard) {
+            _delay_guard = false;
+          } else {
+            _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+          }
+          break;
+        }
+      } while (!_queue.isEmpty());
+      _mutex = false;
+    }
+    if (_queue.isEmpty()) {
+      _nodelay = false;
+    }
+  }
+}
+
+} // namespace Backlog

--- a/tasmota/tasmota_support/support_backlog.cpp
+++ b/tasmota/tasmota_support/support_backlog.cpp
@@ -73,10 +73,14 @@ namespace {
   uint32_t     _mutex_skip            = 0;
   uint32_t     _depth                 = 0;  // running counter: +1 on enqueue/insert, -1 on drain, 0 on clear
   uint32_t     _max_depth             = 0;
-  uint32_t     _max_bytes             = 0;  // Phase S: always 0 until then
+  uint32_t     _max_bytes             = 0;
   uint32_t     _max_entry_len         = 0;
   uint32_t     _chunk_size            = 20;
   bool         _trace_drain           = false;
+
+  // Phase S: queue byte limit
+  uint32_t     _queue_bytes           = 0;  // current heap used by queue entries
+  uint32_t     _discard_count         = 0;  // enqueue attempts rejected due to byte limit
 
   // Byte offset from start of a queue entry to the command string.
 #ifdef BACKLOG_TRACE_SOURCE
@@ -84,6 +88,39 @@ namespace {
 #else
   static constexpr uint8_t kCmdOffset = 1;
 #endif
+
+  static constexpr uint32_t kDefaultMaxBytes = BACKLOG_QUEUE_MAX_BYTES;
+  static constexpr uint32_t kMinBytes        = BACKLOG_QUEUE_MIN_BYTES;
+  static uint32_t           _bytes_limit     = kDefaultMaxBytes;
+
+  // Estimated bookkeeping added by the heap allocator per malloc/new call on ESP targets.
+  // Applied twice per queued command: once for the malloc'd entry, once for the LList node.
+  static constexpr uint32_t kHeapAllocOverhead = 8;
+  // Fixed heap cost per queued command, independent of command length:
+  //   LList<char*>::element_size - node struct (pointer + value), from LList's public interface
+  //   2 * kHeapAllocOverhead     - allocator bookkeeping for entry malloc + LList node new
+  static constexpr uint32_t kEntryFixedOverhead =
+      static_cast<uint32_t>(LList<char*>::element_size) + 2 * kHeapAllocOverhead;
+  // Total fixed accounting cost added per queued command on top of the raw string length:
+  //   kCmdOffset + 1 - header byte(s) + null terminator in the malloc'd entry (1+1 or 2+1)
+  //   kEntryFixedOverhead - LList node struct (8 B) + 2 x allocator bookkeeping (2x8 B) = 24 B
+  // Sum: 26 B (without BACKLOG_TRACE_SOURCE) or 27 B (with). Empirically confirmed on ESP8266.
+  // See BACKLOG_QUEUE_MAX_BYTES / BACKLOG_QUEUE_MIN_BYTES in tasmota.h for capacity estimates.
+  static constexpr uint32_t kPerCmdAcctOverhead = kCmdOffset + 1 + kEntryFixedOverhead;
+}
+
+// Accounting byte cost for cmd_count commands whose strings sum to str_len bytes.
+// Single source of truth for the per-entry overhead formula - used by all check and
+// drain sites so that formula changes require editing exactly one place.
+static uint32_t _AcctBytes(uint32_t str_len, uint32_t cmd_count) {
+  return str_len + cmd_count * kPerCmdAcctOverhead;
+}
+
+// Returns true if acct_bytes fit within the queue limit.
+// On failure: increments _discard_count, returns false. Caller owns the log message.
+static bool _CheckUsageCount(uint32_t acct_bytes) {
+  if (_queue_bytes + acct_bytes > _bytes_limit) { _discard_count++; return false; }
+  return true;
 }
 
 /*********************************************************************************************\
@@ -106,6 +143,11 @@ void SetNodelay(bool val)        { _nodelay_staged      = val; }
 void SetNoMqttResponse(bool val) { _no_mqtt_resp_staged = val; }
 void SetChunkSize(uint32_t n)    { if (n > 0) _chunk_size = n; }
 void SetTraceDrain(bool val)     { _trace_drain = val; }
+
+uint32_t GetMaxBytes() { return _bytes_limit; }
+void SetMaxBytes(uint32_t limit) {
+  _bytes_limit = (limit == 0) ? kDefaultMaxBytes : max(limit, kMinBytes);
+}
 
 // Log a warning when a command that requires inter-command settling time is called
 // inside a NoDelay drain step. Call from handlers with hardware or state-machine
@@ -154,6 +196,20 @@ void ScheduleDelay(uint32_t ms) {
   if (_mutex) { _delay_guard = true; }
 }
 
+// Pre-check for CmndBacklog(): whole-sequence-or-nothing gate.
+// Call before the tokenisation loop with the raw data string length and the number of
+// commands (semicolons + 1). Counts the rejection and logs the byte context on failure.
+// Contract: after a true return the caller MUST enqueue the sequence - no exceptions.
+bool TryReserveSequence(uint32_t total_str_len, uint32_t cmd_count) {
+  uint32_t estimated = _AcctBytes(total_str_len, cmd_count);
+  if (!_CheckUsageCount(estimated)) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLG: Sequence rejected, queue %u/%u B, need ~%u B"),
+           _queue_bytes, _bytes_limit, estimated);
+    return false;
+  }
+  return true;
+}
+
 // Append a single command string to the queue (called once per parsed token
 // inside CmndBacklog's tokenisation loop).
 // Each entry is prefixed with a flavor byte (bit0=nodelay, bit1=no_mqtt_resp)
@@ -165,8 +221,15 @@ void EnqueueCmd(const char* cmd, uint8_t source, NoDelay noDelay, NoMqttResponse
   if (NoMqttResponse::NoChange != noMqttResponse)
     _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
 
-  uint32_t cmd_len = strlen(cmd);
-  char* temp = (char*)malloc(cmd_len + 1 + kCmdOffset);
+  uint32_t cmd_len     = strlen(cmd);
+  uint32_t alloc_bytes = cmd_len + 1 + kCmdOffset;
+  uint32_t acct_bytes  = _AcctBytes(cmd_len, 1);
+  if (!_CheckUsageCount(acct_bytes)) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLG: Queue full (%u/%u B), discarded: %s"),
+           _queue_bytes, _bytes_limit, cmd);
+    return;
+  }
+  char* temp = (char*)malloc(alloc_bytes);
   if (temp != nullptr) {
     *temp = 0;
     _SetNoDelayIn(temp, _nodelay_staged);
@@ -179,7 +242,9 @@ void EnqueueCmd(const char* cmd, uint8_t source, NoDelay noDelay, NoMqttResponse
     elem = temp;
     _enqueue_count++;
     _depth++;
-    if (cmd_len > _max_entry_len) { _max_entry_len = cmd_len; }
+    _queue_bytes += acct_bytes;
+    if (_queue_bytes > _max_bytes)  { _max_bytes  = _queue_bytes; }
+    if (cmd_len > _max_entry_len)   { _max_entry_len = cmd_len; }
     uint32_t d = _queue.length();
     if (d > _max_depth) { _max_depth = d; }
   }
@@ -194,8 +259,15 @@ void InsertCmd(const char* cmd, uint32_t position, uint8_t source, NoDelay noDel
   if (NoMqttResponse::NoChange != noMqttResponse)
     _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
 
-  uint32_t cmd_len = strlen(cmd);
-  char* temp = (char*)malloc(cmd_len + 1 + kCmdOffset);
+  uint32_t cmd_len     = strlen(cmd);
+  uint32_t alloc_bytes = cmd_len + 1 + kCmdOffset;
+  uint32_t acct_bytes  = _AcctBytes(cmd_len, 1);
+  if (!_CheckUsageCount(acct_bytes)) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLG: Queue full (%u/%u B), discarded: %s"),
+           _queue_bytes, _bytes_limit, cmd);
+    return;
+  }
+  char* temp = (char*)malloc(alloc_bytes);
   if (temp != nullptr) {
     *temp = 0;
     _SetNoDelayIn(temp, _nodelay_staged);
@@ -208,7 +280,9 @@ void InsertCmd(const char* cmd, uint32_t position, uint8_t source, NoDelay noDel
     elem = temp;
     _insert_count++;
     _depth++;
-    if (cmd_len > _max_entry_len) { _max_entry_len = cmd_len; }
+    _queue_bytes += acct_bytes;
+    if (_queue_bytes > _max_bytes)  { _max_bytes  = _queue_bytes; }
+    if (cmd_len > _max_entry_len)   { _max_entry_len = cmd_len; }
     uint32_t d = _queue.length();
     if (d > _max_depth) { _max_depth = d; }
   }
@@ -220,7 +294,8 @@ void Clear() {
     free(elem);
     _queue.remove(&elem);
   }
-  _depth = 0;
+  _depth       = 0;
+  _queue_bytes = 0;
 }
 
 // Main drain loop - called every iteration from BacklogLoop().
@@ -232,7 +307,8 @@ void Loop() {
       _queue.removeHead();
       _nodelay_current      = _NoDelayOf(head);
       _no_mqtt_resp_current = _NoMqttOf(head);
-      char* cmd = head + kCmdOffset;
+      char*    cmd        = head + kCmdOffset;
+      uint32_t acct_bytes = _AcctBytes(strlen(cmd), 1);  // must be read before free(head)
       if (_trace_drain) {
         // D= shows depth before this drain step (pre-decrement): last entry logs D=1, not D=0.
         // Semantics: "queue held D entries when this command was taken."
@@ -250,6 +326,8 @@ void Loop() {
       ExecuteCommand(cmd, SRC_BACKLOG);
       free(head);
       _drain_count++;
+      if (_queue_bytes >= acct_bytes) { _queue_bytes -= acct_bytes; }
+      else { _queue_bytes = 0; }
       // Loop() is the sole owner of _timer after each drain step.
       // Exception: when CmndDelay ran during the drain it sets _delay_guard via
       // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
@@ -277,7 +355,7 @@ void DumpStats() {
   int32_t  timer_delta = (int32_t)(_timer - millis());
 
   Response_P(PSTR("{\"BacklogStat\":{"));
-  ResponseAppend_P(PSTR("\"Depth\":%u,\"DepthCounter\":%u,\"Bytes\":0,"), depth, _depth);
+  ResponseAppend_P(PSTR("\"Depth\":%u,\"DepthCounter\":%u,\"Bytes\":%u,"), depth, _depth, _queue_bytes);
   ResponseAppend_P(PSTR("\"TimerMs\":%d,\"Ready\":%u,\"Mutex\":%u,"),
                    timer_delta, TimeReached(_timer) ? 1 : 0, _mutex ? 1 : 0);
   ResponseAppend_P(PSTR("\"StagedNodelay\":%u,\"StagedNoMqtt\":%u,"),
@@ -286,14 +364,15 @@ void DumpStats() {
                    _nodelay_current ? 1 : 0, _trace_drain ? 1 : 0);
   ResponseAppend_P(PSTR("\"Drained\":%u,\"Enqueued\":%u,\"Inserted\":%u,"),
                    _drain_count, _enqueue_count, _insert_count);
-  ResponseAppend_P(PSTR("\"Discarded\":0,\"MutexSkipped\":%u,"), _mutex_skip);
-  ResponseAppend_P(PSTR("\"MaxDepth\":%u,\"MaxBytes\":0,\"MaxEntryLen\":%u,"),
-                   _max_depth, _max_entry_len);
+  ResponseAppend_P(PSTR("\"Discarded\":%u,\"MutexSkipped\":%u,"), _discard_count, _mutex_skip);
+  ResponseAppend_P(PSTR("\"MaxDepth\":%u,\"MaxBytes\":%u,\"MaxEntryLen\":%u,"),
+                   _max_depth, _max_bytes, _max_entry_len);
   ResponseAppend_P(PSTR("\"SO34\":%u,\"SO166\":%u,\"ExtDelayMs\":%u,"),
                    SettingsParam(P_BACKLOG_DELAY),
                    GetOption(SO_BACKLOG_EXT_DELAY_DISABLE),
                    _ExtDelayMs());
-  ResponseAppend_P(PSTR("\"ChunkSize\":%u}}"), _chunk_size);
+  ResponseAppend_P(PSTR("\"ChunkSize\":%u,\"BytesLimit\":%u,\"DefaultBytesLimit\":%u}}"),
+                   _chunk_size, _bytes_limit, kDefaultMaxBytes);
 }
 
 // Backlog21..29 - Queue content, paged

--- a/tasmota/tasmota_support/support_backlog.cpp
+++ b/tasmota/tasmota_support/support_backlog.cpp
@@ -26,18 +26,20 @@
 #include "include/support_backlog.h"
 
 // Prototype duplicates for symbols defined in the unity build (no header available)
-bool     TimeReached(uint32_t timer);
-int32_t  TimePassedSince(uint32_t timestamp);
-void     ExecuteCommand(const char *cmnd, uint32_t source);
-void     SuppressMqttResponse();
-uint8_t& SettingsParam(uint32_t index);
+bool      TimeReached(uint32_t timer);
+int32_t   TimePassedSince(uint32_t timestamp);
+void      ExecuteCommand(const char *cmnd, uint32_t source);
+void      SuppressMqttResponse();
+uint8_t&  SettingsParam(uint32_t index);
+uint32_t  GetOption(uint32_t index);
+void      AddLog(uint32_t loglevel, PGM_P formatP, ...);
 
 /*********************************************************************************************\
  * Backlog - command queue with configurable inter-command timing
  *
  * Variants:
  *   Backlog  / Backlog1 - commands separated by SetOption34 delay, MQTT responses on
- *   Backlog0 / Backlog2 - no delay (D_CMND_NODELAY inserted), MQTT responses on/off
+ *   Backlog0 / Backlog2 - no delay, MQTT responses on/off
  *   Backlog3            - SetOption34 delay, MQTT responses off
 \*********************************************************************************************/
 
@@ -48,11 +50,13 @@ namespace Backlog {
 \*********************************************************************************************/
 namespace {
   LList<char*> _queue;
-  uint32_t     _timer        = 0;
-  bool         _nodelay      = false;
-  bool         _mutex        = false;
-  bool         _delay_guard  = false;  // set by ScheduleDelay() inside a timed drain; prevents Loop() from overwriting _timer
-  bool         _no_mqtt_resp = false;
+  uint32_t     _timer                = 0;
+  bool         _nodelay_staged       = false;   // set by CmndBacklog / ExecuteCommandBlock
+  bool         _nodelay_current      = false;   // set per drain step from flavor byte
+  bool         _mutex                = false;
+  bool         _delay_guard          = false;   // set by ScheduleDelay() inside a timed drain; prevents Loop() from overwriting _timer
+  bool         _no_mqtt_resp_staged  = false;   // set by CmndBacklog / ExecuteCommandBlock
+  bool         _no_mqtt_resp_current = false;   // set per drain step from flavor byte
 }
 
 /*********************************************************************************************\
@@ -62,20 +66,46 @@ namespace {
 void Init() { _timer = millis(); }
 
 bool IsEmpty()   { return _queue.isEmpty(); }
-bool IsNodelay() { return _nodelay; }
+bool IsNodelay() { return _nodelay_current; }
 
 uint32_t GetRemainingDelay_ms() {
   if (TimeReached(_timer)) { return 0; }
   return (uint32_t)(-TimePassedSince(_timer));
 }
 
-void SetNodelay(bool val)        { _nodelay      = val; }
-void SetNoMqttResponse(bool val) { _no_mqtt_resp = val; }
+void SetNodelay(bool val)        { _nodelay_staged      = val; }
+void SetNoMqttResponse(bool val) { _no_mqtt_resp_staged = val; }
 
-// Called by CommandHandler for every dispatched command so that normal
-// command processing schedules a new backlog drain window.
+// Log a warning when a command that requires inter-command settling time is called
+// inside a NoDelay drain step. Call from handlers with hardware or state-machine
+// dependencies that make them unsafe at zero inter-command delay.
+void WarnIfNoDelay(PGM_P cmd_name_P) {
+  if (_nodelay_current)
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLG: '%s' unsafe in NoDelay context"), cmd_name_P);
+}
+
+// Flavor-byte accessors - bit0=nodelay, bit1=no_mqtt_resp
+static bool _NoDelayOf(const char* head)       { return !!(*head & (1 << 0)); }
+static bool _NoMqttOf(const char* head)        { return !!(*head & (1 << 1)); }
+static void _SetNoDelayIn(char* val, bool flag) { *val |= (flag ? 1 : 0) << 0; }
+static void _SetNoMqttIn(char* val, bool flag)  { *val |= (flag ? 1 : 0) << 1; }
+
+// Returns the configured post-external-command drain window in ms, or 0 if disabled.
+// SO166=0 (default): window active, value from BACKLOG_EXT_DELAY compile constant.
+// SO166=1:           window disabled; BacklogLoop is sole timer owner (SO34 still applies).
+// Override at build time: #define BACKLOG_EXT_DELAY XXX in user_config_override.h.
+static uint32_t _ExtDelayMs() {
+  if (GetOption(SO_BACKLOG_EXT_DELAY_DISABLE)) { return 0; }
+  return BACKLOG_EXT_DELAY;
+}
+
+// Called by CommandHandler for every dispatched command so that external commands
+// (MQTT, Serial, Button, ...) can extend the Backlog drain window.
+// BacklogLoop() overrides _timer after each drain step regardless - this only
+// has lasting effect for commands that do NOT originate from the Backlog itself.
 void OnCommandExecuted() {
-  _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+  uint32_t ms = _ExtDelayMs();
+  if (ms) { _timer = millis() + ms; }
 }
 
 // Schedule the next drain to happen immediately (used after Backlog enqueue).
@@ -84,19 +114,32 @@ void ScheduleNow() {
 }
 
 // Schedule the next drain after an explicit delay (used by CmndDelay).
+// No-op when _nodelay_current is set (Delay has no effect inside NoDelay sequences).
 // When called from within a timed drain (_mutex=true): sets _delay_guard so Loop() preserves
 // the timer instead of overwriting it with the standard inter-command delay.
 void ScheduleDelay(uint32_t ms) {
+  if (_nodelay_current) { return; }
   _timer = millis() + ms;
   if (_mutex) { _delay_guard = true; }
 }
 
 // Append a single command string to the queue (called once per parsed token
 // inside CmndBacklog's tokenisation loop).
-void EnqueueCmd(const char* cmd) {
-  char* temp = (char*)malloc(strlen(cmd) + 1);
+// Each entry is prefixed with a flavor byte (bit0=nodelay, bit1=no_mqtt_resp)
+// baked in from the staged flags at enqueue time.
+void EnqueueCmd(const char* cmd, NoDelay noDelay, NoMqttResponse noMqttResponse) {
+  if (NoDelay::NoChange != noDelay)
+    _nodelay_staged = NoDelay::ON == noDelay;
+
+  if (NoMqttResponse::NoChange != noMqttResponse)
+    _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
+
+  char* temp = (char*)malloc(strlen(cmd) + 2);
   if (temp != nullptr) {
-    strcpy(temp, cmd);
+    *temp = 0;
+    _SetNoDelayIn(temp, _nodelay_staged);
+    _SetNoMqttIn(temp, _no_mqtt_resp_staged);
+    strcpy(temp + 1, cmd);
     char* &elem = _queue.addToLast();
     elem = temp;
   }
@@ -104,10 +147,19 @@ void EnqueueCmd(const char* cmd) {
 
 // Insert a command at a specific position (used by the rules IF/ENDIF engine
 // to prepend a command block in-order at the head of the queue).
-void InsertCmd(const char* cmd, uint32_t position) {
-  char* temp = (char*)malloc(strlen(cmd) + 1);
+void InsertCmd(const char* cmd, uint32_t position, NoDelay noDelay, NoMqttResponse noMqttResponse) {
+  if (NoDelay::NoChange != noDelay)
+    _nodelay_staged = NoDelay::ON == noDelay;
+
+  if (NoMqttResponse::NoChange != noMqttResponse)
+    _no_mqtt_resp_staged = NoMqttResponse::ON == noMqttResponse;
+
+  char* temp = (char*)malloc(strlen(cmd) + 2);
   if (temp != nullptr) {
-    strcpy(temp, cmd);
+    *temp = 0;
+    _SetNoDelayIn(temp, _nodelay_staged);
+    _SetNoMqttIn(temp, _no_mqtt_resp_staged);
+    strcpy(temp + 1, cmd);
     char* &elem = _queue.insertAt(position);
     elem = temp;
   }
@@ -126,34 +178,29 @@ void Loop() {
   if (TimeReached(_timer)) {
     if (!_queue.isEmpty() && !_mutex) {
       _mutex = true;
-      bool nodelay = false;
-      do {
-        char* cmd = *_queue.head();
-        _queue.removeHead();
-        if (!strncasecmp_P(cmd, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
-          free(cmd);
-          nodelay = true;
-        } else {
-          if (_no_mqtt_resp) { SuppressMqttResponse(); }
-          ExecuteCommand(cmd, SRC_BACKLOG);
-          free(cmd);
-          // Loop() owns the timer after each timed drain step.
-          // Exception: when CmndDelay ran during the drain it sets _delay_guard via
-          // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
-          if (nodelay || _nodelay) {
-            _timer = millis();
-          } else if (_delay_guard) {
-            _delay_guard = false;
-          } else {
-            _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
-          }
-          break;
-        }
-      } while (!_queue.isEmpty());
+      char* head = *_queue.head();
+      _queue.removeHead();
+      _nodelay_current      = _NoDelayOf(head);
+      _no_mqtt_resp_current = _NoMqttOf(head);
+      char* cmd = head + 1;
+      if (_no_mqtt_resp_current) { SuppressMqttResponse(); }
+      ExecuteCommand(cmd, SRC_BACKLOG);
+      free(head);
+      // Loop() is the sole owner of _timer after each drain step.
+      // Exception: when CmndDelay ran during the drain it sets _delay_guard via
+      // ScheduleDelay(). In that case Loop() preserves _timer for that one step.
+      if (_nodelay_current) {
+        _timer = millis();
+      } else if (_delay_guard) {
+        _delay_guard = false;
+      } else {
+        _timer = millis() + SettingsParam(P_BACKLOG_DELAY);
+      }
       _mutex = false;
     }
     if (_queue.isEmpty()) {
-      _nodelay = false;
+      _nodelay_current      = false;
+      _no_mqtt_resp_current = false;
     }
   }
 }

--- a/tasmota/tasmota_support/support_backlog.ino
+++ b/tasmota/tasmota_support/support_backlog.ino
@@ -1,0 +1,25 @@
+/*
+  support_backlog.ino - Backlog queue bridge for Tasmota
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*********************************************************************************************\
+ * Scheduler entry point - called from the main loop in tasmota.ino.
+ * Implementation lives in support_backlog.cpp (separate translation unit).
+\*********************************************************************************************/
+
+void BacklogLoop(void) { Backlog::Loop(); }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1589,7 +1589,7 @@ void CmndSetoption(void) {
         for (uint32_t i = 0; i < PARAM8_SIZE; i++) {
           ResponseAppend_P(PSTR("%s%d"),
             (i) ? "," : "",
-            Settings->param[i]);                   // SetOption32 .. 49
+            SettingsParam(i));                     // SetOption32 .. 49
         }
         ResponseAppend_P(PSTR("]"));
       }
@@ -1642,7 +1642,7 @@ uint32_t GetOption(uint32_t index) {
   uint32_t pindex;
   if (SetoptionDecode(index, &ptype, &pindex)) {
     if (1 == ptype) {
-      return Settings->param[pindex];
+      return SettingsParam(pindex);
     } else {
       uint32_t flag = Settings->flag.data;
       if (3 == ptype) {
@@ -1687,7 +1687,7 @@ void CmndSetoptionBase(bool indexed) {
             break;
         }
         if ((XdrvMailbox.payload >= param_low) && (XdrvMailbox.payload <= param_high)) {
-          Settings->param[pindex] = XdrvMailbox.payload;
+          SettingsParam(pindex) = XdrvMailbox.payload;
 #ifdef USE_LIGHT
           if (P_RGB_REMAP == pindex) {
             LightUpdateColorMapping();

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -466,8 +466,8 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len) {
   if (strlen(type)) {
     if (Settings->ledstate &0x02) { TasmotaGlobal.blinks++; }
 
-//    TasmotaGlobal.backlog_timer = millis() + (100 * MIN_BACKLOG_DELAY);
-    TasmotaGlobal.backlog_timer = millis() + Settings->param[P_BACKLOG_DELAY];  // SetOption34
+//    Backlog::ScheduleDelay(100 * MIN_BACKLOG_DELAY);
+    Backlog::OnCommandExecuted();  // SetOption34 - keeps drain window open during burst
 
     char command[CMDSZ] = { 0 };
     XdrvMailbox.command = command;
@@ -528,8 +528,8 @@ void CmndBacklog(void) {
   // Backlog3 command1;command2;..  Execute commands in sequence with a delay but no response but rule processing only
 
   if (XdrvMailbox.data_len) {
-    TasmotaGlobal.backlog_nodelay = (0 == (XdrvMailbox.index & 0x01));           // Backlog0, Backlog2
-    TasmotaGlobal.backlog_no_mqtt_response = (2 == (XdrvMailbox.index & 0x02));  // Backlog2, Backlog3
+    Backlog::SetNodelay(0 == (XdrvMailbox.index & 0x01));           // Backlog0, Backlog2
+    Backlog::SetNoMqttResponse(2 == (XdrvMailbox.index & 0x02));    // Backlog2, Backlog3
 
     char *blcommand = strtok(XdrvMailbox.data, ";");
     while (blcommand != nullptr) {
@@ -550,24 +550,17 @@ void CmndBacklog(void) {
         }
       }
       // Do not allow command Reset in backlog
-      if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0))  {
-        char* temp = strdup(blcommand);
-        if (temp != nullptr) {
-          char* &elem = backlog.addToLast();
-          elem = temp;
-        }
+      if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0)) {
+        Backlog::EnqueueCmd(blcommand);
       }
       blcommand = strtok(nullptr, ";");
     }
 //    ResponseCmndChar(D_JSON_APPENDED);
     ResponseClear();
-    TasmotaGlobal.backlog_timer = millis();
+    Backlog::ScheduleNow();
   } else {
-    bool blflag = BACKLOG_EMPTY;
-    for (auto &elem : backlog) {
-      free(elem);
-      backlog.remove(&elem);
-    }
+    bool blflag = Backlog::IsEmpty();
+    Backlog::Clear();
     ResponseCmndChar(blflag ? PSTR(D_JSON_EMPTY) : PSTR(D_JSON_ABORTED));
   }
 }
@@ -652,16 +645,12 @@ void CmndDelay(void) {
   // Delay 2   - Wait 2 x 100ms
   // Delay 10  - Wait 10 x 100ms
   if (XdrvMailbox.payload == -1) {
-    TasmotaGlobal.backlog_timer = millis() + (1000 - RtcMillis());  // Next second (#18984)
+    Backlog::ScheduleDelay(1000 - RtcMillis());  // Next second (#18984)
   }
   else if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
-    TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
+    Backlog::ScheduleDelay(100 * XdrvMailbox.payload);
   }
-  if (TasmotaGlobal.backlog_mutex) { TasmotaGlobal.backlog_delay_guard = true; }
-  uint32_t bl_delay = 0;
-  long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
-  if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }
-  ResponseCmndNumber(bl_delay);
+  ResponseCmndNumber(Backlog::GetRemainingDelay_ms() / 100);
 }
 
 void CmndJsonPP(void) {

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -657,6 +657,7 @@ void CmndDelay(void) {
   else if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
     TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
   }
+  if (TasmotaGlobal.backlog_mutex) { TasmotaGlobal.backlog_delay_guard = true; }
   uint32_t bl_delay = 0;
   long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
   if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -528,9 +528,11 @@ void CmndBacklog(void) {
   // Backlog3 command1;command2;..  Execute commands in sequence with a delay but no response but rule processing only
 
   if (XdrvMailbox.data_len) {
-    Backlog::SetNodelay(0 == (XdrvMailbox.index & 0x01));           // Backlog0, Backlog2
+    const bool initial_nodelay = (0 == (XdrvMailbox.index & 0x01));  // true for Backlog0/2
+    Backlog::SetNodelay(initial_nodelay);                            // Backlog0, Backlog2
     Backlog::SetNoMqttResponse(2 == (XdrvMailbox.index & 0x02));    // Backlog2, Backlog3
 
+    bool nodelay_oneshot = false;
     char *blcommand = strtok(XdrvMailbox.data, ";");
     while (blcommand != nullptr) {
       // Ignore semicolon (; = end of single command) between brackets {}
@@ -549,9 +551,18 @@ void CmndBacklog(void) {
           break;
         }
       }
-      // Do not allow command Reset in backlog
-      if ((*blcommand != '\0') && (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0)) {
-        Backlog::EnqueueCmd(blcommand);
+      // Do not allow command Reset in backlog; resolve NoDelay at enqueue time.
+      // NoDelay is one-shot: it affects exactly the next enqueued command, then reverts to the
+      // sequence's initial nodelay state - matching the original drain-time semantics where NoDelay
+      // was a queue entry that set a local flag for one command only.
+      if (*blcommand != '\0') {
+        if (0 == strncasecmp_P(blcommand, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
+          Backlog::SetNodelay(true);
+          nodelay_oneshot = true;
+        } else if (strncasecmp_P(blcommand, PSTR(D_CMND_RESET), strlen(D_CMND_RESET)) != 0) {
+          Backlog::EnqueueCmd(blcommand);
+          if (nodelay_oneshot) { Backlog::SetNodelay(initial_nodelay); nodelay_oneshot = false; }
+        }
       }
       blcommand = strtok(nullptr, ";");
     }
@@ -644,6 +655,7 @@ void CmndDelay(void) {
   // Delay 1   - Wait default time (200ms)
   // Delay 2   - Wait 2 x 100ms
   // Delay 10  - Wait 10 x 100ms
+  Backlog::WarnIfNoDelay(PSTR(D_CMND_DELAY));
   if (XdrvMailbox.payload == -1) {
     Backlog::ScheduleDelay(1000 - RtcMillis());  // Next second (#18984)
   }

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -528,6 +528,7 @@ void CmndBacklog(void) {
   // Backlog3 command1;command2;..  Execute commands in sequence with a delay but no response but rule processing only
   // Backlog16 N    Set queue-content chunk size for Backlog21-29 (runtime, non-persistent)
   // Backlog17 0/1  Enable/disable per-entry drain trace log (BLG: tag)
+  // Backlog18 N    Set queue byte limit (0 = reset to compile-time default; clamped to BACKLOG_QUEUE_MIN_BYTES)
   // Backlog20      Queue statistics snapshot
   // Backlog21-29   Queue content, paged (page = index - 21)
 
@@ -544,12 +545,17 @@ void CmndBacklog(void) {
         Backlog::SetTraceDrain(XdrvMailbox.payload != 0);
       }
       Response_P(PSTR("{\"BacklogTraceDrain\":%u}"), Backlog::IsTraceDrain() ? 1 : 0);
+    } else if (18 == idx) {
+      if (XdrvMailbox.data_len > 0) {
+        Backlog::SetMaxBytes((uint32_t)XdrvMailbox.payload);
+      }
+      Response_P(PSTR("{\"BacklogQueueLimit\":%u}"), Backlog::GetMaxBytes());
     } else if (20 == idx) {
       Backlog::DumpStats();
     } else if (idx >= 21 && idx <= 29) {
       Backlog::DumpQueue(idx - 21);
     }
-    // indices 4-15, 18-19: reserved, no response
+    // indices 4-15 and 19: reserved, no response
     return;
   }
 
@@ -557,6 +563,18 @@ void CmndBacklog(void) {
     const bool initial_nodelay = (0 == (XdrvMailbox.index & 0x01));  // true for Backlog0/2
     Backlog::SetNodelay(initial_nodelay);                            // Backlog0, Backlog2
     Backlog::SetNoMqttResponse(2 == (XdrvMailbox.index & 0x02));    // Backlog2, Backlog3
+
+    // Whole-sequence-or-nothing gate - must run before strtok() destroys the string.
+    // Semicolons inside {} pairs are re-joined in the loop below but counted here: the
+    // resulting overcount is intentional (conservative estimate, never underestimates).
+    uint32_t semicolon_count = 0;
+    for (const char* p = XdrvMailbox.data; *p; p++) {
+      if (';' == *p) { semicolon_count++; }
+    }
+    if (!Backlog::TryReserveSequence(XdrvMailbox.data_len, semicolon_count + 1)) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLG: Discarded: %s"), XdrvMailbox.data);
+      return;
+    }
 
     bool nodelay_oneshot = false;
     char *blcommand = strtok(XdrvMailbox.data, ";");

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -526,6 +526,32 @@ void CmndBacklog(void) {
   // Backlog0 command1;command2;..  Execute commands in sequence with no delay
   // Backlog2 command1;command2;..  Execute commands in sequence with no delay and no response but rule processing only
   // Backlog3 command1;command2;..  Execute commands in sequence with a delay but no response but rule processing only
+  // Backlog16 N    Set queue-content chunk size for Backlog21-29 (runtime, non-persistent)
+  // Backlog17 0/1  Enable/disable per-entry drain trace log (BLG: tag)
+  // Backlog20      Queue statistics snapshot
+  // Backlog21-29   Queue content, paged (page = index - 21)
+
+  auto idx = XdrvMailbox.index;
+  if (idx >= 4) {
+    // Runtime config and diagnostic indices - independent of data payload
+    if (16 == idx) {
+      if (XdrvMailbox.data_len > 0 && XdrvMailbox.payload > 0) {
+        Backlog::SetChunkSize((uint32_t)XdrvMailbox.payload);
+      }
+      Response_P(PSTR("{\"BacklogChunkSize\":%u}"), Backlog::GetChunkSize());
+    } else if (17 == idx) {
+      if (XdrvMailbox.data_len > 0) {
+        Backlog::SetTraceDrain(XdrvMailbox.payload != 0);
+      }
+      Response_P(PSTR("{\"BacklogTraceDrain\":%u}"), Backlog::IsTraceDrain() ? 1 : 0);
+    } else if (20 == idx) {
+      Backlog::DumpStats();
+    } else if (idx >= 21 && idx <= 29) {
+      Backlog::DumpQueue(idx - 21);
+    }
+    // indices 4-15, 18-19: reserved, no response
+    return;
+  }
 
   if (XdrvMailbox.data_len) {
     const bool initial_nodelay = (0 == (XdrvMailbox.index & 0x01));  // true for Backlog0/2

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -2008,11 +2008,7 @@ void ExecuteCommandBlock(const char * commands, int len)
 
     if (strlen(blcommand)) {
       //Insert into backlog
-      char* temp = strdup(blcommand);
-      if (temp != nullptr) {
-        char* &elem = backlog.insertAt(insertPosition++);
-        elem = temp;
-      }
+      Backlog::InsertCmd(blcommand, insertPosition++);
     }
   }
   return;

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1965,6 +1965,8 @@ void ExecuteCommandBlock(const char * commands, int len)
 
   char oneCommand[len + 1];     //To put one command
   int insertPosition = 0;       //When insert into backlog, we should do it by 0, 1, 2 ...
+  Backlog::SetNodelay(false);        // IF block behaves like plain Backlog (timed, MQTT on)
+  Backlog::SetNoMqttResponse(false);
   char * pos = cmdbuff;
   int lenEndBlock = 0;
   while (*pos) {
@@ -2007,8 +2009,12 @@ void ExecuteCommandBlock(const char * commands, int len)
 //    AddLog(LOG_LEVEL_DEBUG, PSTR("DBG: Position %d, Command '%s'"), insertPosition, blcommand);
 
     if (strlen(blcommand)) {
-      //Insert into backlog
-      Backlog::InsertCmd(blcommand, insertPosition++);
+      //Insert into backlog; resolve NoDelay at enqueue time
+      if (0 == strncasecmp_P(blcommand, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
+        Backlog::SetNodelay(true);
+      } else {
+        Backlog::InsertCmd(blcommand, insertPosition++);
+      }
     }
   }
   return;


### PR DESCRIPTION
## Description

Part of the backlog improvement series documented in discussion #24776. 

Implementation choices are open to discussion. If you'd prefer a different approach, please comment -- I'll revise.

### Problem

The Backlog queue had no visibility into its own state. Depth, drain
counters, timer status, staged flags, and configuration values were
inaccessible at runtime, making it difficult to diagnose timing issues,
verify that sequences executed as intended, or confirm that behavioral
fixes from earlier PRs had the expected effect.

The queue also had no upper bound on heap consumption. Under sustained
MQTT load the queue can grow until a malloc failure leaves a partial
command sequence in flight, or until the node resets. Both outcomes can 
be considered worse than refusing the sequence before it enters the queue.

---

### Changes

Two commits, each independently buildable.

#### Commit 1: queue diagnostics

`Backlog16 N` - set the chunk size for paged queue content output
  (Backlog21-29, default 20 entries per page; runtime, non-persistent).

`Backlog17 0/1` - enable a per-drain-step trace log at INFO level.
  Each drained command is logged with the queue depth at that moment
  and the entry's flavor byte. Build flag `BACKLOG_TRACE_SOURCE` extends
  the trace with the originating command source per entry.

`Backlog20` - JSON statistics snapshot: current and counter-verified
  depth, byte usage, timer state, mutex state, staged and current
  behavioral flags, per-operation counters (drained / enqueued /
  inserted / discarded / mutex-skipped), high-watermark values, and
  runtime config (SO34, SO166, chunk size). Bytes/Discarded/MaxBytes/
  BytesLimit report 0 in this commit; the byte-limit commit fills them.

`Backlog21-29` - queue content as JSON, paged by chunk size. Each entry
  appears on its own log line and in the assembled MQTT/Web-Console
  response.

The entry header is generalized to support the optional
  `BACKLOG_TRACE_SOURCE` source byte without scattering conditionals
  across access sites.

#### Commit 2: queue byte limit

`Backlog18 N` - set the byte limit at runtime (0 resets to the
  compile-time default; clamped to a minimum confirmed stable on ESP8266
  under sustained load). Platform-dependent compile-time defaults in
  `tasmota.h`; override via `user_config_override.h`.
  Capacity at default settings: ESP8266 4096 B ~= 97 short commands;
  ESP32 32768 B ~= 780.

A whole-sequence-or-nothing gate in `CmndBacklog` pre-checks the full
  estimated cost before tokenising the string. A sequence that would
  exceed the limit is rejected intact; the node stays reachable and logs
  the rejection. Per-command fallback checks guard the IF/ENDIF insertion
  path and any caller that bypasses the sequence gate.

Accounting covers command strings, linked-list node overhead, and
  heap-allocator bookkeeping per allocation - the cost a string-length
  check alone would miss.

`Backlog20` now reports real byte counters and the active limit.

---

### Memory impact (measured, per commit)

Ref: pr/backlog-behavior tip (85ba5553)

| Commit             | Target     | Flash  | RAM | IRAM |
|--------------------|------------|--------|-----|------|
| diagnostics        | tasmota32  | +1484  | +32 | 0    |
| diagnostics        | tasmota-4M | +1380  | +36 | 0    |
| byte limit         | tasmota32  | +600   | +8  | 0    |
| byte limit         | tasmota-4M | +708   | +20 | 0    |
| PR9 total          | tasmota32  | +2084  | +40 | 0    |
| PR9 total          | tasmota-4M | +2088  | +56 | 0    |

**Requires pr/backlog-behavior:** per-entry flavor byte and queue-access API from that PR are the structural prerequisite for the diagnostics and byte-limit accounting here.

---

### Tested

Build-tested on ESP8266 (tasmota-4M) and ESP32 (tasmota32).
Target test on ESP8266 (ESP-12F): Backlog20 snapshot verified; Backlog17
drain trace verified; byte-limit rejection under sustained MQTT load
confirmed (30+ min without crash; limit adjustment under load drains the
queue cleanly without side effects).

## Checklist
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

