### PR TITLE
MAX7219 matrix: add positioned text support for multi-row displays

### DIFF
--- a/tasmota/tasmota_xdsp_display/xdsp_19_max7219_matrix.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_19_max7219_matrix.ino
@@ -52,6 +52,15 @@
     If the text fits into the display, it is shown in the center.
     Otherwise it scrolls to the left and repeats as long it is cleared or new "DisplayText" overwrites it.
 
+  DisplayText  [xNNyNN]text
+    The text can be prefixed by an optional position in pixel. Both parameters "x" and "y" are optional.
+    On displays with more than one module row this addresses a text row, e.g. "DisplayText [y8]second row".
+    Positioned text is not scrolled.
+    Examples:
+      DisplayText [y0]first row     // text at the top row
+      DisplayText [y8]second row    // text at the second module row
+      DisplayText [x4y8]indented    // second row, starting at pixel 4
+
   DisplayDimmer [0..100]
     Sets the intensity of the display.
 
@@ -166,11 +175,60 @@ bool MAX7291Matrix_init(void)
     return true;
 }
 
+/**
+ * @brief Parses an optional leading position prefix "[xNNyNN]" of the display text.
+ * Supported are the parameters "x" (horizontal) and "y" (vertical) in pixel, both optional.
+ * On multi row displays this allows to address a text row, e.g. "[y8]" for the second row.
+ * 
+ * @param text pointer to the display text. It is moved behind the prefix when a prefix was found.
+ * @param x horizontal pixel position, only written when the prefix contains "x"
+ * @param y vertical pixel position, only written when the prefix contains "y"
+ * @return true when a position prefix was found
+ */
+bool MAX7291Matrix_parseTextPos(char **text, int *x, int *y)
+{
+    char *cp = *text;
+    if (nullptr == cp || '[' != *cp) { return false; }
+
+    bool found = false;
+    cp++; // skip '['
+    while (*cp && ']' != *cp)
+    {
+        char param = *cp++;
+        if ('x' != param && 'y' != param) { return false; } // unknown parameter, keep text unchanged
+        if (*cp < '0' || *cp > '9') { return false; }       // missing value, keep text unchanged
+        int value = 0;
+        while (*cp >= '0' && *cp <= '9')
+        {
+            if (value < 10000) { value = (value * 10) + (*cp - '0'); } // limit value to avoid integer overflow
+            cp++;
+        }
+        if ('x' == param) { *x = value; } else { *y = value; }
+        found = true;
+    }
+    if (']' != *cp || !found) { return false; } // unterminated or empty prefix, keep text unchanged
+
+    *text = cp + 1; // move text pointer behind ']'
+    return true;
+}
+
 bool MAX7291Matrix_setText(bool clearBefore=true)
 {
     if(Settings->display_mode != 0) MAX7291Matrix_init();
     LedMatrix_settings.blink_delay = 0; // no blinking    
-    return max7219_Matrix->drawText(XdrvMailbox.data, clearBefore); 
+
+    char *text = XdrvMailbox.data;
+    int posX = 0;
+    int posY = 0;
+    if (MAX7291Matrix_parseTextPos(&text, &posX, &posY))
+    {
+        // positioned text, e.g. "[y8]second row" on a display with more than one module row
+        if(clearBefore) max7219_Matrix->clearDisplay();
+        bool result = max7219_Matrix->drawTextAt(text, posX, posY);
+        max7219_Matrix->refresh();
+        return result;
+    }
+    return max7219_Matrix->drawText(text, clearBefore); 
 }
 
 // FUNC_DISPLAY_SCROLLDELAY


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** none — related discussion #13590

MAX7219 dot matrix: add positioned text support for multi-row displays.

`DisplayText` now accepts an optional leading position prefix in pixels, making the second and further module rows addressable.
DisplayText [y0]first row
DisplayText [y8]second row
DisplayText [x4y8]indented
Backlog DisplayText [y0]TOP; DisplayTextNC [y8]BOTTOM

`DisplayTextNC` is needed for the second command because `DisplayText` clears first. Commands without a prefix behave exactly as before.

### Background

The driver header states *"To extend the display height, multiple rows are supported"*, and `LedMatrix::setPixel()` maps coordinates across module rows correctly. But `LedMatrix::drawText()` hardcodes `textPosY = 0`, so text could only appear on the first row. The docs list this under Constraints as *"Only one text row is supported"*. In #13590 the driver author confirmed:

