### PR TITLE
Udisp SPI fix for mono color display

### DIFF
--- a/lib/lib_display/UDisplay/src/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay.cpp
@@ -634,6 +634,12 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
               panel_config->i2c.col_start = next_hex(&lp1);
               panel_config->i2c.col_end = next_hex(&lp1);
               panel_config->i2c.cmd_write_ram = next_hex(&lp1);
+              // SPI + bpp==1: also write to spi config (union offset mismatch)
+              if (interface == _UDSP_SPI) {
+                panel_config->spi.cmd_set_addr_x = panel_config->i2c.cmd_set_addr_x;
+                panel_config->spi.cmd_set_addr_y = panel_config->i2c.cmd_set_addr_y;
+                panel_config->spi.cmd_write_ram = panel_config->i2c.cmd_write_ram;
+              }
               // Also keep in legacy vars for now
               saw_1 = panel_config->i2c.cmd_set_addr_x;
               i2c_page_start = panel_config->i2c.page_start;

--- a/lib/lib_display/UDisplay/src/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay.cpp
@@ -905,8 +905,13 @@ void UfsCheckSDCardInit(void);
   AddLog(LOG_LEVEL_DEBUG, "UDisplay: Device:%s xs:%d ys:%d bpp:%d", dname, gxs, gys, bpp);
 
   if (interface == _UDSP_SPI) {
+#if USE_UNIVERSAL_TOUCH
     AddLog(LOG_LEVEL_DEBUG, "UDisplay: Nr:%d CS:%d CLK:%d MOSI:%d DC:%d TS_CS:%d TS_RST:%d TS_IRQ:%d", 
        spiController->spi_config.bus_nr, spiController->spi_config.cs, spiController->spi_config.clk, spiController->spi_config.mosi, spiController->spi_config.dc, ut_spi_cs, ut_reset, ut_irq);
+#else
+    AddLog(LOG_LEVEL_DEBUG, "UDisplay: Nr:%d CS:%d CLK:%d MOSI:%d DC:%d", 
+       spiController->spi_config.bus_nr, spiController->spi_config.cs, spiController->spi_config.clk, spiController->spi_config.mosi, spiController->spi_config.dc);
+#endif
     AddLog(LOG_LEVEL_DEBUG, "UDisplay: BPAN:%d RES:%d MISO:%d SPED:%d Pixels:%d SaMode:%d DMA-Mode:%d opts:%02x,%02x,%02x SetAddr:%x,%x,%x", 
        bpanel, reset, spiController->spi_config.miso, spiController->spi_config.speed*1000000, col_mode, sa_mode, lvgl_param.use_dma, saw_3, dim_op, startline, saw_1, saw_2, saw_3);
     AddLog(LOG_LEVEL_DEBUG, "UDisplay: Rot 0: %x,%x - %d - %d", madctrl, rot[0], x_addr_offs[0], y_addr_offs[0]);


### PR DESCRIPTION
## Description:

Fix union offset for SPI panels with mono color.

Fixed debug log by @blu006.

Should fix https://github.com/arendst/Tasmota/issues/24894

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
