### PR TITLE
Include USE_TCP_BRIDGE with tasmota-zigbee build

### DIFF
--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -58,6 +58,7 @@ lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/lib_div
 [env:tasmota-zigbee]
 build_flags             = ${env.build_flags}
                           -DUSE_ZIGBEE
+                          -USE_TCP_BRIDGE
                           -DUSE_CCLOADER
                           -DCODE_IMAGE_STR='"zigbee"'
                           -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-zigbee.bin.gz"'


### PR DESCRIPTION
Since tasmota-zigbee is for use with CC2530, it makes sense to have USE_TCP_BRIDGE included too, for users wanting to use it with Z2M or ZHA.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