> Currently only one display line is supported. Sending text to a second line is not implemented yet.

and suggested a space-padding workaround (both rows wired as one logical line), described as "a bit tricky". That workaround cannot update rows independently, and `Power OFF` only reaches the first `maxDevices` chips, leaving the second row frozen — measured on device.

**No new syntax is introduced.** The `[xNN yNN]` bracket escape is existing documented Tasmota syntax — `DisplayText()` in `xdrv_13_display.ino` already parses it into `disp_xpos` / `disp_ypos` for every display; this driver simply ignored the result. `drawTextAt(str, x, y)` also already exists as a public method in `LedMatrix`. This PR connects the two.

### Scope

Single file `xdsp_19_max7219_matrix.ino`, +59/−1. No library, font, GPIO, template or command-table changes. Flash +184 bytes, no RAM increase.

### Design: why a local parser instead of `disp_xpos` / `disp_ypos`

Reusing those globals would make this patch much smaller, so the choice needs justification. Measured on device:
DisplayText [x4y8]Offset -> dsp_x=4 dsp_y=8
DisplayText [y8]Second -> dsp_x=4 dsp_y=8 (x kept from previous)
DisplayText NoPrefix -> dsp_x=4 dsp_y=8 (both kept)

The globals persist between commands; the only reset is inside the `[z]` escape. This cursor-persistence model is how `xdsp_01` (character LCD) consumes them, so it is established semantics — but reusing it here has two problems:

1. **Callback safety.** `FUNC_DISPLAY_SCROLLTEXT` and `FUNC_DISPLAY_SEVENSEG_TEXT` route to the same text function here but do **not** pass through the `DisplayText()` parser, so `dsp_str` / `dsp_y` would be stale — e.g. `DisplayScrollText` after a `[y8]` command would render the previous string at the previous position. Reading `XdrvMailbox.data` keeps all three callbacks safe without callback-type discrimination.
2. **Precedent.** `xdsp_03_matrix` repurposes `dsp_x` / `dsp_y` as mode flags (scroll direction / loop) rather than coordinates, so driver-specific interpretation is established practice in the non-renderer family.

The local parser keeps each command self-contained: coordinates default to 0 unless the prefix specifies them. Verified: with `disp_ypos` left at 8 by a previous command, `DisplayText NoPrefix` still renders on the first row.

### Solved / not solved

Solved: any module row addressable; independent content per row (with `DisplayTextNC`); horizontal offset; works from all command entry points; space-padding workaround obsolete.

Not solved: font stays 6×8 (no 16px font in repo, so no double-height characters); positioned text is not scrolled (intentional — the scroll state machine tracks one string); `DisplayClock` still first row only; CJK/Korean unchanged (3-byte UTF-8 skipped by the renderer); no bitmap/graphics (`renderer = nullptr`, so LVGL and drawing commands do not apply); `LedMatrix` not exposed to Berry (`tasmota.cmd()` works).

### Backward compatibility

With no prefix, or when parsing fails, the pointer is left unchanged and the text goes to the existing `drawText()` path. The parser returns `false` when the string does not start with `[`, a parameter other than `x`/`y` appears, a parameter is not followed by a digit, `]` is missing, or the prefix is empty.

Verified literal rendering, identical to pre-change behaviour: `[y]nodigit`, `[]empty`, `[a1]test`, `[z]Test`. A control build with the parser call disabled (`if (false && ...)`) confirmed single-row behaviour is unaffected, including `DisplayHeight 8` on the 2-row unit.

<img width="4032" height="3024" alt="image (7)" src="https://github.com/user-attachments/assets/ad78cd9b-8e74-400d-809c-ed51fc3dd4f1" />
<img width="4032" height="3024" alt="image (8)" src="https://github.com/user-attachments/assets/88199f9d-b765-4558-be16-3cfaab394a05" />
<img width="4032" height="3024" alt="image (9)" src="https://github.com/user-attachments/assets/ecee91a3-515b-4a33-8df6-f53bef4d6f09" />


### Verification

Display: 64×16 (8×2 modules, 16 chips). Primary testing on ESP32-C3; core behaviour re-verified on ESP8266 (NodeMCU).

