### PR TITLE
TLS support for EC P-384 curve in server certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - HASPmota ability to set default screen background on `p0b0` object (#24874)
 - Matter virtual IR HVAC thermostat support (#24821)
 - HASPmota and LVGL `stripes` widget
+- TLS support for EC P-384 curve in server certificate
 
 ### Breaking Changed
 

--- a/lib/lib_ssl/bearssl-esp8266/src/ec/ec_all_m15.c
+++ b/lib/lib_ssl/bearssl-esp8266/src/ec/ec_all_m15.c
@@ -110,8 +110,21 @@ api_muladd(unsigned char *A, const unsigned char *B, size_t len,
 }
 
 /* see bearssl_ec.h */
+/*
+ * Tasmota: only advertise curves that fit in BR_MAX_EC_SIZE, since the
+ * i15 big-integer buffers (ec_prime_i15, ecdsa_i15_*) are statically
+ * sized from it. Advertising a larger curve would let the peer select
+ * it and overflow those stack buffers.
+ * Curve id bits: secp256r1=23, secp384r1=24, secp521r1=25, curve25519=29
+ */
 const br_ec_impl br_ec_all_m15 PROGMEM = {
-	(uint32_t)0x23800000,
+#if BR_MAX_EC_SIZE >= 521
+	(uint32_t)0x23800000,	/* P-256, P-384, P-521, Curve25519 */
+#elif BR_MAX_EC_SIZE >= 384
+	(uint32_t)0x21800000,	/* P-256, P-384, Curve25519 */
+#else
+	(uint32_t)0x20800000,	/* P-256, Curve25519 */
+#endif
 	&api_generator,
 	&api_order,
 	&api_xoff,

--- a/lib/lib_ssl/bearssl-esp8266/src/t_bearssl_tasmota_config.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/t_bearssl_tasmota_config.h
@@ -34,7 +34,7 @@
 #endif
 
 #ifndef BR_MAX_EC_SIZE
-#define BR_MAX_EC_SIZE 256      // max 256 bits EC keys
+#define BR_MAX_EC_SIZE 384      // max 384 bits EC keys (required for P-384 certificates, ex: Letsencrypt ECDSA)
 #endif
 
 #endif

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -920,8 +920,11 @@ extern "C" {
     br_ssl_engine_set_aes_ctr(&cc->eng, &br_aes_small_ctr_vtable);
     br_ssl_engine_set_ghash(&cc->eng, &br_ghash_ctmul32);
 
-    // we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
-    br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);
+    // Use all supported EC curves (P-256, P-384, P-521, Curve25519) for ECDHE key exchange.
+    // Some servers (e.g. with ECDSA P-384 certificates) refuse P-256 for key exchange
+    // and abort the handshake with SSL3_ALERT_HANDSHAKE_FAILURE (error 296).
+    // `br_ec_all_m15` is already linked for X509 ECDSA validation, so no flash size impact.
+    br_ssl_engine_set_ec(&cc->eng, &br_ec_all_m15);
 #if defined(ESP32) || (defined(ESP8266) && defined(USE_MQTT_TLS_ECDSA))
     br_ssl_engine_set_ecdsa(&cc->eng, &br_ecdsa_i15_vrfy_asn1);
 #endif


### PR DESCRIPTION
## Description:

TLS support for EC P-384 curve in server certificate, now used by Letsencrypt certificates.
No functional change and (surprisingly) no flash size change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
