### PR TITLE
Reset BLE scan flag on new operation

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -1819,6 +1819,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 #ifdef BLE_ESP32_DEBUG
       if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: new currentOperation"));
 #endif
+      BLERunningScan = 0;
       BLEOpCount++;
       generic_sensor_t* temp = *pCurrentOperation;
       //this will null it out, so save and restore.


### PR DESCRIPTION
## Description:
Clear the BLERunningScan flag when starting a new BLE operation to ensure proper state management. This prevents the scanning state from persisting incorrectly across operations.

**Related issue:** fixes #24268 

The fixed version is running over 16 hours without any problem described in the issue.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