**Command entry points** — serial console, web console, HTTP `/cm` (needs `SetOption128 1`), Rules, Berry `tasmota.cmd()`: all pass. MQTT not tested (see below). Rules verified with boot and state triggers; reading back `Rule1` confirmed brackets are stored verbatim:
Rule1 ON System#Boot DO Backlog DisplayText [y0]TOP; DisplayTextNC [y8]BOT ENDON
Rule2 ON Power1#State DO DisplayText [y8]PowerChanged ENDON

**Functional** — `[y8]` second row, `[y0]` first row, two independent rows via `DisplayTextNC`, `[x20]` offset, `[x4y8]`/`[y8x4]` order-independent, prefix absent, long text still scrolls: all pass.

**Regression** — `DisplayClock` 1/2/0, `DisplayDimmer`, `DisplayClear`, `DisplayScrollDelay`, `DisplayRotate` 0/2 with prefix (coordinates interpreted in the pre-rotation logical frame), heap stability: all pass.

**Robustness** — `[y99]`, `[x999]`, `[y21474836470]x`, `[y2147483648]x`, `[y99999999999999]x`, `[x99999999999]y`: no output, no crash, uptime preserved. `[y8][y0]double`: first prefix consumed, remainder literal.

An earlier revision had no digit limit in the value loop, allowing an integer overflow to produce a negative coordinate. `setPixel()` checks only the upper bound (`y >= displayHeight`), so a negative value would pass and index `buffer[]` below zero. The parser now caps accumulation (`if (value < 10000)`). Note: that missing lower-bound check is pre-existing and not reachable through this change (digits only); it may warrant a separate issue.

**Character set** — ASCII upper/lower/digits/punctuation pass; `[y8]Grüße` and `[y8]café` with `USE_UTF8_LATIN1` pass; `[y8]안녕` not rendered, no crash (unchanged). An initial non-ASCII test over the PlatformIO serial monitor was invalid — the monitor dropped characters before transmission; retested via web console.

**Build**

| Env | Result |
|---|---|
| `tasmota32c3` | SUCCESS — RAM 19.5%, Flash 74.4% |
| `tasmota` (ESP8266) | SUCCESS — RAM 52.7%, Flash 68.6%, IRAM 93.2% |

**Cross-platform hardware verification**

| Test | ESP32-C3 | ESP8266 (NodeMCU, GPIO13/14/15) |
|---|---|---|
| Plain text, first row (backward compatibility) | pass | pass |
| `[y8]` second row | pass | pass |
| Two independent rows via `DisplayTextNC` | pass | pass |
| Integer overflow coordinate, no crash | pass | pass |

### Known behaviour — unknown escape characters (pre-existing)

`[q]test`, `[1]test`, `[z5]literal` produce no visible output, with and without this patch. Cause traced: `DisplayText()` parses the bracket escape **before** the driver is called; an unknown character inside the escape hits `default:`, responds "Unknown Escape" and jumps to `exit` with an empty line buffer, so `FUNC_DISPLAY_DRAW_STRING` is never dispatched and the driver-level parser never runs. (The response is then overwritten by the command echo in `CmndDisplayText`.) Measured: 2 ms for `[q]test` (no SPI transfer) vs 28 ms for `[z]Test` (rendered). Which malformed prefixes render literally is therefore decided upstream — `[z]Test` renders (`z` is a known escape), `[z5]literal` does not (`5` is unknown inside the escape). This patch neither causes nor changes it.

### Not verified

MQTT entry point — no private broker; a public broker was attempted but a third party issued `Reset` within one second of connecting and wiped the configuration, so this was abandoned. MQTT shares the same `ExecuteCommand` dispatch path as the five verified entry points. Single-row hardware (8×1) — not owned; substituted by `DisplayHeight 8` on the 2-row unit plus the disabled-parser control build. Three or more module rows — not owned; `DisplayHeight 24` initialises as `size(8x3)` without error and `[y16]` is accepted, but physical output is unconfirmed. CI across all environments — two envs built locally.

### Open question

The prefix implemented here is a minimal, stateless parser handling one leading prefix, matching the pixel semantics of `xdrv_13_display.ino` but not its cursor-persistence model. If full consistency with the cursor model used by the GFX/LCD paths is preferred, I am happy to rework — with the `FUNC_DISPLAY_SCROLLTEXT` staleness issue addressed as part of it.

Testing on other module layouts would be appreciated; I have one configuration (8×2).


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
