### PR TITLE
Update default .clangd with new compile flags and includes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,115 @@
 CompileFlags:
+  Add:
+    - "-Wall"
+    - "-Wextra"
+    - "-Wunused-variable"
+    - "-Wunused-function"
+    - "-Wno-unused-parameter"
+    - "-Wno-reserved-identifier"
   Remove:
-    - -fstrict-volatile-bitfields
-    - -fno-tree-switch-conversion
-    - -free
-    - -fipa-pta
-    - -march=*
+    - "-W*"
+    - "-m*"
+    - "-specs=*"
+    - "-MMD"
+    - "-MP"
+    - "-MF"
+    - "-MT"
+    - "-MQ"
+    - "-o"
+    - "--driver-mode=*"
+    - "-fno-shrink-wrap"
+    - "-fno-malloc-dce"
+    - "-fno-tree-switch-conversion"
+    - "-fstrict-volatile-bitfields"
+    - "-fzero-init-padding-bits=*"
+    - "-free"
+    - "-fipa-pta"
+    - "-isysroot"
+    - "-sysroot"
+---
+CompileFlags:
+  BuiltinHeaders: QueryDriver
+Diagnostics:
+  Suppress: [unused-includes]
+---
+If:
+  PathMatch: [tasmota/tasmota_.*/.*\.ino]
+CompileFlags:
+  Add:
+    - "-ferror-limit=0"
+    - "-include"
+    - "Arduino.h"
+    - "-include"
+    - "tasmota/tasmota.ino"
+Diagnostics:
+  Suppress: [undeclared_var_use]
+---
+If:
+  PathMatch: [tasmota/include/.*\.h]
+  PathExclude:
+    - "tasmota/include/i18n.h"
+    - "tasmota/include/tasmota_compat.h"
+    - "tasmota/include/tasmota.h"
+    - "tasmota/include/tasmota_globals.h"
+CompileFlags:
+  Add:
+    - "-include"
+    - "Arduino.h"
+    - "-include"
+    - "tasmota/include/tasmota_compat.h"
+    - "-include"
+    - "tasmota/include/tasmota.h"
+    - "-include"
+    - "tasmota/my_user_config.h"
+    - "-include"
+    - "tasmota/include/tasmota_globals.h"
+    - "-include"
+    - "tasmota/include/i18n.h"
+---
+If:
+  PathMatch:
+    - "tasmota/include/tasmota_compat.h"
+    - "tasmota/include/tasmota.h"
+CompileFlags:
+  Add:
+    - "-include"
+    - "Arduino.h"
+---
+If:
+  PathMatch: [tasmota/include/tasmota_globals.h]
+CompileFlags:
+  Add:
+    - "-include"
+    - "Arduino.h"
+    - "-include"
+    - "tasmota/include/tasmota_compat.h"
+    - "-include"
+    - "tasmota/include/tasmota.h"
+    - "-include"
+    - "tasmota/my_user_config.h"
+---
+If:
+  PathMatch: [tasmota/include/i18n.h]
+CompileFlags:
+  Add:
+    - "-include"
+    - "Arduino.h"
+    - "-include"
+    - "tasmota/include/tasmota_compat.h"
+    - "-include"
+    - "tasmota/include/tasmota.h"
+    - "-include"
+    - "tasmota/my_user_config.h"
+    - "-include"
+    - "tasmota/include/tasmota_globals.h"
+---
+If:
+  PathMatch: [tasmota/my_user_config.h]
+CompileFlags:
+  Add:
+    - "-include"
+    - "Arduino.h"
+    - "-include"
+    - "tasmota/include/tasmota_compat.h"
+    - "-include"
+    - "tasmota/include/tasmota.h"


### PR DESCRIPTION
Intended as base configuration for editors other than Visual Studio Code, which do not have such feature rich extensions like Pioarduino for Visual Studio Code. Tested with Zed.

## Description:
There are alternatives to Visual Studio code like Zed, which typically uses way less RAM (can be gigabytes) and is faster overall.
This PR provides only a minimal change to better support such alternative with regards to clangd. IMHO it is impossible to perfectly support complex Arduino projects like Tasmota, but result is okay'ish. It would be possible to change some parts of the code just for the sake of making life easier for clangd, like declaring all functions, but this is another topic.

For VS Code this does not change much, as default extension Intellisense ignores this file and using Pioarduino extension with clangd will override this file per environment.

More info about using Zed in the comment section.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
