### PR TITLE
TLS fix public key fingerprint for ECDSA certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Can sniffer functionality (#18287)
 - Reset BLE scan flag on new operation (#24925)
 - Minor fixes in `LList`
+- TLS fix public key fingerprint for ECDSA certificates
 
 ### Removed
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -199,6 +199,7 @@ void WiFiClientSecure_light::_clear() {
   _fingerprint_any = true; // by default accept all fingerprints
   _fingerprint1 = nullptr;
   _fingerprint2 = nullptr;
+  memset(_recv_fingerprint, 0, sizeof(_recv_fingerprint)); // don't leave the received fingerprint uninitialized
   _chain_P = nullptr;
   _sk_ec_P = nullptr;
   _ta_P = nullptr;
@@ -823,6 +824,8 @@ extern "C" {
       int32_t curve = htonl(eckey.curve);
       sha1_update_len(&shactx, &curve, 4);   // curve id as int32be
       sha1_update_len(&shactx, eckey.q, eckey.qlen);       // public point
+
+      br_sha1_out(&shactx, xc->pubkey_recv_fingerprint); // copy to fingerprint
     }
   #endif
     else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -1283,16 +1283,15 @@ void MqttReconnect(void) {
 
         bool learned = false;
 
-        // If the fingerprint slot is marked for update, we'll do so.
-        // Otherwise, if the fingerprint slot had the magic trust-on-first-use
-        // value, we will save the current fingerprint there, but only if the other fingerprint slot
+        // If the fingerprint slot had the magic trust-on-first-use value, we will
+        // save the current fingerprint there, but only if the other fingerprint slot
         // *didn't* match it.
-        if (recv_fingerprint[20] & 0x1 || (learn_fingerprint1 && 0 != memcmp(recv_fingerprint, Settings->mqtt_fingerprint[1], 20))) {
+        if (learn_fingerprint1 && 0 != memcmp(recv_fingerprint, Settings->mqtt_fingerprint[1], 20)) {
           memcpy(Settings->mqtt_fingerprint[0], recv_fingerprint, 20);
           learned = true;
         }
         // As above, but for the other slot.
-        if (recv_fingerprint[20] & 0x2 || (learn_fingerprint2 && 0 != memcmp(recv_fingerprint, Settings->mqtt_fingerprint[0], 20))) {
+        if (learn_fingerprint2 && 0 != memcmp(recv_fingerprint, Settings->mqtt_fingerprint[0], 20)) {
           memcpy(Settings->mqtt_fingerprint[1], recv_fingerprint, 20);
           learned = true;
         }


### PR DESCRIPTION
## Description:

TLS fix public key fingerprint for ECDSA certificates

Thanks to Andreas Mansfeld for raising the issue

The EC branch of `pubkeyfingerprint_pubkey_fingerprint()` computed the `SHA1` digest of the server public key but never called `br_sha1_out()`, so `_recv_fingerprint` was left holding whatever was in that memory. The comparison in `pubkeyfingerprint_end_chain()` then ran against meaningless data. Add the missing `br_sha1_out()` to mirror the RSA branch, and `zero _recv_fingerprint in _clear()` so the buffer is never uninitialized.

Reachability is limited: `setPubKeyFingerprint()` forces `_rsa_only`, so an ECDSA-only server aborts at ServerHello before its certificate is parsed. Callers that re-enable `ECDSA` after pinning (`AsyncHttpClientLight`) are the exception. MQTT and Telegram were not affected. This was put in place to force using RSA when both certificates are present.

Also drop the reads of `recv_fingerprint[20]` in `MqttReconnect()`. The buffer is 20 bytes, so these were out of bounds, and they were dead logic: the status byte and its only writer were removed in 8d1b4094d together with the old fingerprint algorithm. Reading the adjacent byte could spuriously trigger fingerprint re-learning and a settings save on any TLS connect, including RSA.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
