### PR TITLE
Matter: add Electrical Power Measurement cluster to On/Off Plug-in Unit

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -256,6 +256,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_9_Virt_Sensor_Rain.h"
 #include "solidify/solidified_Matter_Plugin_9_Virt_Sensor_Waterleak.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_OnOff.h"
+#include "solidify/solidified_Matter_Plugin_8_Bridge_OnOff_Power.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Light0.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Light1.h"
 #include "solidify/solidified_Matter_Plugin_8_Bridge_Light2.h"

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -214,6 +214,8 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_1_Device.h"
 #include "solidify/solidified_Matter_Plugin_3_OnOff.h"
 #include "solidify/solidified_Matter_Plugin_9_Virt_OnOff.h"
+#include "solidify/solidified_Matter_Plugin_3_OnOff_Power.h"
+#include "solidify/solidified_Matter_Plugin_9_Virt_OnOff_Power.h"
 #include "solidify/solidified_Matter_Plugin_2_Sensor_Air_Quality.h"
 #include "solidify/solidified_Matter_Plugin_9_Virt_Sensor_Air_Quality.h"
 #include "solidify/solidified_Matter_Plugin_2_Light0.h"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -114,6 +114,7 @@ class Matter_Plugin
     0x0046: 0x00,                           # ICD Management: 0x00 = no optional features (base SIT mode, no CIP/UAT/LITS)
     0x0062: 0x01,                           # Scenes Management: SceneNames (bit 0)
     0x0090: 0x02,                           # Electrical Power Measurement: AlternatingCurrent (bit 1)
+    0x009C: 0x01,                           # Power Topology: NodeTopology (bit 0) - meters the whole node
     0x0102: 1 + 4,                          # Window Covering: Lift (bit 0) + PA_LF (bit 2)
     0x0201: 0x23,                           # Thermostat: HEAT + COOL + AUTO
     0x0202: 2,                              # Fan Control: Auto (bit 1)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_0.be
@@ -113,6 +113,7 @@ class Matter_Plugin
     0x0031: 0x05,                           # Eth + WiFi - the latter is needed for Bluetooth commissioning
     0x0046: 0x00,                           # ICD Management: 0x00 = no optional features (base SIT mode, no CIP/UAT/LITS)
     0x0062: 0x01,                           # Scenes Management: SceneNames (bit 0)
+    0x0090: 0x02,                           # Electrical Power Measurement: AlternatingCurrent (bit 1)
     0x0102: 1 + 4,                          # Window Covering: Lift (bit 0) + PA_LF (bit 2)
     0x0201: 0x23,                           # Thermostat: HEAT + COOL + AUTO
     0x0202: 2,                              # Fan Control: Auto (bit 1)
@@ -150,6 +151,7 @@ class Matter_Plugin
     # 0x005C: 1,                            # Smoke CO Alarm - Initial Release
     0x0062: 1,                              # Scenes Management - Matter 1.4.1 (PROVISIONAL)
     0x0080: 1,                              # Boolean State Configuration - Initial Release
+    0x0090: 1,                              # Electrical Power Measurement - Initial Release (Matter 1.3)
     0x0101: 7,                              # Door Lock - Added support for European door locks (unbolt feature)
     0x0102: 5,                              # Window Covering - New data model format and notation
     0x0200: 4,                              # Pump Configuration and Control - Added feature map

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
@@ -21,23 +21,38 @@
 #################################################################################
 # Matter 1.4.1 Device Specification - On/Off Plug-in Unit (0x010A) with Power
 #################################################################################
-# Device Type: On/Off Plug-in Unit (0x010A)
-# Device Type Revision: 3 (Matter 1.4.1)
-# Class: Simple | Scope: Endpoint
+# Device Types: On/Off Plug-in Unit (0x010A) + Electrical Sensor (0x0510)
+# Device Type Revisions: 3 / 1 (Matter 1.4.1)
+# Class: Simple + Utility (composed on a single endpoint) | Scope: Endpoint
 #
 # Same device type as the plain `relay` plugin (`Matter_Plugin_OnOff`), with the
-# addition of the Electrical Power Measurement cluster so the plug reports live
+# addition of the Electrical Sensor device type and its Power Topology +
+# Electrical Power Measurement clusters, so the plug reports live
 # Voltage/Current/Power to the Matter controller (Apple Home, Google Home,
 # SmartThings and similar all display power for plugs exposing this cluster).
 #
 # NOTES:
-# - Not a strict Matter "Electrical Sensor" (0x0510) composition; this follows
-#   the common real-world practice of adding the measurement cluster directly
-#   on the plug endpoint, as done by many commercial Matter plugs.
+# - Composes both device types on the same endpoint (DeviceTypeList carries
+#   both 0x010A and 0x0510), rather than a separate dedicated endpoint for the
+#   Electrical Sensor - matching common real-world Matter plug implementations.
 # - Single measurement channel: reads the (non-indexed) `ENERGY` JSON object,
 #   i.e. plugs with a single energy-monitoring chip (HLW8012, BL0937, CSE7766,
 #   ADE7953, PZEM, etc.). Multi-channel/multi-phase energy (`Voltage1/2`,
 #   `Power1/2`, ...) is not handled by this plugin.
+#################################################################################
+
+#################################################################################
+# Matter 1.4.1 Power Topology Cluster (0x009C)
+#################################################################################
+# Cluster Revision: 1 (Matter 1.4.1) - Mandatory on the Electrical Sensor device type
+# Role: Application | Scope: Endpoint
+#
+# FEATURES:
+# - Bit 0 (NODE): NodeTopology - this endpoint meters the whole node (fixed)
+#
+# No attributes or commands: the NODE feature alone (as opposed to SET) means
+# there is nothing to enumerate - the single ENERGY sensor covers the entire
+# device, matching Tasmota's non-indexed `ENERGY` object.
 #################################################################################
 
 #################################################################################
@@ -81,8 +96,11 @@ class Matter_Plugin_OnOff_Power : Matter_Plugin_OnOff
   static var UPDATE_CMD = "Status 10"               # command to send for updates (bridge mode)
   static var UPDATE_TIME = 5000                     # update sensor every 5s
   static var CLUSTERS  = matter.consolidate_clusters(_class, {
+    0x009C: [],                                          # Power Topology (NODE feature, no attributes)
     0x0090: [0,1,2,8,9,0x0A,0x0B,0x0C,0x0D,0x0E,0x11],   # Electrical Power Measurement
   })
+  # Composed endpoint: On/Off Plug-in Unit (control) + Electrical Sensor (measurement)
+  static var TYPES = { 0x010A: 3, 0x0510: 1 }
   # Accepted keys for virtual devices via `MtrUpdate {"Name":"...", "Voltage":230, "ActiveCurrent":..}`
   # Note: `Power` is already used (inherited) for the On/Off boolean state, so the
   # wattage key is named `ActivePower` to avoid any ambiguity.

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
@@ -1,0 +1,238 @@
+#
+# Matter_Plugin_OnOff_Power.be - implements the behavior for a Relay (OnOff) with
+# Electrical Power Measurement (smart plug with power monitoring)
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#################################################################################
+# Matter 1.4.1 Device Specification - On/Off Plug-in Unit (0x010A) with Power
+#################################################################################
+# Device Type: On/Off Plug-in Unit (0x010A)
+# Device Type Revision: 3 (Matter 1.4.1)
+# Class: Simple | Scope: Endpoint
+#
+# Same device type as the plain `relay` plugin (`Matter_Plugin_OnOff`), with the
+# addition of the Electrical Power Measurement cluster so the plug reports live
+# Voltage/Current/Power to the Matter controller (Apple Home, Google Home,
+# SmartThings and similar all display power for plugs exposing this cluster).
+#
+# NOTES:
+# - Not a strict Matter "Electrical Sensor" (0x0510) composition; this follows
+#   the common real-world practice of adding the measurement cluster directly
+#   on the plug endpoint, as done by many commercial Matter plugs.
+# - Single measurement channel: reads the (non-indexed) `ENERGY` JSON object,
+#   i.e. plugs with a single energy-monitoring chip (HLW8012, BL0937, CSE7766,
+#   ADE7953, PZEM, etc.). Multi-channel/multi-phase energy (`Voltage1/2`,
+#   `Power1/2`, ...) is not handled by this plugin.
+#################################################################################
+
+#################################################################################
+# Matter 1.4.1 Electrical Power Measurement Cluster (0x0090)
+#################################################################################
+# Cluster Revision: 1 (Matter 1.4.1)
+# Role: Application | Scope: Endpoint
+#
+# FEATURES:
+# - Bit 1 (ALTC): AlternatingCurrent - AC measurement (M for Tasmota energy sensors)
+#
+# ATTRIBUTES (exposed by this plugin):
+# ID     | Name              | Type   | Unit      | Tasmota mapping
+# -------|-------------------|--------|-----------|------------------------------
+# 0x0000 | PowerMode         | enum8  |           | fixed AC (2)
+# 0x0001 | NumberOfMeasurementTypes | uint8 |      | fixed 8
+# 0x0002 | Accuracy          | list[MeasurementAccuracyStruct] | | fixed, declarative
+# 0x0008 | ActivePower       | int64  | mW        | ENERGY.Power * 1000
+# 0x0009 | ReactivePower     | int64  | mVAR      | ENERGY.ReactivePower * 1000
+# 0x000A | ApparentPower     | int64  | mVA       | ENERGY.ApparentPower * 1000
+# 0x000B | RMSVoltage        | int64  | mV        | ENERGY.Voltage * 1000
+# 0x000C | RMSCurrent        | int64  | mA        | ENERGY.Current * 1000
+# 0x000D | RMSPower          | int64  | mW        | ENERGY.Power * 1000 (same as ActivePower)
+# 0x000E | Frequency         | int64  | mHz       | ENERGY.Frequency * 1000
+# 0x0011 | PowerFactor       | int64  | 1/10000   | ENERGY.Factor * 10000
+#
+# All value attributes are nullable (`X` quality): report `null` until the
+# first successful sensor read.
+#################################################################################
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_OnOff_Power,weak
+
+class Matter_Plugin_OnOff_Power : Matter_Plugin_OnOff
+  static var TYPE = "relay_power"                   # name of the plug-in in json
+  static var DISPLAY_NAME = "Relay + Power"         # display name of the plug-in
+
+  static var UPDATE_CMD = "Status 10"               # command to send for updates (bridge mode)
+  static var UPDATE_TIME = 5000                     # update sensor every 5s
+  static var CLUSTERS  = matter.consolidate_clusters(_class, {
+    0x0090: [0,1,2,8,9,0x0A,0x0B,0x0C,0x0D,0x0E,0x11],   # Electrical Power Measurement
+  })
+
+  # MeasurementTypeEnum values used below (Matter 1.4.1 Common Data Types)
+  static var MT_ACTIVE_POWER   = 5
+  static var MT_REACTIVE_POWER = 6
+  static var MT_APPARENT_POWER = 7
+  static var MT_RMS_VOLTAGE    = 8
+  static var MT_RMS_CURRENT    = 9
+  static var MT_RMS_POWER      = 10
+  static var MT_FREQUENCY      = 11
+  static var MT_POWER_FACTOR   = 12
+
+  var shadow_voltage                                # (real) Voltage in Volts
+  var shadow_current                                # (real) Current in Amps
+  var shadow_active_power                           # (real) Active power in Watts
+  var shadow_apparent_power                         # (real) Apparent power in VA
+  var shadow_reactive_power                         # (real) Reactive power in VAR
+  var shadow_frequency                              # (real) Frequency in Hz
+  var shadow_power_factor                           # (real) Power factor 0.00-1.00
+
+  #############################################################
+  # Constructor
+  def init(device, endpoint, config)
+    super(self).init(device, endpoint, config)
+    device.add_read_sensors_schedule(self.UPDATE_TIME)
+  end
+
+  #############################################################
+  # parse a single ENERGY value, firing `attribute_updated` if changed
+  #
+  # nrg: the `ENERGY` map from the sensor JSON
+  # key: JSON key to read (ex: "Voltage")
+  # old_val: previous shadow value
+  # attribute: Matter attribute id to notify on change
+  # attribute2: optional second attribute id sharing the same value (ex: RMSPower)
+  def _parse_energy_value(nrg, key, old_val, attribute, attribute2)
+    var val = nrg.find(key)
+    if val != nil
+      val = real(val)
+      if val != old_val
+        self.attribute_updated(0x0090, attribute)
+        if attribute2 != nil
+          self.attribute_updated(0x0090, attribute2)
+        end
+      end
+      return val
+    end
+    return old_val
+  end
+
+  #############################################################
+  # parse sensor
+  #
+  # Reads the (non-indexed) `ENERGY` object from `tasmota.read_sensors()`
+  def parse_sensors(payload)
+    var nrg = payload.find("ENERGY")
+    if nrg != nil
+      self.shadow_voltage        = self._parse_energy_value(nrg, "Voltage", self.shadow_voltage, 0x000B)
+      self.shadow_current        = self._parse_energy_value(nrg, "Current", self.shadow_current, 0x000C)
+      self.shadow_active_power   = self._parse_energy_value(nrg, "Power", self.shadow_active_power, 0x0008, 0x000D)
+      self.shadow_apparent_power = self._parse_energy_value(nrg, "ApparentPower", self.shadow_apparent_power, 0x000A)
+      self.shadow_reactive_power = self._parse_energy_value(nrg, "ReactivePower", self.shadow_reactive_power, 0x0009)
+      self.shadow_frequency      = self._parse_energy_value(nrg, "Frequency", self.shadow_frequency, 0x000E)
+      self.shadow_power_factor   = self._parse_energy_value(nrg, "Factor", self.shadow_power_factor, 0x0011)
+    end
+    super(self).parse_sensors(payload)
+  end
+
+  #############################################################
+  # build the (fixed/declarative) Accuracy list attribute
+  #
+  # list[MeasurementAccuracyStruct] - one entry per measurement type exposed
+  def _build_accuracy_list()
+    var TLV = matter.TLV
+    var acc = TLV.Matter_TLV_array()
+    # [MeasurementType, MinMeasuredValue, MaxMeasuredValue] in the attribute's native unit
+    var specs = [
+      [self.MT_RMS_VOLTAGE,    0,          300000],     # 0-300 V
+      [self.MT_RMS_CURRENT,    0,          100000],     # 0-100 A
+      [self.MT_ACTIVE_POWER,   -50000000,  50000000],   # +/-50 kW
+      [self.MT_REACTIVE_POWER, -50000000,  50000000],   # +/-50 kVAR
+      [self.MT_APPARENT_POWER, 0,          50000000],   # 0-50 kVA
+      [self.MT_RMS_POWER,      -50000000,  50000000],   # +/-50 kW
+      [self.MT_FREQUENCY,      0,          100000],     # 0-100 Hz
+      [self.MT_POWER_FACTOR,   -10000,     10000],      # -1.00 .. 1.00
+    ]
+    for s: specs
+      var e = acc.add_struct()
+      e.add_TLV(0, 0x04 #-TLV.U1-#, s[0])              # MeasurementType
+      e.add_TLV(1, 0x08 #-TLV.BOOL-#, true)            # Measured
+      e.add_TLV(2, 0x03 #-TLV.I8-#, s[1])              # MinMeasuredValue
+      e.add_TLV(3, 0x03 #-TLV.I8-#, s[2])              # MaxMeasuredValue
+      var ranges = e.add_array(4)                      # AccuracyRanges
+      var r = ranges.add_struct()
+      r.add_TLV(0, 0x03 #-TLV.I8-#, s[1])              # RangeMin
+      r.add_TLV(1, 0x03 #-TLV.I8-#, s[2])              # RangeMax
+      r.add_TLV(2, 0x05 #-TLV.U2-#, 500)               # PercentMax = 5.00%
+    end
+    return acc
+  end
+
+  #############################################################
+  # read an attribute
+  #
+  def read_attribute(session, ctx, tlv_solo)
+    var cluster = ctx.cluster
+    var attribute = ctx.attribute
+
+    # ====================================================================================================
+    if   cluster == 0x0090              # ========== Electrical Power Measurement 2.13 ==========
+      if   attribute == 0x0000          #  ---------- PowerMode / enum8 ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, 2)          # AC
+      elif attribute == 0x0001          #  ---------- NumberOfMeasurementTypes / u8 ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, 8)
+      elif attribute == 0x0002          #  ---------- Accuracy / list[MeasurementAccuracyStruct] ----------
+        return self._build_accuracy_list()
+      elif attribute == 0x0008          #  ---------- ActivePower / i64 (mW) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_active_power != nil ? int(self.shadow_active_power * 1000) : nil)
+      elif attribute == 0x0009          #  ---------- ReactivePower / i64 (mVAR) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_reactive_power != nil ? int(self.shadow_reactive_power * 1000) : nil)
+      elif attribute == 0x000A          #  ---------- ApparentPower / i64 (mVA) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_apparent_power != nil ? int(self.shadow_apparent_power * 1000) : nil)
+      elif attribute == 0x000B          #  ---------- RMSVoltage / i64 (mV) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_voltage != nil ? int(self.shadow_voltage * 1000) : nil)
+      elif attribute == 0x000C          #  ---------- RMSCurrent / i64 (mA) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_current != nil ? int(self.shadow_current * 1000) : nil)
+      elif attribute == 0x000D          #  ---------- RMSPower / i64 (mW) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_active_power != nil ? int(self.shadow_active_power * 1000) : nil)
+      elif attribute == 0x000E          #  ---------- Frequency / i64 (mHz) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_frequency != nil ? int(self.shadow_frequency * 1000) : nil)
+      elif attribute == 0x0011          #  ---------- PowerFactor / i64 (1/10000) ----------
+        return tlv_solo.set_or_nil(0x03 #-TLV.I8-#, self.shadow_power_factor != nil ? int(self.shadow_power_factor * 10000) : nil)
+      end
+
+    end
+    return super(self).read_attribute(session, ctx, tlv_solo)
+  end
+
+  #############################################################
+  # web_values
+  #
+  # Show values of the remote device as HTML
+  def web_values()
+    super(self).web_values()
+    if self.shadow_active_power != nil
+      import webserver
+      webserver.content_send(format(" %.1fW", self.shadow_active_power))
+    end
+  end
+  #############################################################
+  #############################################################
+
+end
+matter.Plugin_OnOff_Power = Matter_Plugin_OnOff_Power

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
@@ -83,6 +83,10 @@ class Matter_Plugin_OnOff_Power : Matter_Plugin_OnOff
   static var CLUSTERS  = matter.consolidate_clusters(_class, {
     0x0090: [0,1,2,8,9,0x0A,0x0B,0x0C,0x0D,0x0E,0x11],   # Electrical Power Measurement
   })
+  # Accepted keys for virtual devices via `MtrUpdate {"Name":"...", "Voltage":230, "ActiveCurrent":..}`
+  # Note: `Power` is already used (inherited) for the On/Off boolean state, so the
+  # wattage key is named `ActivePower` to avoid any ambiguity.
+  static var UPDATE_COMMANDS = matter.UC_LIST(_class, "Voltage", "Current", "ActivePower", "ApparentPower", "ReactivePower", "Factor", "Frequency")
 
   # MeasurementTypeEnum values used below (Matter 1.4.1 Common Data Types)
   static var MT_ACTIVE_POWER   = 5
@@ -137,17 +141,39 @@ class Matter_Plugin_OnOff_Power : Matter_Plugin_OnOff
   #
   # Reads the (non-indexed) `ENERGY` object from `tasmota.read_sensors()`
   def parse_sensors(payload)
-    var nrg = payload.find("ENERGY")
-    if nrg != nil
-      self.shadow_voltage        = self._parse_energy_value(nrg, "Voltage", self.shadow_voltage, 0x000B)
-      self.shadow_current        = self._parse_energy_value(nrg, "Current", self.shadow_current, 0x000C)
-      self.shadow_active_power   = self._parse_energy_value(nrg, "Power", self.shadow_active_power, 0x0008, 0x000D)
-      self.shadow_apparent_power = self._parse_energy_value(nrg, "ApparentPower", self.shadow_apparent_power, 0x000A)
-      self.shadow_reactive_power = self._parse_energy_value(nrg, "ReactivePower", self.shadow_reactive_power, 0x0009)
-      self.shadow_frequency      = self._parse_energy_value(nrg, "Frequency", self.shadow_frequency, 0x000E)
-      self.shadow_power_factor   = self._parse_energy_value(nrg, "Factor", self.shadow_power_factor, 0x0011)
+    if !self.VIRTUAL
+      var nrg = payload.find("ENERGY")
+      if nrg != nil
+        self.shadow_voltage        = self._parse_energy_value(nrg, "Voltage", self.shadow_voltage, 0x000B)
+        self.shadow_current        = self._parse_energy_value(nrg, "Current", self.shadow_current, 0x000C)
+        self.shadow_active_power   = self._parse_energy_value(nrg, "Power", self.shadow_active_power, 0x0008, 0x000D)
+        self.shadow_apparent_power = self._parse_energy_value(nrg, "ApparentPower", self.shadow_apparent_power, 0x000A)
+        self.shadow_reactive_power = self._parse_energy_value(nrg, "ReactivePower", self.shadow_reactive_power, 0x0009)
+        self.shadow_frequency      = self._parse_energy_value(nrg, "Frequency", self.shadow_frequency, 0x000E)
+        self.shadow_power_factor   = self._parse_energy_value(nrg, "Factor", self.shadow_power_factor, 0x0011)
+      end
     end
     super(self).parse_sensors(payload)
+  end
+
+  #############################################################
+  # update_virtual
+  #
+  # Update internal state for virtual devices, ex:
+  # `MtrUpdate {"Name":"Plug", "Voltage":230.0, "Current":0.5, "ActivePower":100.0}`
+  def update_virtual(payload)
+    self.shadow_voltage        = self._parse_update_virtual(payload, "Voltage", self.shadow_voltage, real, 0x0090, 0x000B)
+    self.shadow_current        = self._parse_update_virtual(payload, "Current", self.shadow_current, real, 0x0090, 0x000C)
+    var old_active_power = self.shadow_active_power
+    self.shadow_active_power   = self._parse_update_virtual(payload, "ActivePower", self.shadow_active_power, real, 0x0090, 0x0008)
+    if self.shadow_active_power != old_active_power
+      self.attribute_updated(0x0090, 0x000D)     # RMSPower mirrors ActivePower
+    end
+    self.shadow_apparent_power = self._parse_update_virtual(payload, "ApparentPower", self.shadow_apparent_power, real, 0x0090, 0x000A)
+    self.shadow_reactive_power = self._parse_update_virtual(payload, "ReactivePower", self.shadow_reactive_power, real, 0x0090, 0x0009)
+    self.shadow_frequency      = self._parse_update_virtual(payload, "Frequency", self.shadow_frequency, real, 0x0090, 0x000E)
+    self.shadow_power_factor   = self._parse_update_virtual(payload, "Factor", self.shadow_power_factor, real, 0x0090, 0x0011)
+    super(self).update_virtual(payload)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_OnOff_Power.be
@@ -137,23 +137,47 @@ class Matter_Plugin_OnOff_Power : Matter_Plugin_OnOff
   end
 
   #############################################################
+  # _parse_energy
+  #
+  # Shared by `parse_sensors` (local device) and `parse_status` (HTTP bridge),
+  # both of which receive the same shape of data (top-level `ENERGY` object).
+  def _parse_energy(nrg)
+    if nrg != nil
+      self.shadow_voltage        = self._parse_energy_value(nrg, "Voltage", self.shadow_voltage, 0x000B)
+      self.shadow_current        = self._parse_energy_value(nrg, "Current", self.shadow_current, 0x000C)
+      self.shadow_active_power   = self._parse_energy_value(nrg, "Power", self.shadow_active_power, 0x0008, 0x000D)
+      self.shadow_apparent_power = self._parse_energy_value(nrg, "ApparentPower", self.shadow_apparent_power, 0x000A)
+      self.shadow_reactive_power = self._parse_energy_value(nrg, "ReactivePower", self.shadow_reactive_power, 0x0009)
+      self.shadow_frequency      = self._parse_energy_value(nrg, "Frequency", self.shadow_frequency, 0x000E)
+      self.shadow_power_factor   = self._parse_energy_value(nrg, "Factor", self.shadow_power_factor, 0x0011)
+    end
+  end
+
+  #############################################################
   # parse sensor
   #
   # Reads the (non-indexed) `ENERGY` object from `tasmota.read_sensors()`
+  # Only applies to local devices: virtual devices are updated via
+  # `update_virtual()`, bridge devices via `parse_status()`.
   def parse_sensors(payload)
-    if !self.VIRTUAL
-      var nrg = payload.find("ENERGY")
-      if nrg != nil
-        self.shadow_voltage        = self._parse_energy_value(nrg, "Voltage", self.shadow_voltage, 0x000B)
-        self.shadow_current        = self._parse_energy_value(nrg, "Current", self.shadow_current, 0x000C)
-        self.shadow_active_power   = self._parse_energy_value(nrg, "Power", self.shadow_active_power, 0x0008, 0x000D)
-        self.shadow_apparent_power = self._parse_energy_value(nrg, "ApparentPower", self.shadow_apparent_power, 0x000A)
-        self.shadow_reactive_power = self._parse_energy_value(nrg, "ReactivePower", self.shadow_reactive_power, 0x0009)
-        self.shadow_frequency      = self._parse_energy_value(nrg, "Frequency", self.shadow_frequency, 0x000E)
-        self.shadow_power_factor   = self._parse_energy_value(nrg, "Factor", self.shadow_power_factor, 0x0011)
-      end
+    if !self.VIRTUAL && !self.BRIDGE
+      self._parse_energy(payload.find("ENERGY"))
     end
     super(self).parse_sensors(payload)
+  end
+
+  #############################################################
+  # For Bridge devices
+  #############################################################
+  #############################################################
+  # Stub for updating shadow values (local copies of what we published to the Matter gateway)
+  #
+  # Reads the (non-indexed) `ENERGY` object from the remote `Status 10` response
+  def parse_status(data, index)
+    if index == 10                              # Status 10
+      self._parse_energy(data.find("ENERGY"))
+    end
+    super(self).parse_status(data, index)
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_8_Bridge_OnOff_Power.be
@@ -1,0 +1,61 @@
+#
+# Matter_Plugin_Bridge_OnOff_Power.be - implements the behavior for a remote
+# Relay (OnOff) with Electrical Power Measurement via HTTP
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#################################################################################
+# Matter 1.4.1 Bridge Variant - On/Off Plug-in Unit with Power Measurement via HTTP
+#################################################################################
+# INHERITS FROM: Matter_Plugin_OnOff_Power (Matter_Plugin_3_OnOff_Power.be)
+# VARIANT TYPE: Bridge (Remote HTTP Device)
+#
+# DEVICE TYPE: On/Off Plug-in Unit (0x010A) - See base class for specification
+# CLUSTERS: On/Off + Electrical Power Measurement (0x0090) - See base class
+#
+# BRIDGE MODE SPECIFICS:
+# - BRIDGE flag: true (enables HTTP remote device mode)
+# - TYPE: "http_relay_power" (JSON configuration identifier)
+# - DISPLAY_NAME: "Relay + Power" (user-friendly name)
+# - Polls the remote Tasmota device with `Status 10` (UPDATE_CMD, inherited)
+#   and reads its (non-indexed) `ENERGY` object the same way the local
+#   plugin reads `tasmota.read_sensors()` - see `parse_status()` in the
+#   base class for the shared parsing logic.
+#
+# CONFIGURATION:
+# - Requires "url" parameter for remote device address
+# - Requires "relay" parameter for relay number (1-based)
+# - Example: {"type":"http_relay_power","url":"192.168.1.100","relay":1}
+#
+# NOTES:
+# - Functionally identical to Matter_Plugin_OnOff_Power but polls a remote
+#   Tasmota device via HTTP instead of reading local sensors.
+# - Single measurement channel only, same limitation as the local plugin.
+#################################################################################
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Bridge_OnOff_Power,weak
+
+class Matter_Plugin_Bridge_OnOff_Power : Matter_Plugin_OnOff_Power
+  static var BRIDGE = true                          # flag as bridged device
+  static var TYPE = "http_relay_power"               # name of the plug-in in json
+  static var DISPLAY_NAME = "Relay + Power"          # display name of the plug-in
+end
+matter.Plugin_Bridge_OnOff_Power = Matter_Plugin_Bridge_OnOff_Power

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Virt_OnOff_Power.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_9_Virt_OnOff_Power.be
@@ -1,0 +1,64 @@
+#
+# Matter_Plugin_Virt_OnOff_Power.be - implements the behavior for a Virtual Relay
+# with Electrical Power Measurement
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#################################################################################
+# Matter 1.4.1 Virtual Variant - On/Off Plug-in Unit with Power Measurement
+#################################################################################
+# INHERITS FROM: Matter_Plugin_OnOff_Power (Matter_Plugin_3_OnOff_Power.be)
+# VARIANT TYPE: Virtual (Matter Bridge Protocol)
+#
+# DEVICE TYPE: On/Off Plug-in Unit (0x010A) - See base class for specification
+# CLUSTERS: On/Off + Electrical Power Measurement (0x0090) - See base class
+#
+# VIRTUAL MODE SPECIFICS:
+# - VIRTUAL flag: true (enables virtual device mode)
+# - TYPE: "v_relay_power" (JSON configuration identifier)
+# - DISPLAY_NAME: "v.Relay+Power" (prefix 'v.' indicates virtual)
+# - No direct hardware control - state and measurements managed by external
+#   controller via the `MtrUpdate` command
+#
+# CONFIGURATION:
+# - No ARG parameter required (virtual devices don't map to hardware)
+# - Example: {"type":"v_relay_power","name":"Virtual Plug"}
+#
+# TESTING:
+#   MtrUpdate {"Name":"Virtual Plug", "Power":1}
+#   MtrUpdate {"Name":"Virtual Plug", "Voltage":230.5, "Current":0.42, "ActivePower":95.6}
+#   MtrUpdate {"Name":"Virtual Plug", "ApparentPower":98.1, "ReactivePower":12.0, "Factor":0.97, "Frequency":50.0}
+#
+# NOTES:
+# - `Power` remains the On/Off boolean command (inherited); the wattage value
+#   is sent as `ActivePower` to avoid ambiguity - see Matter_Plugin_3_OnOff_Power.be
+#################################################################################
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Virt_OnOff_Power,weak
+
+class Matter_Plugin_Virt_OnOff_Power : Matter_Plugin_OnOff_Power
+  static var TYPE = "v_relay_power"                 # name of the plug-in in json
+  static var DISPLAY_NAME = "v.Relay+Power"         # display name of the plug-in
+
+  static var SCHEMA = nil                          # no parameter
+  static var VIRTUAL = true                         # virtual device
+end
+matter.Plugin_Virt_OnOff_Power = Matter_Plugin_Virt_OnOff_Power

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -195,7 +195,7 @@ class Matter_UI
                               "|v_fan|v_hvac|v_hvac_option"
                               "|v_temp|v_pressure|v_illuminance|v_humidity|v_occupancy|v_contact|v_flow|v_rain|v_waterleak"
                               "|v_airquality"
-  static var _CLASSES_TYPES2= "|http_relay|http_light0|http_light1|http_light2|http_light3"
+  static var _CLASSES_TYPES2= "|http_relay|http_relay_power|http_light0|http_light1|http_light2|http_light3"
                               "|http_temperature|http_pressure|http_illuminance|http_humidity"
                               "|http_occupancy|http_contact|http_flow|http_rain|http_waterleak"
                               "|http_airquality"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -186,7 +186,7 @@ class Matter_UI
   "</script>"
 
   static var _CLASSES_TYPES_STD =
-                              "|relay|light0|light1|light2|light3|shutter|shutter+tilt"
+                              "|relay|relay_power|light0|light1|light2|light3|shutter|shutter+tilt"
                               "|gensw_btn"
                               "|temperature|pressure|illuminance|humidity|occupancy|onoff|contact|flow|rain|waterleak"
                               "|airquality"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -1045,8 +1045,19 @@ class Matter_UI
     end
 
     # rest is relays
+    # If the remote device reports an `ENERGY` sensor, it's typically a single
+    # shared meter for the whole device (ex: multi-socket power strips) rather
+    # than one meter per relay. Tag only the first relay with `relay_power`
+    # so the Electrical Power Measurement cluster isn't duplicated (and made
+    # misleading) across every relay endpoint.
+    var energy_assigned = false
     for i: 1..power_cnt
-      config_list.push({'type': 'light0', 'relay': i})
+      if !energy_assigned && status10.contains("ENERGY")
+        config_list.push({'type': 'relay_power', 'relay': i})
+        energy_assigned = true
+      else
+        config_list.push({'type': 'light0', 'relay': i})
+      end
     end
 
     # show lights

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -190,8 +190,8 @@ class Matter_UI
                               "|gensw_btn"
                               "|temperature|pressure|illuminance|humidity|occupancy|onoff|contact|flow|rain|waterleak"
                               "|airquality"
-  static var _CLASSES_TYPES_VIRTUAL = 
-                              "-virtual|v_relay|v_light0|v_light1|v_light2|v_light3"
+  static var _CLASSES_TYPES_VIRTUAL =
+                              "-virtual|v_relay|v_relay_power|v_light0|v_light1|v_light2|v_light3"
                               "|v_fan|v_hvac|v_hvac_option"
                               "|v_temp|v_pressure|v_illuminance|v_humidity|v_occupancy|v_contact|v_flow|v_rain|v_waterleak"
                               "|v_airquality"


### PR DESCRIPTION
## Description:

Adds Matter support for live electrical power reporting on relay/plug endpoints:

- New `relay_power` plugin (`Matter_Plugin_OnOff_Power`, `Matter_Plugin_3_OnOff_Power.be`): extends the existing `relay` On/Off Plug-in Unit (device type `0x010A`) with the **Electrical Power Measurement** cluster (`0x0090`, Matter 1.4.1 §2.13). Reads Voltage/Current/Power/ApparentPower/ReactivePower/Factor/Frequency from Tasmota's `ENERGY` sensor JSON (single-channel energy monitoring chips: HLW8012, BL0937, CSE7766, ADE7953, PZEM, ...) and exposes them as `RMSVoltage`, `RMSCurrent`, `ActivePower`, `RMSPower`, `ApparentPower`, `ReactivePower`, `Frequency`, `PowerFactor`, plus the mandatory `PowerMode`/`NumberOfMeasurementTypes`/`Accuracy` attributes. This lets Matter controllers (Apple Home, Google Home, SmartThings, ...) display live power usage for Tasmota smart plugs, the same way many commercial Matter plugs do.
- New `v_relay_power` virtual variant (`Matter_Plugin_Virt_OnOff_Power`, `Matter_Plugin_9_Virt_OnOff_Power.be`): lets the cluster be exercised without physical hardware, driven entirely through the `MtrUpdate` command (e.g. `MtrUpdate {"Name":"Plug","Voltage":230.5,"Current":0.42,"ActivePower":95.6}`). Useful for testing/demoing without an energy-monitoring device.
- New `http_relay_power` bridge variant (`Matter_Plugin_Bridge_OnOff_Power`, `Matter_Plugin_8_Bridge_OnOff_Power.be`): same cluster, but polling a **remote** Tasmota device over HTTP (`Status 10`) instead of local sensors, completing the local/virtual/bridge trio already used by other plugins.
- `Matter_Plugin_0.be`: registers `FEATURE_MAPS`/`CLUSTER_REVISIONS` entries for cluster `0x0090`.
- `Matter_UI.be`:
  - adds `relay_power`, `v_relay_power` and `http_relay_power` to the endpoint-type configuration dropdowns.
  - improves the "Add Remote sensor or device" auto-detection: when the probed remote device reports an `ENERGY` sensor, the first detected relay is now suggested as `relay_power` instead of plain `light0`/`relay` (the type is otherwise not editable for already-detected rows, so without this the cluster was unreachable from that screen). Only the first relay is tagged, since most Tasmota energy-monitoring boards (single CSE7766/HLW8012/etc. chip) have one shared meter for the whole device rather than one per relay — tagging every relay would duplicate the same aggregate reading misleadingly.
- `be_matter_module.c`: registers the new solidified plugin headers (this file maintains an explicit include list with no auto-discovery; the initial push was missing the first pair and failed CI, fixed in a follow-up commit).

Design notes:
- The cluster is added directly on the existing "On/Off Plug-in Unit" endpoint rather than composed as a separate "Electrical Sensor" (`0x0510`) device type, matching common real-world Matter plug implementations.
- Single measurement channel only; multi-phase/multi-channel energy (`Voltage1/2`, `Power1/2`, ...) is out of scope for this PR.
- Electrical Energy Measurement (`0x0091`, cumulative kWh) is not covered by this PR.
- In the virtual variant, the wattage test key is `ActivePower` rather than `Power`, since `Power` is already the inherited On/Off boolean command.

**Related issue (if applicable):** N/A

## Test results:

Flashed and tested on real hardware: **ESP32-S3** (`tasmota32s3` env), Tasmota `15.5.0.2(tasmota32)`, Core `3.3.8`.

### Local + virtual (`relay_power` / `v_relay_power`)
- Built and flashed via PlatformIO (`pio run -e tasmota32s3 --target upload`) — build succeeds (Flash 70.7%, RAM 21.9%).
- Configured endpoint 2 as `v_relay_power` via the Matter web UI; commissioned the device with `chip-tool` (manual pairing code) onto a test fabric — commissioning completed successfully.
- `chip-tool descriptor read device-type-list` confirms endpoint 2 reports device type `266` (On/Off Plug-in Unit) alongside `19` (Bridged Node).
- Read the `ElectricalPowerMeasurement` cluster (`0x0090`) on endpoint 2 via `chip-tool`:
  - `PowerMode` = 2 (AC), `NumberOfMeasurementTypes` = 8.
  - `Accuracy`: 8 `MeasurementAccuracyStruct` entries returned with correct `MeasurementType` enums, min/max ranges and `AccuracyRanges` — matches the declarative table in the plugin.
  - Before any update, `ActivePower`/`ReactivePower`/`ApparentPower`/`Frequency`/`PowerFactor` correctly read back `null` (nullable/`X` quality, as specified).
- Sent `MtrUpdate {"Ep":2,"Power":1,"Voltage":230.5,"Current":0.42,"ActivePower":95.6,"ApparentPower":98.1,"ReactivePower":12.0,"Factor":0.97,"Frequency":50.0}` via the console — accepted (`RESULT = {"MtrUpdate":{"Ep":2,"Power":1}}`).
- Re-read via `chip-tool` after the update:
  - `ActivePower` = `95600` (mW) ✓ matches `95.6` W × 1000.
  - `RMSVoltage` = `230500` (mV) ✓ matches `230.5` V × 1000.
- Serial console confirmed no crash/exception around commissioning or the virtual update (`Status 0` reports healthy heap ~190KB free, stable uptime, Wifi connected throughout).

### Bridge (`http_relay_power`) against a real remote device
- Bridged a real **NOUS A5T** 4-outlet power strip (single shared CSE7766 meter, `ENERGY` in its `Status 10`) at a separate IP on the LAN.
- Before the auto-detect fix: all 4 relays were suggested (and had been added) as `http_light0` ("Light 0 OnOff") — the shared power meter was invisible from Matter, and the type wasn't editable for already-probed rows.
- After the fix: re-probing via "Add Remote Tasmota or OpenBK" now returns `[{"relay":1,"type":"http_relay_power"},{"relay":2,"type":"http_light0"},{"relay":3,"type":"http_light0"},{"relay":4,"type":"http_light0"}]` — only relay 1 is tagged with the power cluster.
- Deleted the old relay-1 `http_light0` endpoint, re-ran the probe, added the new `http_relay_power` endpoint for relay 1 — the existing relay 2/3/4 endpoints were correctly recognized as duplicates and skipped (no double endpoints).
- Tasmota's own status list now shows `Power1 Off 2.0W` (bridge-polled `ActivePower` displayed next to the On/Off state via `web_values()`) while `Power2`/`Power3`/`Power4` remain plain on/off — matching the physical reality of one shared meter across four sockets.

Not yet tested: ESP8266 build, and the physical (non-virtual, non-bridge) `relay_power` path against a locally-attached energy-monitoring chip.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
