### PR TITLE
Adapt `BLEDebug` to common command syntax

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2922,6 +2922,7 @@ void AddLog(uint32_t loglevel, PGM_P formatP, ...) {
     return;
   }
 #endif
+  if (!loglevel) return; // loglevel == 0 -> nothing to log
   uint32_t highest_loglevel = HighestLogLevel();
   // If no logging is requested then do not access heap to fight fragmentation
   if ((loglevel <= highest_loglevel) && (TasmotaGlobal.masterlog_level <= highest_loglevel)) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -92,10 +92,13 @@
         BLEName <mac|alias> - read the name
         BLEName <mac|alias> <name> - write the name - few devices support this
       BLEDebug
-        enable more debug logging
-        BLEDebug - show debug logging status
-        BLEDebug 0 - turn off
-        BLEDebug 1 - turn on
+        Set log levels more debug logging
+        BLEDebug0 - show debug logging status
+        BLEDebug1 <loglevel> - Set log level for errors     - default 0 -> off
+        BLEDebug2 <loglevel> - Set log level for infos      - default 0 -> off
+        BLEDebug3 <loglevel> - Set log level for debug      - default 0 -> off
+        BLEDebug4 <loglevel> - Set log level for more debug - default 0 -> off
+        * for all details compile with #define BLE_ESP32_DEBUG and #define EQ3_DEBUG
       BLEDevices
         display or clear the devices list
         BLEDevices0 - clear list
@@ -436,7 +439,8 @@ uint64_t BLEScanStartedAt = 0;
 uint64_t BLEScanToEndBefore = 0;
 uint8_t BLEStopScan = 0;
 uint8_t BLEOtaStallBLE = 0;
-uint8_t BLEDebugMode = 0;
+//uint8_t BLELogLevel[5] = {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+uint8_t BLELogLevel[5];
 int BLEMaxTaskLoopTime = 120; // we expect the task to NOT take > 120s per loop!!!
 uint64_t BLELastLoopTime = 0;
 int BLEScanTimeS = 20; // scan duraiton in S
@@ -674,7 +678,7 @@ int addSeenDevice(const uint8_t *mac, uint8_t addrtype, const char *name, int8_t
       int total = seenDevices.size();
       if (total < MAX_BLE_DEVICES_LOGGED){
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: New seendev slot %d"), total);
+        AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: New seendev slot %d"), total);
 #endif
         BLE_ESP32::BLE_simple_device_t* dev = new BLE_ESP32::BLE_simple_device_t;
         freeDevices.push_back(dev);
@@ -1161,7 +1165,7 @@ void ReverseMAC(uint8_t _mac[]){
 #ifdef BLE_ESP32_FILTER_BY_NAME
 bool isDeviceInFilter(const String& deviceName) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Device checked in filter %s"), deviceName);
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Device checked in filter %s"), deviceName);
 #endif  
   for (const auto& filterName : bleFilterNames) {
     if (deviceName == filterName) {
@@ -1297,7 +1301,6 @@ void setDetails(ble_advertisment_t *ad){
   BLEAdvertismentDetailsJsonSet = 1;
 }
 
-
 // call from main thread only!
 // post advertisment detail if available, then clear.
 void postAdvertismentDetails(){
@@ -1319,8 +1322,6 @@ void postAdvertismentDetails(){
   }
 }
 
-
-
 /*********************************************************************************************\
  * Classes
 \*********************************************************************************************/
@@ -1329,17 +1330,17 @@ void postAdvertismentDetails(){
 class BLESensorCallback : public NimBLEClientCallbacks {
   void onConnect(NimBLEClient* pClient) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   void onDisconnect(NimBLEClient* pClient, int reason) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   bool onConnParamsUpdateRequest(NimBLEClient* pClient, const ble_gap_upd_params* params) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
 
 //    if(params->itvl_min < 24) { /** 1.25ms units */
@@ -1500,13 +1501,13 @@ static BLESensorCallback BLESensorCB;
 static void BLEscanEndedCB(NimBLEScanResults results){
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Scan ended"));
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Scan ended"));
 #endif
   for (int i = 0; i < scancompleteCallbacks.size(); i++){
     SCANCOMPLETE_CALLBACK *pFn = scancompleteCallbacks[i];
     int callbackres = pFn(results);
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
 #endif
   }
 
@@ -1534,7 +1535,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
 
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Notified length: %u"),length);
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Notified length: %u"),length);
 #endif
   // find the operation this is associated with
   const NimBLERemoteService *pSvc = pRemoteCharacteristic->getRemoteService();
@@ -1737,7 +1738,7 @@ static void BLETaskStopStartNimBLE(NimBLEClient **ppClient, bool start = true){
   BLERunningScan = 0;
 
   if (start){
-    AddLog(LOG_LEVEL_INFO, PSTR("BLE: BLETask:Starting NimBLE"));
+    AddLog(LOG_LEVEL_INFO, PSTR("BLE: BLETask: Starting NimBLE"));
     NimBLEDevice::init("BLE_ESP32");
 
     *ppClient = NimBLEDevice::createClient();
@@ -1782,7 +1783,7 @@ int BLETaskStartScan(int time){
   }
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: Startscan"));
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: BLETask: Startscan"));
 #endif
   //vTaskDelay(500/ portTICK_PERIOD_MS);
   ble32Scan->setActiveScan(BLEScanActiveMode ? 1: 0);
@@ -1816,7 +1817,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     *pCurrentOperation = nextOperation(&queuedOperations);
     if (*pCurrentOperation){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: new currentOperation"));
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: BLETask: new currentOperation"));
 #endif
       BLERunningScan = 0;
       BLEOpCount++;
@@ -1855,7 +1856,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
       (*pCurrentOperation)->state = GEN_STATE_NOTIFIED;
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: notify operation complete"));
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: BLETask: notify operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1866,7 +1867,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     case GEN_STATE_NOTIFIED: // - may have completed DURING our read/write to get here
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: operation complete"));
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: BLETask: operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1924,7 +1925,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
   snprintf(addrstr, sizeof(addrstr), "%02X%02X%02X%02X%02X%02X", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
 #endif
 
   if (!op->serviceUUID.bitSize()){
@@ -1938,7 +1939,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     BLE_ESP32::BLETaskStartScan(20);
 
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
 #endif
     NimBLERemoteService *pService = pClient->getService(op->serviceUUID);
     int waitNotify = false;
@@ -1947,7 +1948,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
     if (pService != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got service"));
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: got service"));
 #endif
       // pre-set to fail if no operations requested
       //newstate = GEN_STATE_FAILED_NOREADWRITE;
@@ -1964,7 +1965,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pService->getCharacteristic(op->notificationCharacteristicUUID);
         if (pNCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got notify characteristic"));
+          AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: got notify characteristic"));
 #endif
           op->notifylen = 0;
           bool response = false;
@@ -1978,7 +1979,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           */
           uint8_t props = pNCharacteristic->getProperties();
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: characteristic props 0x%02X"), props);
+          AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: characteristic props 0x%02X"), props);
 #endif
 
           if(pNCharacteristic->canNotify()) {
@@ -1987,7 +1988,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
             if(pNCharacteristic->subscribe(true, BLE_ESP32::BLEGenNotifyCB, response)) {
 #ifdef BLE_ESP32_DEBUG
-              if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
+              AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
 #endif
               // this will get changed to read or write,
               // but here in case it's notify only (can that happen?)
@@ -2044,7 +2045,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pCharacteristic = pService->getCharacteristic(op->characteristicUUID);
           if (pCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-            if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got read/write characteristic"));
+            AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: got read/write characteristic"));
 #endif
             newstate = GEN_STATE_FAILED_NOREADWRITE; // overwritten on failure
 
@@ -2064,12 +2065,12 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 if (op->readmodifywritecallback){
                   READ_CALLBACK *pFn = (READ_CALLBACK *)op->readmodifywritecallback;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read characteristic with readmodifywritecallback"));
+                  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: read characteristic with readmodifywritecallback"));
 #endif
                   pFn(op);
                 } else {
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read characteristic"));
+                  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: read characteristic"));
 #endif
                 }
 
@@ -2090,7 +2091,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 } else {
                   if (!waitNotify) newstate = GEN_STATE_WRITEDONE;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: write characteristic"));
+                  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: write characteristic"));
 #endif
                 }
               } else {
@@ -2160,7 +2161,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLEClient **ppClient){
   if ((*ppClient)->isConnected()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
 #endif
     (*ppClient)->disconnect();
     // wait for 1/2 second after disconnect
@@ -2213,7 +2214,7 @@ static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLE
 
   // by adding it to this list, this will cause it to be sent to MQTT
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
 #endif
   addOperation(&completedOperations, op);
   return;
@@ -2667,13 +2668,22 @@ void CmndBLEAdv(void){
     case 3:
       break;
   }
-
   ResponseCmndNumber(BLEAdvertMode);
 }
 
 void CmndBLEDebug(void){
-  if (XdrvMailbox.data_len) BLEDebugMode = (bool)XdrvMailbox.payload;
-  ResponseCmndNumber(BLEDebugMode);
+  if ((XdrvMailbox.index > LOG_LEVEL_NONE) && (XdrvMailbox.index <= LOG_LEVEL_DEBUG_MORE)) {
+    if ((XdrvMailbox.payload >= LOG_LEVEL_NONE) && (XdrvMailbox.payload <= LOG_LEVEL_DEBUG_MORE)) {
+      BLELogLevel[XdrvMailbox.index] = XdrvMailbox.payload;
+    }
+    ResponseCmndIdxNumber(BLELogLevel[XdrvMailbox.index]);
+  } else {
+    ResponseClear();
+    for (uint32_t i = LOG_LEVEL_ERROR; i <= LOG_LEVEL_DEBUG_MORE; i++) {
+      ResponseAppend_P(PSTR("%c\"%s%d\":\"%d\""), (i - 1) ? ',' : '{', XdrvMailbox.command, i, BLELogLevel[i]);
+    }
+    ResponseJsonEnd();
+  }
 }
 
 void CmndBLEDevices(void){
@@ -2880,7 +2890,7 @@ void CmndBleFilterNames(void) {
 #ifdef BLE_ESP32_FILTER_BY_NAME
   int op = XdrvMailbox.index;
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
 #endif
   switch(op){
     case 0:{
@@ -2927,7 +2937,7 @@ void CmndSetMinRSSI(void) {
 void CmndBLEAlias(void){
 #ifdef BLE_ESP32_ALIASES
   int op = XdrvMailbox.index;
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
   int res = -1;
   switch(op){
     case 0:
@@ -2969,7 +2979,7 @@ void CmndBLEAlias(void){
         p = strtok(nullptr, " ,=");
       } while (p);
       if (added){
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Added %d Aliases"), added);
+        AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Added %d Aliases"), added);
         BLEAliasListResp();
       } else {
         BLEAliasListResp();
@@ -2977,7 +2987,7 @@ void CmndBLEAlias(void){
       return;
     } break;
     case 2:{ // clear
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Alias clearing %d"), aliases.size());
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: Alias clearing %d"), aliases.size());
       for (int i = aliases.size()-1; i >= 0; i--){
         BLE_ESP32::ble_alias_t *alias = aliases[i];
         aliases.pop_back();
@@ -3005,10 +3015,10 @@ void CmndBLEName(void) {
   NimBLEAddress addr(addrbin, addrbin[6]);
   if (addrres){
     if (addrres == 2){
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: addr used alias: %s"), p);
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: addr used alias: %s"), p);
     }
 //#ifdef EQ3_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
+    AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
 //#endif
   } else {
     AddLog(LOG_LEVEL_ERROR, PSTR("BLE: addr invalid: %s"), p);
@@ -3023,7 +3033,7 @@ void CmndBLEName(void) {
     ResponseCmndChar(PSTR("FAIL"));
     return;
   } else {
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got a newOperation from BLE"));
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: got a newOperation from BLE"));
   }
   op->addr = addr;
   op->serviceUUID = NimBLEUUID("1800");
@@ -3032,16 +3042,16 @@ void CmndBLEName(void) {
   char *name = strtok(nullptr, " ");
   bool write = false;
   if (name && *name){
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: write name %s"), name);
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: write name %s"), name);
     op->writelen = strlen(name);
     memcpy(op->dataToWrite, name, op->writelen);
     write = true;
   } else {
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read name"));
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: read name"));
     op->readlen = 1;
   }
   res = BLE_ESP32::extQueueOperation(&op);
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: queue res %d"), res);
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: queue res %d"), res);
   if (!res){
     // if it fails to add to the queue, do please delete it
     BLE_ESP32::freeOperation(&op);
@@ -3050,9 +3060,9 @@ void CmndBLEName(void) {
     return;
   }
   if (write){
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will write name"));
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: will write name"));
   } else {
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will read name"));
+    AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: will read name"));
   }
   ResponseCmndDone();
   return;
@@ -3086,7 +3096,7 @@ void CmndBLEOperation(void){
   switch(op) {
     case 0:
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: preview"));
+      AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: preview"));
 #endif
       BLEPostMQTTTrigger = 1;
       break;
@@ -3160,7 +3170,7 @@ void CmndBLEOperation(void){
         } else {
           // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+          AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
           char temp[40];
           sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3195,7 +3205,7 @@ void CmndBLEOperation(void){
       } else {
         // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+        AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
         char temp[40];
         sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3235,20 +3245,20 @@ static void BLEPostMQTT(bool onlycompleted) {
 //  if (TasmotaGlobal.ota_state_flag) return;
   if (prepOperation || mqttOperations.size() || queuedOperations.size() || currentOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: some to show"));
+    AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: some to show"));
 #endif
     if (prepOperation && !onlycompleted){
       std::string out = BLETriggerResponse(prepOperation);
       Response_P(PSTR("%s"), out.c_str());
       MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: prep sent %s"), out.c_str());
+      AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: prep sent %s"), out.c_str());
 #endif
     }
 
     if (queuedOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: queued %d"), queuedOperations.size());
+      AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: queued %d"), queuedOperations.size());
 #endif
       for (int i = 0; i < queuedOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost1");
@@ -3261,7 +3271,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: queued %d sent %s"), i, out.c_str());
+          AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: queued %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3270,7 +3280,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (currentOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: current %d"), currentOperations.size());
+      AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: current %d"), currentOperations.size());
 #endif
       for (int i = 0; i < currentOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost2");
@@ -3283,7 +3293,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: curr %d sent %s"), i, out.c_str());
+          AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: curr %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3292,7 +3302,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (mqttOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: completed %d"), mqttOperations.size());
+      AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: completed %d"), mqttOperations.size());
 #endif
       do {
         generic_sensor_t *toSend = nextOperation(&mqttOperations);
@@ -3300,7 +3310,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           break; // break from while loop
         } else {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
+          AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
 #endif
           std::string out = BLETriggerResponse(toSend);
           Response_P(PSTR("%s"), out.c_str());
@@ -3372,22 +3382,22 @@ static void mainThreadOpCallbacks() {
 
       bool callbackres = false;
 
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
+      AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
       if (op->completecallback){
         OPCOMPLETE_CALLBACK *pFn = (OPCOMPLETE_CALLBACK *)(op->completecallback);
         callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
+        AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
 #endif
       }
 
       if (!callbackres){
         for (int i = 0; i < operationsCallbacks.size(); i++){
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
+          AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
           OPCOMPLETE_CALLBACK *pFn = operationsCallbacks[i];
           callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
+          AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
 #endif
           if (callbackres){
             break; // this callback ate the op.
@@ -3403,7 +3413,7 @@ static void mainThreadOpCallbacks() {
         addOperation(&mqttOperations, &op);
       } else {
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
+        AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
 #endif
         delete op;
       }
@@ -3446,13 +3456,13 @@ void BLEAliasListResp(){
   ResponseAppend_P(PSTR("}}"));
 }
 
-
 static void BLEDiag()
 {
   uint32_t totalCount = BLEAdvertisment.totalCount;
   uint32_t deviceCount = seenDevices.size();
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
+//  AddLog(LOG_LEVEL_INFO, PSTR("BLE: BLELogLevel[LOG_LEVEL_NONE]: %d, BLELogLevel[LOG_LEVEL_ERROR]: %d, BLELogLevel[LOG_LEVEL_INFO]: %d, BLELogLevel[LOG_LEVEL_DEBUG]: %d, BLELogLevel[LOG_LEVEL_DEBUG_MORE]: %d"), BLELogLevel[LOG_LEVEL_NONE], BLELogLevel[LOG_LEVEL_ERROR], BLELogLevel[LOG_LEVEL_INFO], BLELogLevel[LOG_LEVEL_DEBUG], BLELogLevel[LOG_LEVEL_DEBUG_MORE]);
+  AddLog(BLELogLevel[LOG_LEVEL_INFO], PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
 #endif
 }
 
@@ -3573,7 +3583,7 @@ void HandleBleConfiguration(void)
   WebGetArg("en", tmp, sizeof(tmp));
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: arg en is %s"), tmp);
+  AddLog(BLELogLevel[LOG_LEVEL_DEBUG], PSTR("BLE: arg en is %s"), tmp);
 #endif
 
   if (Webserver->hasArg("save")) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -92,9 +92,10 @@
         BLEName <mac|alias> - read the name
         BLEName <mac|alias> <name> - write the name - few devices support this
       BLEDebug
-        enable more debug
-        BLEDebug0 - turn off
-        BLEDebug|BLEDebug1 - turn on
+        enable more debug logging
+        BLEDebug - show debug logging status
+        BLEDebug 0 - turn off
+        BLEDebug 1 - turn on
       BLEDevices
         display or clear the devices list
         BLEDevices0 - clear list
@@ -673,7 +674,7 @@ int addSeenDevice(const uint8_t *mac, uint8_t addrtype, const char *name, int8_t
       int total = seenDevices.size();
       if (total < MAX_BLE_DEVICES_LOGGED){
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: New seendev slot %d"), total);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: New seendev slot %d"), total);
 #endif
         BLE_ESP32::BLE_simple_device_t* dev = new BLE_ESP32::BLE_simple_device_t;
         freeDevices.push_back(dev);
@@ -1162,7 +1163,7 @@ void ReverseMAC(uint8_t _mac[]){
 #ifdef BLE_ESP32_FILTER_BY_NAME
 bool isDeviceInFilter(const String& deviceName) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Device chcked in filter %s"), deviceName);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Device chcked in filter %s"), deviceName);
 #endif  
   for (const auto& filterName : bleFilterNames) {
     if (deviceName == filterName) {
@@ -1330,17 +1331,17 @@ void postAdvertismentDetails(){
 class BLESensorCallback : public NimBLEClientCallbacks {
   void onConnect(NimBLEClient* pClient) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   void onDisconnect(NimBLEClient* pClient, int reason) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   bool onConnParamsUpdateRequest(NimBLEClient* pClient, const ble_gap_upd_params* params) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
 
 //    if(params->itvl_min < 24) { /** 1.25ms units */
@@ -1501,13 +1502,13 @@ static BLESensorCallback BLESensorCB;
 static void BLEscanEndedCB(NimBLEScanResults results){
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Scan ended"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Scan ended"));
 #endif
   for (int i = 0; i < scancompleteCallbacks.size(); i++){
     SCANCOMPLETE_CALLBACK *pFn = scancompleteCallbacks[i];
     int callbackres = pFn(results);
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
 #endif
   }
 
@@ -1535,7 +1536,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
 
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Notified length: %u"),length);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Notified length: %u"),length);
 #endif
   // find the operation this is associated with
   const NimBLERemoteService *pSvc = pRemoteCharacteristic->getRemoteService();
@@ -1783,7 +1784,7 @@ int BLETaskStartScan(int time){
   }
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: Startscan"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: Startscan"));
 #endif
   //vTaskDelay(500/ portTICK_PERIOD_MS);
   ble32Scan->setActiveScan(BLEScanActiveMode ? 1: 0);
@@ -1817,7 +1818,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     *pCurrentOperation = nextOperation(&queuedOperations);
     if (*pCurrentOperation){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: new currentOperation"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: new currentOperation"));
 #endif
       BLERunningScan = 0;
       BLEOpCount++;
@@ -1856,7 +1857,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
       (*pCurrentOperation)->state = GEN_STATE_NOTIFIED;
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: notify operation complete"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: notify operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1867,7 +1868,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     case GEN_STATE_NOTIFIED: // - may have completed DURING our read/write to get here
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: operation complete"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1925,7 +1926,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
   snprintf(addrstr, sizeof(addrstr), "%02X%02X%02X%02X%02X%02X", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
 #endif
 
   if (!op->serviceUUID.bitSize()){
@@ -1939,7 +1940,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     BLE_ESP32::BLETaskStartScan(20);
 
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
 #endif
     NimBLERemoteService *pService = pClient->getService(op->serviceUUID);
     int waitNotify = false;
@@ -1948,7 +1949,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
     if (pService != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got service"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got service"));
 #endif
       // pre-set to fail if no operations requested
       //newstate = GEN_STATE_FAILED_NOREADWRITE;
@@ -1965,7 +1966,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pService->getCharacteristic(op->notificationCharacteristicUUID);
         if (pNCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got notify characteristic"));
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got notify characteristic"));
 #endif
           op->notifylen = 0;
           bool response = false;
@@ -1979,7 +1980,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           */
           uint8_t props = pNCharacteristic->getProperties();
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic props 0x%02X"), props);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic props 0x%02X"), props);
 #endif
 
           if(pNCharacteristic->canNotify()) {
@@ -1988,7 +1989,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
             if(pNCharacteristic->subscribe(true, BLE_ESP32::BLEGenNotifyCB, response)) {
 #ifdef BLE_ESP32_DEBUG
-              if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
+              if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
 #endif
               // this will get changed to read or write,
               // but here in case it's notify only (can that happen?)
@@ -2045,7 +2046,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pCharacteristic = pService->getCharacteristic(op->characteristicUUID);
           if (pCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-            if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got read/write characteristic"));
+            if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got read/write characteristic"));
 #endif
             newstate = GEN_STATE_FAILED_NOREADWRITE; // overwritten on failure
 
@@ -2065,12 +2066,12 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 if (op->readmodifywritecallback){
                   READ_CALLBACK *pFn = (READ_CALLBACK *)op->readmodifywritecallback;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic with readmodifywritecallback"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic with readmodifywritecallback"));
 #endif
                   pFn(op);
                 } else {
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic"));
 #endif
                 }
 
@@ -2091,7 +2092,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 } else {
                   if (!waitNotify) newstate = GEN_STATE_WRITEDONE;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write characteristic"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write characteristic"));
 #endif
                 }
               } else {
@@ -2162,7 +2163,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLEClient **ppClient){
   if ((*ppClient)->isConnected()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
 #endif
     (*ppClient)->disconnect();
     // wait for 1/2 second after disconnect
@@ -2215,7 +2216,7 @@ static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLE
 
   // by adding it to this list, this will cause it to be sent to MQTT
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
 #endif
   addOperation(&completedOperations, op);
   return;
@@ -2653,7 +2654,6 @@ static void CmndBLEPeriod(void) {
   ResponseCmndDone();
 }
 
-
 //////////////////////////////////////////////////////////////
 // Determine what to do with advertismaents
 // BLEAdv0 -> suppress MQTT about devices found
@@ -2676,13 +2676,8 @@ void CmndBLEAdv(void){
   ResponseCmndNumber(BLEAdvertMode);
 }
 
-
-//////////////////////////////////////////////////////////////
-// Determine what to do with advertisements
-// BLEAdv0 -> suppress MQTT about devices found
-// BLEAdv1 -> send MQTT about devices found after each scan
 void CmndBLEDebug(void){
-  BLEDebugMode = XdrvMailbox.index;
+  if (XdrvMailbox.data_len) BLEDebugMode = (bool)XdrvMailbox.payload;
   ResponseCmndNumber(BLEDebugMode);
 }
 
@@ -2721,7 +2716,6 @@ void CmndBLEAddrFilter(void){
   }
   ResponseCmndIdxNumber(BLEAddressFilter);
 }
-
 
 //////////////////////////////////////////////////////////////
 // Scan options
@@ -2767,7 +2761,6 @@ void CmndBLEScan(void){
   }
 }
 
-
 //////////////////////////////////////////////////////////////
 // Determine what to do with advertismaents
 // BLEMode0 -> kill BLE completely
@@ -2778,7 +2771,6 @@ void CmndBLEMode(void){
   if (XdrvMailbox.data_len > 0) {
     val = XdrvMailbox.payload;
   }
-
   switch(val){
     case BLEModeDisabled:{
       if (BLEMode != BLEModeDisabled){
@@ -2843,13 +2835,11 @@ void CmndBLEEnableUnsaved(void){
   if (XdrvMailbox.data_len > 0) {
     val = XdrvMailbox.payload;
   }
-
   if (val >= 0){
     BLEEnableUnsaved = val;
   }
   ResponseCmndNumber(BLEEnableUnsaved);
 }
-
 
 //////////////////////////////////////////
 // get more drtails for a single MAC address
@@ -2867,7 +2857,6 @@ void CmndBLEDetails(void){
       BLEDetailsRequest = 0;
       ResponseCmndNumber(BLEDetailsRequest);
       break;
-
     case 1:
     case 2:{
       BLEDetailsRequest = 0;
@@ -2878,17 +2867,14 @@ void CmndBLEDetails(void){
         ResponseCmndChar("InvalidMac");
       }
     } break;
-
     case 3:{
       BLEDetailsRequest = XdrvMailbox.index;
       ResponseCmndNumber(BLEDetailsRequest);
     } break;
-
     case 4:{
       BLEDetailsRequest = XdrvMailbox.index;
       ResponseCmndNumber(BLEDetailsRequest);
     } break;
-
     default:
       ResponseCmndChar("InvalidIndex");
       break;
@@ -2900,9 +2886,8 @@ void CmndBleFilterNames(void) {
 #ifdef BLE_ESP32_FILTER_BY_NAME
   int op = XdrvMailbox.index;
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
 #endif
-
   switch(op){
     case 0:{
       bleFilterNames.clear();
@@ -2912,7 +2897,6 @@ void CmndBleFilterNames(void) {
       if (XdrvMailbox.data_len) {
         String filters = XdrvMailbox.data;
         bleFilterNames.clear();
-        
         int start = 0;
         int end = filters.indexOf(',');
         while (end != -1) {
@@ -2921,7 +2905,6 @@ void CmndBleFilterNames(void) {
           end = filters.indexOf(',', start);
         }
         bleFilterNames.push_back(filters.substring(start));
-        
         Response_P(PSTR("{\"BLEFilterNames\":\"%s\"}"), filters.c_str());
       } else {
         String filterList;
@@ -2931,7 +2914,6 @@ void CmndBleFilterNames(void) {
           }
           filterList += name;
         }
-
         Response_P(PSTR("{\"BLEFilterNames\":\"%s\"}"), filterList.c_str());
       }
     } break;
@@ -2951,8 +2933,7 @@ void CmndSetMinRSSI(void) {
 void CmndBLEAlias(void){
 #ifdef BLE_ESP32_ALIASES
   int op = XdrvMailbox.index;
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
-
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
   int res = -1;
   switch(op){
     case 0:
@@ -2960,12 +2941,10 @@ void CmndBLEAlias(void){
       char *p = strtok(XdrvMailbox.data, " ,=");
       bool trigger = false;
       int added = 0;
-
       do {
         if (!p || !(*p)){
           break;
         }
-
         uint8_t addr[7];
         char *mac = p;
         int len = fromMAC(addr, p, sizeof(addr));
@@ -2974,7 +2953,6 @@ void CmndBLEAlias(void){
           ResponseCmndChar("invalidmac");
           return;
         }
-
         p = strtok(nullptr, " ,=");
         char *name = p;
         if (!p || !(*p)){
@@ -2990,16 +2968,14 @@ void CmndBLEAlias(void){
           ResponseCmndChar("invalidmac");
           return;
         }
-
         AddLog(LOG_LEVEL_INFO, PSTR("BLE: Add Alias mac %s = name %s"), mac, p);
         if (addAlias( addr, name )){
           added++;
         }
         p = strtok(nullptr, " ,=");
       } while (p);
-
       if (added){
-        if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Added %d Aliases"), added);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Added %d Aliases"), added);
         BLEAliasListResp();
       } else {
         BLEAliasListResp();
@@ -3007,7 +2983,7 @@ void CmndBLEAlias(void){
       return;
     } break;
     case 2:{ // clear
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias clearing %d"), aliases.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias clearing %d"), aliases.size());
       for (int i = aliases.size()-1; i >= 0; i--){
         BLE_ESP32::ble_alias_t *alias = aliases[i];
         aliases.pop_back();
@@ -3026,30 +3002,25 @@ void CmndBLEAlias(void){
 // uses s:1800 c:2a00 and writes name to DEVICE
 void CmndBLEName(void) {
   char *p = strtok(XdrvMailbox.data, " ");
-
   if (!p || !(*p)){
     ResponseCmndIdxChar(PSTR("invalid"));
     return;
   }
-
   uint8_t addrbin[7];
   int addrres = BLE_ESP32::getAddr(addrbin, p);
   NimBLEAddress addr(addrbin, addrbin[6]);
-
   if (addrres){
     if (addrres == 2){
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: addr used alias: %s"), p);
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: addr used alias: %s"), p);
     }
-
 //#ifdef EQ3_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
 //#endif
   } else {
     AddLog(LOG_LEVEL_ERROR,PSTR("BLE: addr invalid: %s"), p);
     ResponseCmndIdxChar(PSTR("invalidaddr"));
     return;
   }
-
   BLE_ESP32::generic_sensor_t *op = nullptr;
   // ALWAYS use this function to create a new one.
   int res = BLE_ESP32::newOperation(&op);
@@ -3058,28 +3029,25 @@ void CmndBLEName(void) {
     ResponseCmndChar(PSTR("FAIL"));
     return;
   } else {
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got a newOperation from BLE"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got a newOperation from BLE"));
   }
-
   op->addr = addr;
   op->serviceUUID = NimBLEUUID("1800");
   op->characteristicUUID = NimBLEUUID("2A00");
-
   // get next part of cmd
   char *name = strtok(nullptr, " ");
   bool write = false;
   if (name && *name){
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write name %s"), name);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write name %s"), name);
     op->writelen = strlen(name);
     memcpy(op->dataToWrite, name, op->writelen);
     write = true;
   } else {
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read name"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read name"));
     op->readlen = 1;
   }
-
   res = BLE_ESP32::extQueueOperation(&op);
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: queue res %d"), res);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: queue res %d"), res);
   if (!res){
     // if it fails to add to the queue, do please delete it
     BLE_ESP32::freeOperation(&op);
@@ -3087,11 +3055,10 @@ void CmndBLEName(void) {
     ResponseCmndChar(PSTR("QUEUEFAIL"));
     return;
   }
-
   if (write){
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will write name"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will write name"));
   } else {
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will read name"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: will read name"));
   }
   ResponseCmndDone();
   return;
@@ -3118,18 +3085,14 @@ void CmndBLEName(void) {
 
 // You may queue up operations.  they are currently processed serially.
 void CmndBLEOperation(void){
-
   int op = XdrvMailbox.index;
-
   //AddLog(LOG_LEVEL_INFO,PSTR("BLE: op %d"), op);
-
   int res = -1;
-
   // if in progress, only op 0 or 11 are allowed
   switch(op) {
     case 0:
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: preview"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: preview"));
 #endif
       BLEPostMQTTTrigger = 1;
       break;
@@ -3186,10 +3149,8 @@ void CmndBLEOperation(void){
             }
             break;
         }
-
         p = strtok(nullptr, " ,");
       }
-
       if (trigger){
         int u = (int)prepOperation->context;
         int opres = BLE_ESP32::extQueueOperation(&prepOperation);
@@ -3205,7 +3166,7 @@ void CmndBLEOperation(void){
         } else {
           // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
           char temp[40];
           sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3240,7 +3201,7 @@ void CmndBLEOperation(void){
       } else {
         // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
         char temp[40];
         sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3282,20 +3243,20 @@ static void BLEPostMQTT(bool onlycompleted) {
 
   if (prepOperation || mqttOperations.size() || queuedOperations.size() || currentOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: some to show"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: some to show"));
 #endif
     if (prepOperation && !onlycompleted){
       std::string out = BLETriggerResponse(prepOperation);
       Response_P(PSTR("%s"), out.c_str());
       MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: prep sent %s"), out.c_str());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: prep sent %s"), out.c_str());
 #endif
     }
 
     if (queuedOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d"), queuedOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d"), queuedOperations.size());
 #endif
       for (int i = 0; i < queuedOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost1");
@@ -3309,7 +3270,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d sent %s"), i, out.c_str());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3318,7 +3279,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (currentOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: current %d"), currentOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: current %d"), currentOperations.size());
 #endif
       for (int i = 0; i < currentOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost2");
@@ -3331,7 +3292,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: curr %d sent %s"), i, out.c_str());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: curr %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3340,7 +3301,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (mqttOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: completed %d"), mqttOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: completed %d"), mqttOperations.size());
 #endif
       do {
         generic_sensor_t *toSend = nextOperation(&mqttOperations);
@@ -3348,7 +3309,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           break; // break from while loop
         } else {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
 #endif
           std::string out = BLETriggerResponse(toSend);
           Response_P(PSTR("%s"), out.c_str());
@@ -3420,22 +3381,22 @@ static void mainThreadOpCallbacks() {
 
       bool callbackres = false;
 
-      if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
       if (op->completecallback){
         OPCOMPLETE_CALLBACK *pFn = (OPCOMPLETE_CALLBACK *)(op->completecallback);
         callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
 #endif
       }
 
       if (!callbackres){
         for (int i = 0; i < operationsCallbacks.size(); i++){
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
           OPCOMPLETE_CALLBACK *pFn = operationsCallbacks[i];
           callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
 #endif
           if (callbackres){
             break; // this callback ate the op.
@@ -3451,7 +3412,7 @@ static void mainThreadOpCallbacks() {
         addOperation(&mqttOperations, &op);
       } else {
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
 #endif
         delete op;
       }
@@ -3500,7 +3461,7 @@ static void BLEDiag()
   uint32_t totalCount = BLEAdvertisment.totalCount;
   uint32_t deviceCount = seenDevices.size();
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_INFO,PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
 #endif
 }
 
@@ -3621,7 +3582,7 @@ void HandleBleConfiguration(void)
   WebGetArg("en", tmp, sizeof(tmp));
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode > 0) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: arg en is %s"), tmp);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: arg en is %s"), tmp);
 #endif
 
   if (Webserver->hasArg("save")) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -674,7 +674,7 @@ int addSeenDevice(const uint8_t *mac, uint8_t addrtype, const char *name, int8_t
       int total = seenDevices.size();
       if (total < MAX_BLE_DEVICES_LOGGED){
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: New seendev slot %d"), total);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: New seendev slot %d"), total);
 #endif
         BLE_ESP32::BLE_simple_device_t* dev = new BLE_ESP32::BLE_simple_device_t;
         freeDevices.push_back(dev);
@@ -742,10 +742,10 @@ int deleteSeenDevices(int ageS = 0){
           dump(addr, 20, dev->mac, 6);
           const char *alias = getAlias(dev->mac);
           if (!filter){
-            AddLog(LOG_LEVEL_INFO,PSTR("BLE: Delete device %s(%s) by age lastseen %u + maxage %u < now %u."),
+            AddLog(LOG_LEVEL_INFO, PSTR("BLE: Delete device %s(%s) by age lastseen %u + maxage %u < now %u."),
               addr, alias, lastseenS, ageS, nowS);
           } else {
-            AddLog(LOG_LEVEL_INFO,PSTR("BLE: Delete device %s(%s) by addrtype filter %d > %d."),
+            AddLog(LOG_LEVEL_INFO, PSTR("BLE: Delete device %s(%s) by addrtype filter %d > %d."),
               addr, alias, dev->addrtype, BLEAddressFilter);
           }
 #endif
@@ -757,7 +757,7 @@ int deleteSeenDevices(int ageS = 0){
   }
   if (res){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: Deleted %d devices"), res);
+    AddLog(LOG_LEVEL_INFO, PSTR("BLE: Deleted %d devices"), res);
 #endif
   }
   return res;
@@ -885,7 +885,6 @@ int getSeenDeviceToJson(int index, BLE_ESP32::BLE_simple_device_t* dev, char **d
   return 1;
 }
 
-
 int nextSeenDev = 0;
 
 int getSeenDevicesToJson(char *dest, int maxlen){
@@ -895,8 +894,7 @@ int getSeenDevicesToJson(char *dest, int maxlen){
   }
 
   // deliberate test of SafeAddLog_P from main thread...
-  //AddLog(LOG_LEVEL_INFO,PSTR("BLE: getSeen %d"), seenDevices.size());
-
+  //AddLog(LOG_LEVEL_INFO, PSTR("BLE: getSeen %d"), seenDevices.size());
 
   int len;
   if (!maxlen) return 0;
@@ -1163,7 +1161,7 @@ void ReverseMAC(uint8_t _mac[]){
 #ifdef BLE_ESP32_FILTER_BY_NAME
 bool isDeviceInFilter(const String& deviceName) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Device chcked in filter %s"), deviceName);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Device checked in filter %s"), deviceName);
 #endif  
   for (const auto& filterName : bleFilterNames) {
     if (deviceName == filterName) {
@@ -1331,17 +1329,17 @@ void postAdvertismentDetails(){
 class BLESensorCallback : public NimBLEClientCallbacks {
   void onConnect(NimBLEClient* pClient) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onConnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   void onDisconnect(NimBLEClient* pClient, int reason) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onDisconnect %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
   }
   bool onConnParamsUpdateRequest(NimBLEClient* pClient, const ble_gap_upd_params* params) {
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: onConnParamsUpdateRequest %s"), ((std::string)pClient->getPeerAddress()).c_str());
 #endif
 
 //    if(params->itvl_min < 24) { /** 1.25ms units */
@@ -1502,13 +1500,13 @@ static BLESensorCallback BLESensorCB;
 static void BLEscanEndedCB(NimBLEScanResults results){
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Scan ended"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Scan ended"));
 #endif
   for (int i = 0; i < scancompleteCallbacks.size(); i++){
     SCANCOMPLETE_CALLBACK *pFn = scancompleteCallbacks[i];
     int callbackres = pFn(results);
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: scancompleteCallbacks %d %d"), i, callbackres);
 #endif
   }
 
@@ -1529,21 +1527,21 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
 
   if (!pRemoteCharacteristic){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Notify: no remote char!!??"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Notify: no remote char!!??"));
 #endif
     return;
   }
 
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Notified length: %u"),length);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Notified length: %u"),length);
 #endif
   // find the operation this is associated with
   const NimBLERemoteService *pSvc = pRemoteCharacteristic->getRemoteService();
 
   if (!pSvc){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Notify: no remote service found"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Notify: no remote service found"));
 #endif
     return;
   }
@@ -1551,7 +1549,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
   pRClient = pSvc->getClient();
   if (!pRClient){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Notify: no remote client!!??"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Notify: no remote client!!??"));
 #endif
     return;
   }
@@ -1566,7 +1564,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
       generic_sensor_t *op = currentOperations[i];
       if (!op){
 #ifdef BLE_ESP32_DEBUG
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Notify: null op in currentOperations!!??"));
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Notify: null op in currentOperations!!??"));
 #endif
       } else {
         if (devaddr == op->addr){
@@ -1574,7 +1572,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
             thisop = op;
             break;
           } else {
-            AddLog(LOG_LEVEL_ERROR,PSTR("BLE: notify: op addr match but op found which is not waiting."));
+            AddLog(LOG_LEVEL_ERROR, PSTR("BLE: notify: op addr match but op found which is not waiting."));
           }
         }
       }
@@ -1586,7 +1584,7 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
 
   if (!thisop){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: no op for notify"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: no op for notify"));
 #endif
     return;
   }
@@ -1618,21 +1616,21 @@ static void BLEGenNotifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, ui
 
 void registerForAdvertismentCallbacks(const char *tag, BLE_ESP32::ADVERTISMENT_CALLBACK* pFn){
 #ifdef BLE_ESP32_DEBUG
-  AddLog(LOG_LEVEL_INFO,PSTR("BLE: registerForAdvertismentCallbacks %s:%x"), tag, (uint32_t) pFn);
+  AddLog(LOG_LEVEL_INFO, PSTR("BLE: registerForAdvertismentCallbacks %s:%x"), tag, (uint32_t) pFn);
 #endif
   advertismentCallbacks.push_back(pFn);
 }
 
 void registerForOpCallbacks(const char *tag, BLE_ESP32::OPCOMPLETE_CALLBACK* pFn){
 #ifdef BLE_ESP32_DEBUG
-  AddLog(LOG_LEVEL_INFO,PSTR("BLE: registerForOpCallbacks %s:%x"), tag, (uint32_t) pFn);
+  AddLog(LOG_LEVEL_INFO, PSTR("BLE: registerForOpCallbacks %s:%x"), tag, (uint32_t) pFn);
 #endif
   operationsCallbacks.push_back(pFn);
 }
 
 void registerForScanCallbacks(const char *tag, BLE_ESP32::SCANCOMPLETE_CALLBACK* pFn){
 #ifdef BLE_ESP32_DEBUG
-  AddLog(LOG_LEVEL_INFO,PSTR("BLE: registerForScnCallbacks %s:%x"), tag, (uint32_t) pFn);
+  AddLog(LOG_LEVEL_INFO, PSTR("BLE: registerForScnCallbacks %s:%x"), tag, (uint32_t) pFn);
 #endif
   scancompleteCallbacks.push_back(pFn);
 }
@@ -1657,7 +1655,7 @@ static void BLEInit(void) {
   if (!TasmotaGlobal.global_state.wifi_down) {
     TasmotaGlobal.wifi_stay_asleep = true;
     if (WiFi.getSleep() == false) {
-      AddLog(LOG_LEVEL_DEBUG,PSTR("%s: Put WiFi modem in sleep mode"), "BLE");
+      AddLog(LOG_LEVEL_DEBUG, PSTR("%s: Put WiFi modem in sleep mode"), "BLE");
       WiFi.setSleep(true); // Sleep
     }
   }
@@ -1687,7 +1685,7 @@ static void BLEOperationTask(void *pvParameters);
 static void BLEStartOperationTask(){
   if (BLERunning == false){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: %s: Start operations"),D_CMND_BLE);
+    AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: %s: Start operations"),D_CMND_BLE);
 #endif
     BLERunning = true;
 
@@ -1710,20 +1708,20 @@ static void BLEStartOperationTask(){
 static void BLETaskStopStartNimBLE(NimBLEClient **ppClient, bool start = true){
 
   if (*ppClient){
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Task:Stopping NimBLE"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Task:Stopping NimBLE"));
 
     (*ppClient)->setClientCallbacks(nullptr, false);
 
     if ((*ppClient)->isConnected()){
 #ifdef BLE_ESP32_DEBUG
-      AddLog(LOG_LEVEL_INFO,PSTR("BLE: disconnecting connected client"));
+      AddLog(LOG_LEVEL_INFO, PSTR("BLE: disconnecting connected client"));
 #endif
       (*ppClient)->disconnect();
     }
     NimBLEDevice::deleteClient((*ppClient));
     (*ppClient) = nullptr;
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: deleted client"));
+    AddLog(LOG_LEVEL_INFO, PSTR("BLE: deleted client"));
 #endif
 
     if (ble32Scan){
@@ -1739,7 +1737,7 @@ static void BLETaskStopStartNimBLE(NimBLEClient **ppClient, bool start = true){
   BLERunningScan = 0;
 
   if (start){
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: BLETask:Starting NimBLE"));
+    AddLog(LOG_LEVEL_INFO, PSTR("BLE: BLETask:Starting NimBLE"));
     NimBLEDevice::init("BLE_ESP32");
 
     *ppClient = NimBLEDevice::createClient();
@@ -1784,7 +1782,7 @@ int BLETaskStartScan(int time){
   }
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: Startscan"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: Startscan"));
 #endif
   //vTaskDelay(500/ portTICK_PERIOD_MS);
   ble32Scan->setActiveScan(BLEScanActiveMode ? 1: 0);
@@ -1818,7 +1816,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     *pCurrentOperation = nextOperation(&queuedOperations);
     if (*pCurrentOperation){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: new currentOperation"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: new currentOperation"));
 #endif
       BLERunningScan = 0;
       BLEOpCount++;
@@ -1840,7 +1838,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     diff = diff/1000;
     if (diff > 20000){ // 20s
 #ifdef BLE_ESP32_DEBUG
-      AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: notify timeout"));
+      AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: notify timeout"));
 #endif
       (*pCurrentOperation)->state = GEN_STATE_FAILED_NOTIFYTIMEOUT;
       (*pCurrentOperation)->notifytimer = 0;
@@ -1857,7 +1855,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
       (*pCurrentOperation)->state = GEN_STATE_NOTIFIED;
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: notify operation complete"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: notify operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1868,7 +1866,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     case GEN_STATE_NOTIFIED: // - may have completed DURING our read/write to get here
       // just stay here until this is removed by the main thread
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: operation complete"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: operation complete"));
 #endif
       BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
       pClient = *ppClient;
@@ -1888,7 +1886,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
   if ((*pCurrentOperation)->state <= GEN_STATE_FAILED){
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: BLETask: op failed %d"), (*pCurrentOperation)->state);
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: BLETask: op failed %d"), (*pCurrentOperation)->state);
 #endif
     BLE_ESP32::BLETaskRunTaskDoneOperation(pCurrentOperation, ppClient);
     pClient = *ppClient;
@@ -1902,7 +1900,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
   if (pClient->isConnected()){
     // don't do anything if we are still connected
 #ifdef BLE_ESP32_DEBUG
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: still connected"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: still connected"));
 #endif
     return;
   }
@@ -1926,7 +1924,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
   snprintf(addrstr, sizeof(addrstr), "%02X%02X%02X%02X%02X%02X", m_address[5], m_address[4], m_address[3], m_address[2], m_address[1], m_address[0]);
 
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask: attempt connect %s"), ((std::string)op->addr).c_str());
 #endif
 
   if (!op->serviceUUID.bitSize()){
@@ -1940,7 +1938,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
     BLE_ESP32::BLETaskStartScan(20);
 
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: connected %s -> getservice"), ((std::string)op->addr).c_str());
 #endif
     NimBLERemoteService *pService = pClient->getService(op->serviceUUID);
     int waitNotify = false;
@@ -1949,7 +1947,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
     if (pService != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got service"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got service"));
 #endif
       // pre-set to fail if no operations requested
       //newstate = GEN_STATE_FAILED_NOREADWRITE;
@@ -1966,7 +1964,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pService->getCharacteristic(op->notificationCharacteristicUUID);
         if (pNCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got notify characteristic"));
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got notify characteristic"));
 #endif
           op->notifylen = 0;
           bool response = false;
@@ -1980,7 +1978,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           */
           uint8_t props = pNCharacteristic->getProperties();
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic props 0x%02X"), props);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: characteristic props 0x%02X"), props);
 #endif
 
           if(pNCharacteristic->canNotify()) {
@@ -1989,7 +1987,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 
             if(pNCharacteristic->subscribe(true, BLE_ESP32::BLEGenNotifyCB, response)) {
 #ifdef BLE_ESP32_DEBUG
-              if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
+              if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: subscribe for notify - resp %d"), response? 1:0);
 #endif
               // this will get changed to read or write,
               // but here in case it's notify only (can that happen?)
@@ -1997,7 +1995,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
               waitNotify = true;
             } else {
 #ifdef BLE_ESP32_DEBUG
-              AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed subscribe for notify - resp %d"), response? 1:0);
+              AddLog(LOG_LEVEL_ERROR, PSTR("BLE: failed subscribe for notify - resp %d"), response? 1:0);
 #endif
               newstate = GEN_STATE_FAILED_NOTIFY;
               op->notifytimer = 0L;
@@ -2008,13 +2006,13 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
               op->notifytimer = now;
               if(pNCharacteristic->subscribe(false, BLE_ESP32::BLEGenNotifyCB, response)) {
 #ifdef BLE_ESP32_DEBUG
-                AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: subscribe for indicate - resp %d"), response? 1:0);
+                AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: subscribe for indicate - resp %d"), response? 1:0);
 #endif
                 notifystate = GEN_STATE_WAITINDICATE;
                 waitNotify = true;
               } else {
 #ifdef BLE_ESP32_DEBUG
-                AddLog(LOG_LEVEL_ERROR,PSTR("BLE: failed subscribe for indicate - resp %d"), response? 1:0);
+                AddLog(LOG_LEVEL_ERROR, PSTR("BLE: failed subscribe for indicate - resp %d"), response? 1:0);
 #endif
                 newstate = GEN_STATE_FAILED_INDICATE;
                 op->notifytimer = 0L;
@@ -2022,14 +2020,14 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
             } else {
               newstate = GEN_STATE_FAILED_CANTNOTIFYORINDICATE;
 #ifdef BLE_ESP32_DEBUG
-              AddLog(LOG_LEVEL_ERROR,PSTR("BLE: characteristic can't notify"));
+              AddLog(LOG_LEVEL_ERROR, PSTR("BLE: characteristic can't notify"));
 #endif
             }
           }
         } else {
           newstate = GEN_STATE_FAILED_NONOTIFYCHAR;
 #ifdef BLE_ESP32_DEBUG
-          AddLog(LOG_LEVEL_ERROR,PSTR("BLE: notify characteristic not found"));
+          AddLog(LOG_LEVEL_ERROR, PSTR("BLE: notify characteristic not found"));
 #endif
         }
 
@@ -2046,7 +2044,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           pCharacteristic = pService->getCharacteristic(op->characteristicUUID);
           if (pCharacteristic != nullptr) {
 #ifdef BLE_ESP32_DEBUG
-            if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got read/write characteristic"));
+            if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got read/write characteristic"));
 #endif
             newstate = GEN_STATE_FAILED_NOREADWRITE; // overwritten on failure
 
@@ -2066,12 +2064,12 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 if (op->readmodifywritecallback){
                   READ_CALLBACK *pFn = (READ_CALLBACK *)op->readmodifywritecallback;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic with readmodifywritecallback"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read characteristic with readmodifywritecallback"));
 #endif
                   pFn(op);
                 } else {
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read characteristic"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read characteristic"));
 #endif
                 }
 
@@ -2087,12 +2085,12 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
                 if (!pCharacteristic->writeValue(op->dataToWrite, op->writelen, !pCharacteristic->canWriteNoResponse())){ // request response, unless we can't
                   newstate = GEN_STATE_FAILED_WRITE;
 #ifdef BLE_ESP32_DEBUG
-                  AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic write fail"));
+                  AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: characteristic write fail"));
 #endif
                 } else {
                   if (!waitNotify) newstate = GEN_STATE_WRITEDONE;
 #ifdef BLE_ESP32_DEBUG
-                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write characteristic"));
+                  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: write characteristic"));
 #endif
                 }
               } else {
@@ -2104,12 +2102,11 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
           } else {
             newstate = GEN_STATE_FAILED_NO_RW_CHAR;
 #ifdef BLE_ESP32_DEBUG
-            AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: r/w characteristic not found"));
+            AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: r/w characteristic not found"));
 #endif
           }
         }
       }
-
 
       // disconnect if not waiting for notify,
       if (!op->notifytimer){
@@ -2125,7 +2122,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
       newstate = GEN_STATE_FAILED_NOSERVICE;
       // failed to get a service
 #ifdef BLE_ESP32_DEBUG
-      AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: failed - svc not on device?"));
+      AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: failed - svc not on device?"));
 #endif
     }
 
@@ -2163,7 +2160,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
 static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLEClient **ppClient){
   if ((*ppClient)->isConnected()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: runTaskDoneOperation: disconnecting connected client"));
 #endif
     (*ppClient)->disconnect();
     // wait for 1/2 second after disconnect
@@ -2174,7 +2171,7 @@ static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLE
         //(*ppClient)->disconnect();
         // we will stall here forever!!! - as testing
 #ifdef BLE_ESP32_DEBUG
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: wait discon%d"), waits);
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: wait disconnect %d"), waits);
 #endif
         vTaskDelay(500/ portTICK_PERIOD_MS);
       }
@@ -2185,11 +2182,11 @@ static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLE
         ble_gap_conn_broken(conn_id, -1);
 #endif        
 #ifdef BLE_ESP32_DEBUG
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: wait discon%d - kill connection"), waits);
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: wait discon%d - kill connection"), waits);
 #endif
       }
       if (waits == 60){
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: >60s waiting -> BLE Failed, restart Tasmota %d"), waits);
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: >60s waiting -> BLE Failed, restart Tasmota %d"), waits);
         BLEStop = 1;
         BLEStopAt = esp_timer_get_time();
 
@@ -2216,7 +2213,7 @@ static void BLETaskRunTaskDoneOperation(BLE_ESP32::generic_sensor_t** op, NimBLE
 
   // by adding it to this list, this will cause it to be sent to MQTT
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: runTaskDoneOperation: add to completedOperations"));
 #endif
   addOperation(&completedOperations, op);
   return;
@@ -2277,7 +2274,7 @@ static void BLEOperationTask(void *pvParameters){
       BLERestartNimBLE = 0;
       BLERestartTasmota = 10;
       BLERestartTasmotaReason = BLE_RESTART_TEAMOTA_REASON_RESTARTING_BLE_TIMEOUT;
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: BLETask: Restart NimBLE - restart Tasmota in 10 if not complt"));
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLE: BLETask: Restart NimBLE - restart Tasmota in 10 if not complt"));
       BLE_ESP32::BLETaskStopStartNimBLE(&pClient);
       BLERestartTasmotaReason = BLE_RESTART_TEAMOTA_REASON_UNKNOWN;
       BLERestartTasmota = 0;
@@ -2291,7 +2288,7 @@ static void BLEOperationTask(void *pvParameters){
   vTaskDelay(100/ portTICK_PERIOD_MS);
 
 #ifdef BLE_ESP32_DEBUG
-  AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLEOperationTask: Left task"));
+  AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLEOperationTask: Left task"));
 #endif
   deleteSeenDevices();
 
@@ -2331,7 +2328,7 @@ static void stopStartBLE(){
         BLEMasterEnable = enable;
       }
     }
-    AddLog(LOG_LEVEL_INFO,PSTR("BLE: MasterEnable->%d"), BLEMasterEnable);
+    AddLog(LOG_LEVEL_INFO, PSTR("BLE: MasterEnable->%d"), BLEMasterEnable);
   }
 }
 
@@ -2378,11 +2375,11 @@ static void BLEEverySecond(bool restart){
       if (!BLERestartTasmotaReason) BLERestartTasmotaReason = BLE_RESTART_TEAMOTA_REASON_UNKNOWN;
       Response_P(PSTR("{\"reboot\":\"%s\"}"), BLERestartTasmotaReason);
       MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Failure! Restarting Tasmota in %d seconds because %s"), BLERestartTasmota, BLERestartTasmotaReason);
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Failure! Restarting Tasmota in %d seconds because %s"), BLERestartTasmota, BLERestartTasmotaReason);
     }
 
     if (!BLERestartTasmota){
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Failure! Restarting Tasmota because %s"), BLERestartTasmotaReason);
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Failure! Restarting Tasmota because %s"), BLERestartTasmotaReason);
       // just a normal restart
       TasmotaGlobal.restart_flag = 1;
     }
@@ -2391,7 +2388,7 @@ static void BLEEverySecond(bool restart){
   if (BLERestartBLEReason){ // just use the ptr as the trigger to send MQTT
     Response_P(PSTR("{\"blerestart\":\"%s\"}"), BLERestartBLEReason);
     MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Failure! Restarting BLE Stack because %s"), BLERestartBLEReason);
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Failure! Restarting BLE Stack because %s"), BLERestartBLEReason);
     BLERestartBLEReason = nullptr;
   }
 
@@ -2436,9 +2433,9 @@ int addOperation(std::deque<generic_sensor_t*> *ops, generic_sensor_t** op){
     }
   }
   if (res){
-    //AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: added operation"));
+    //AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: added operation"));
   } else {
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: op - no room"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: op - no room"));
   }
   return res;
 }
@@ -2446,7 +2443,7 @@ int addOperation(std::deque<generic_sensor_t*> *ops, generic_sensor_t** op){
 
 int newOperation(BLE_ESP32::generic_sensor_t** op){
   if (!op) {
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: op inv in newOperation"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: op inv in newOperation"));
     return 0;
   }
 
@@ -2482,10 +2479,9 @@ int freeOperation(BLE_ESP32::generic_sensor_t** op){
   return 1;
 }
 
-
 int extQueueOperation(BLE_ESP32::generic_sensor_t** op){
   if (!op || !(*op)) {
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: op invalid"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: op invalid"));
     return 0;
   }
 
@@ -2499,11 +2495,10 @@ int extQueueOperation(BLE_ESP32::generic_sensor_t** op){
 
   int res = addOperation(&queuedOperations, op);
   if (!res){
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: extQueueOperation: op adding id %d failed"), (lastopid-1));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: extQueueOperation: op adding id %d failed"), (lastopid-1));
   }
   return res;
 }
-
 
 /*********************************************************************************************\
  * BLE Name alisaes
@@ -2621,7 +2616,7 @@ static int StartBLE(void) {
     BLE_ESP32::BLEStartOperationTask();
     return 1;
   }
-  AddLog(LOG_LEVEL_ERROR,PSTR("BLE: StartBLE - wait as BLEStop==1"));
+  AddLog(LOG_LEVEL_ERROR, PSTR("BLE: StartBLE - wait as BLEStop==1"));
 
   return 0;
 }
@@ -2630,16 +2625,16 @@ static int StopBLE(void){
   if (BLERunning){
     if (BLEStop != 1){
       BLEStop = 1;
-      AddLog(LOG_LEVEL_INFO,PSTR("BLE: StopBLE - BLEStop->1"));
+      AddLog(LOG_LEVEL_INFO, PSTR("BLE: StopBLE - BLEStop->1"));
       BLEStopAt = esp_timer_get_time();
       // give a little time for it to stop.
       vTaskDelay(100/ portTICK_PERIOD_MS);
       return 1;
     }
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: StopBLE - wait as BLEStop==1"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: StopBLE - wait as BLEStop==1"));
     return 0;
   } else {
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: StopBLE - was not running"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: StopBLE - was not running"));
     return 1;
   }
 }
@@ -2881,12 +2876,11 @@ void CmndBLEDetails(void){
   }
 }
 
-
 void CmndBleFilterNames(void) {
 #ifdef BLE_ESP32_FILTER_BY_NAME
   int op = XdrvMailbox.index;
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Name %d %s"), op, XdrvMailbox.data);
 #endif
   switch(op){
     case 0:{
@@ -2933,7 +2927,7 @@ void CmndSetMinRSSI(void) {
 void CmndBLEAlias(void){
 #ifdef BLE_ESP32_ALIASES
   int op = XdrvMailbox.index;
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Alias %d %s"), op, XdrvMailbox.data);
   int res = -1;
   switch(op){
     case 0:
@@ -2949,7 +2943,7 @@ void CmndBLEAlias(void){
         char *mac = p;
         int len = fromMAC(addr, p, sizeof(addr));
         if (len != 7){
-          AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Alias invalid mac %s"), p);
+          AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Alias invalid mac %s"), p);
           ResponseCmndChar("invalidmac");
           return;
         }
@@ -2975,7 +2969,7 @@ void CmndBLEAlias(void){
         p = strtok(nullptr, " ,=");
       } while (p);
       if (added){
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Added %d Aliases"), added);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Added %d Aliases"), added);
         BLEAliasListResp();
       } else {
         BLEAliasListResp();
@@ -2983,7 +2977,7 @@ void CmndBLEAlias(void){
       return;
     } break;
     case 2:{ // clear
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: Alias clearing %d"), aliases.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: Alias clearing %d"), aliases.size());
       for (int i = aliases.size()-1; i >= 0; i--){
         BLE_ESP32::ble_alias_t *alias = aliases[i];
         aliases.pop_back();
@@ -3011,13 +3005,13 @@ void CmndBLEName(void) {
   NimBLEAddress addr(addrbin, addrbin[6]);
   if (addrres){
     if (addrres == 2){
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: addr used alias: %s"), p);
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: addr used alias: %s"), p);
     }
 //#ifdef EQ3_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
+    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: cmd addr: %s -> %s"), p, addr.toString().c_str());
 //#endif
   } else {
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: addr invalid: %s"), p);
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: addr invalid: %s"), p);
     ResponseCmndIdxChar(PSTR("invalidaddr"));
     return;
   }
@@ -3025,11 +3019,11 @@ void CmndBLEName(void) {
   // ALWAYS use this function to create a new one.
   int res = BLE_ESP32::newOperation(&op);
   if (!res){
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Can't get a newOperation"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Can't get a newOperation"));
     ResponseCmndChar(PSTR("FAIL"));
     return;
   } else {
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: got a newOperation from BLE"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: got a newOperation from BLE"));
   }
   op->addr = addr;
   op->serviceUUID = NimBLEUUID("1800");
@@ -3038,20 +3032,20 @@ void CmndBLEName(void) {
   char *name = strtok(nullptr, " ");
   bool write = false;
   if (name && *name){
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: write name %s"), name);
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: write name %s"), name);
     op->writelen = strlen(name);
     memcpy(op->dataToWrite, name, op->writelen);
     write = true;
   } else {
-    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: read name"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: read name"));
     op->readlen = 1;
   }
   res = BLE_ESP32::extQueueOperation(&op);
-  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: queue res %d"), res);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: queue res %d"), res);
   if (!res){
     // if it fails to add to the queue, do please delete it
     BLE_ESP32::freeOperation(&op);
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Failed to queue new operation - deleted"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Failed to queue new operation - deleted"));
     ResponseCmndChar(PSTR("QUEUEFAIL"));
     return;
   }
@@ -3086,13 +3080,13 @@ void CmndBLEName(void) {
 // You may queue up operations.  they are currently processed serially.
 void CmndBLEOperation(void){
   int op = XdrvMailbox.index;
-  //AddLog(LOG_LEVEL_INFO,PSTR("BLE: op %d"), op);
+  //AddLog(LOG_LEVEL_INFO, PSTR("BLE: op %d"), op);
   int res = -1;
   // if in progress, only op 0 or 11 are allowed
   switch(op) {
     case 0:
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: preview"));
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: preview"));
 #endif
       BLEPostMQTTTrigger = 1;
       break;
@@ -3103,7 +3097,7 @@ void CmndBLEOperation(void){
       int opres = BLE_ESP32::newOperation(&prepOperation);
       if (!opres){
 #ifdef BLE_ESP32_DEBUG
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Could not create new operation"));
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Could not create new operation"));
 #endif
         ResponseCmndChar("FailCreate");
         return;
@@ -3159,14 +3153,14 @@ void CmndBLEOperation(void){
           // this means you could retry with another BLEOp10.
           // it WOULD be deleted if you sent another BELOP1 <MAC>
 #ifdef BLE_ESP32_DEBUG
-          AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Could not queue new operation"));
+          AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Could not queue new operation"));
 #endif
           ResponseCmndChar("FailQueue");
           return;
         } else {
           // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
           char temp[40];
           sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3195,13 +3189,13 @@ void CmndBLEOperation(void){
         // this means you could retry with another BLEOp10.
         // it WOULD be deleted if you sent another BELOP1 <MAC>
 #ifdef BLE_ESP32_DEBUG
-        AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Could not queue new operation"));
+        AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Could not queue new operation"));
 #endif
         ResponseCmndChar("FailQueue");
       } else {
         // NOTE: prepOperation has been set to null if we queued sucessfully.
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: Operations queued:%d"), queuedOperations.size());
+        if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: Operations queued:%d"), queuedOperations.size());
 #endif
         char temp[40];
         sprintf(temp, "{\"opid\":%d,\"u\":%d}", lastopid-1, u);
@@ -3239,28 +3233,25 @@ static void BLEPostMQTTSeenDevices(int type) {
 
 static void BLEPostMQTT(bool onlycompleted) {
 //  if (TasmotaGlobal.ota_state_flag) return;
-
-
   if (prepOperation || mqttOperations.size() || queuedOperations.size() || currentOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: some to show"));
+    if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: some to show"));
 #endif
     if (prepOperation && !onlycompleted){
       std::string out = BLETriggerResponse(prepOperation);
       Response_P(PSTR("%s"), out.c_str());
       MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: prep sent %s"), out.c_str());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: prep sent %s"), out.c_str());
 #endif
     }
 
     if (queuedOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d"), queuedOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: queued %d"), queuedOperations.size());
 #endif
       for (int i = 0; i < queuedOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost1");
-
         generic_sensor_t *toSend = queuedOperations[i];
         if (!toSend) {
           break;
@@ -3270,7 +3261,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: queued %d sent %s"), i, out.c_str());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: queued %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3279,7 +3270,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (currentOperations.size() && !onlycompleted){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: current %d"), currentOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: current %d"), currentOperations.size());
 #endif
       for (int i = 0; i < currentOperations.size(); i++){
         TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEPost2");
@@ -3292,7 +3283,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           Response_P(PSTR("%s"), out.c_str());
           MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR("BLE"), Settings->flag.mqtt_sensor_retain);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: curr %d sent %s"), i, out.c_str());
+          if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: curr %d sent %s"), i, out.c_str());
 #endif
           //break;
         }
@@ -3301,7 +3292,7 @@ static void BLEPostMQTT(bool onlycompleted) {
 
     if (mqttOperations.size()){
 #ifdef BLE_ESP32_DEBUG
-      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: completed %d"), mqttOperations.size());
+      if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: completed %d"), mqttOperations.size());
 #endif
       do {
         generic_sensor_t *toSend = nextOperation(&mqttOperations);
@@ -3309,7 +3300,7 @@ static void BLEPostMQTT(bool onlycompleted) {
           break; // break from while loop
         } else {
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: mqttOperation removed opid %d"), toSend->opid);
 #endif
           std::string out = BLETriggerResponse(toSend);
           Response_P(PSTR("%s"), out.c_str());
@@ -3338,11 +3329,11 @@ static void mainThreadBLETimeouts() {
 
   if (BLEStop == 1){
     if (BLEStopAt + 30L*1000L*1000L < now){ // if asked to stop > 30s ago...
-      AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Stop Timeout - restart Tasmota"));
+      AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Stop Timeout - restart Tasmota"));
       BLERestartTasmota = 2;
       BLEStopAt = now;
     }
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Awaiting BLEStop"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Awaiting BLEStop"));
     return;
   }
 
@@ -3352,7 +3343,7 @@ static void mainThreadBLETimeouts() {
   if (BLEScanLastAdvertismentAt + adTimeout < now){
     BLEScanLastAdvertismentAt = now; // initialise the time of the last advertisment
     BLERestartNimBLE = 1;
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: scan stall? no adverts > 120s, restart BLE"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Scan stall? no adverts > 120s, restart BLE"));
 
     BLERestartBLEReason = BLE_RESTART_BLE_REASON_ADVERT_BLE_TIMEOUT;
   }
@@ -3363,7 +3354,7 @@ static void mainThreadBLETimeouts() {
   if (BLELastLoopTime + bleLoopTimeout < now){
     BLELastLoopTime = now; // initialise the time of the last advertisment
     BLERestartTasmota = 10;
-    AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: BLETask stall > 120s, restart Tasmota in 10s"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: BLETask stall > 120s, restart Tasmota in 10s"));
     BLERestartTasmotaReason = BLE_RESTART_TEAMOTA_REASON_BLE_LOOP_STALLED;
   }
 }
@@ -3371,7 +3362,7 @@ static void mainThreadBLETimeouts() {
 
 static void mainThreadOpCallbacks() {
   if (completedOperations.size()){
-    //AddLog(LOG_LEVEL_INFO,PSTR("BLE: completed %d"), completedOperations.size());
+    //AddLog(LOG_LEVEL_INFO, PSTR("BLE: completed %d"), completedOperations.size());
     TasAutoMutex localmutex(&BLEOperationsRecursiveMutex, "BLEMainCB");
 
     // find this operation in currentOperations, and remove it.
@@ -3381,22 +3372,22 @@ static void mainThreadOpCallbacks() {
 
       bool callbackres = false;
 
-      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
+      if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: op->completecallback is %u opid %d"), op->completecallback, op->opid);
       if (op->completecallback){
         OPCOMPLETE_CALLBACK *pFn = (OPCOMPLETE_CALLBACK *)(op->completecallback);
         callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: op->completecallback %d opid %d"), callbackres, op->opid);
 #endif
       }
 
       if (!callbackres){
         for (int i = 0; i < operationsCallbacks.size(); i++){
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: operationsCallbacks %d is %u"), i, operationsCallbacks[i]);
           OPCOMPLETE_CALLBACK *pFn = operationsCallbacks[i];
           callbackres = pFn(op);
 #ifdef BLE_ESP32_DEBUG
-          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
+          if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: operationsCallbacks %d %d"), i, callbackres);
 #endif
           if (callbackres){
             break; // this callback ate the op.
@@ -3412,7 +3403,7 @@ static void mainThreadOpCallbacks() {
         addOperation(&mqttOperations, &op);
       } else {
 #ifdef BLE_ESP32_DEBUG
-        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
+        if (BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("BLE: callbackres true -> delete op opid %d"), op->opid);
 #endif
         delete op;
       }
@@ -3461,7 +3452,7 @@ static void BLEDiag()
   uint32_t totalCount = BLEAdvertisment.totalCount;
   uint32_t deviceCount = seenDevices.size();
 #ifdef BLE_ESP32_DEBUG
-  if (BLEDebugMode) AddLog(LOG_LEVEL_INFO,PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
+  if (BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("BLE: scans:%u,advertisements:%u,devices:%u,resets:%u,BLEStop:%d,BLERunning:%d,BLERunningScan:%d,BLELoopCount:%u,BLEOpCount:%u"), BLEScanCount, totalCount, deviceCount, BLEResets, BLEStop, BLERunning, BLERunningScan, BLELoopCount, BLEOpCount);
 #endif
 }
 
@@ -3759,13 +3750,13 @@ int myAdvertCallback(BLE_ESP32::ble_advertisment_t *pStruct) {
 
 // this one is used to demonstrate processing ALL operations
 int myOpCallback(BLE_ESP32::generic_sensor_t *pStruct){
-  AddLog(LOG_LEVEL_INFO,PSTR("BLE: myOpCallback"));
+  AddLog(LOG_LEVEL_INFO, PSTR("BLE: myOpCallback"));
   return 0; // return true to block MQTT broadcast
 }
 
 // this one is used to demonstrate processing of ONE specific operation
 int myOpCallback2(BLE_ESP32::generic_sensor_t *pStruct){
-  AddLog(LOG_LEVEL_INFO,PSTR("BLE: myOpCallback2"));
+  AddLog(LOG_LEVEL_INFO, PSTR("BLE: myOpCallback2"));
   return 1; // return true to block MQTT broadcast
 }
 #endif
@@ -3788,7 +3779,7 @@ void sendExample(){
   BLE_ESP32::generic_sensor_t *op = nullptr;
   int res = BLE_ESP32::newOperation(&op);
   if (!res){
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Could not create new operation"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Could not create new operation"));
     return;
   }
   strncpy(op->MAC, "001A22092EE0", sizeof(op->MAC));
@@ -3803,7 +3794,7 @@ void sendExample(){
   if (!res){
     // if it fails to add to the queue, do please delete it
     BLE_ESP32::freeOperation(&op);
-    AddLog(LOG_LEVEL_ERROR,PSTR("BLE: Failed to queue new operation - deleted"));
+    AddLog(LOG_LEVEL_ERROR, PSTR("BLE: Failed to queue new operation - deleted"));
     return;
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -849,7 +849,7 @@ int TaskEQ3advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
   if (!found) return 0;
 
 #ifdef EQ3_DEBUG
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("EQ3: %s: saw device"),advertisedDevice->getAddress().toString().c_str());
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("EQ3: %s: saw device"),advertisedDevice->getAddress().toString().c_str());
 #endif
 
   uint8_t* payload = (uint8_t *)advertisedDevice->getPayload().data();

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -676,7 +676,7 @@ bool MI32Operation(int slot, int optype, const char *svc, const char *charactist
     AddLog(LOG_LEVEL_ERROR,PSTR("M32: Can't get a newOperation"));
     return 0;
   } else {
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: Got a newOperation"));
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: Got a newOperation"));
   }
 
   if (slot >= 0){
@@ -737,7 +737,7 @@ bool MI32Operation(int slot, int optype, const char *svc, const char *charactist
   uint32_t context = (optype << 24) | (MIBLEsensors[slot].type << 16) | slot;
   op->context = (void *)context;
 
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: MI s:%d op:%s"), slot, BLE_ESP32::BLETriggerResponse(op).c_str());
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: MI s:%d op:%s"), slot, BLE_ESP32::BLETriggerResponse(op).c_str());
 
   res = BLE_ESP32::extQueueOperation(&op);
   if (!res){
@@ -782,9 +782,9 @@ int genericBatReadFn(int slot){
       break;
   }
   if (res > 0){
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("M32: Req batt read slot %d type %d queued"), slot, MIBLEsensors[slot].type);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("M32: Req batt read slot %d type %d queued"), slot, MIBLEsensors[slot].type);
   } else {
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("M32: Req batt read slot %d type %d non-queued res %d"), slot, MIBLEsensors[slot].type, res);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("M32: Req batt read slot %d type %d non-queued res %d"), slot, MIBLEsensors[slot].type, res);
   }
   return res;
 }
@@ -840,7 +840,7 @@ int readOneSensor(){
     }
 
     res = genericSensorReadFn(MI32.sensorreader.slot, 0);
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: genericSensorReadFn slot %d res %d"), MI32.sensorreader.slot, res);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: genericSensorReadFn slot %d res %d"), MI32.sensorreader.slot, res);
 
     // if this sensor in this slot does not need to be read via notify, just move on top the next one
     if (res < 0){
@@ -861,7 +861,7 @@ int readOneSensor(){
   // and make it wait until the read/notify is complete
   // this is cleared in the response callback.
   MI32.sensorreader.active = 1;
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: readOneSensor reading for slot %d res %d"), MI32.sensorreader.slot-1, res);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: readOneSensor reading for slot %d res %d"), MI32.sensorreader.slot-1, res);
 
   // started one
   return 1;
@@ -884,7 +884,7 @@ int readOneBat(){
   if (res < 0){
     MI32.batteryreader.slot++;
     if (MI32.batteryreader.slot >= MIBLEsensors.size()){
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("M32: Batt loop complete at %d"), MI32.batteryreader.slot);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("M32: Batt loop complete at %d"), MI32.batteryreader.slot);
     }
     return 0;
   }
@@ -900,7 +900,7 @@ int readOneBat(){
   // this is cleared in the response callback.
   MI32.batteryreader.active = 1;
   if (MI32.batteryreader.slot >= MIBLEsensors.size()){
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_INFO, PSTR("M32: Batt loop will complete at %d"), MI32.batteryreader.slot);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("M32: Batt loop will complete at %d"), MI32.batteryreader.slot);
   }
   // started one
   return 1;
@@ -984,7 +984,7 @@ int genericTimeWriteFn(int slot){
 int genericOpCompleteFn(BLE_ESP32::generic_sensor_t *op){
   uint32_t context = (uint32_t) op->context;
 
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: MI op complete context %x"), context);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: MI op complete context %x"), context);
 
   int opType = context >> 24;
   int devType = (context >> 16) & 0xff;
@@ -1066,7 +1066,7 @@ int genericOpCompleteFn(BLE_ESP32::generic_sensor_t *op){
       // allow another...
       MI32.sensorreader.active = 0;
       MI32notifyHT_LY(slot, (char*)op->dataNotify, op->notifylen);
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: HT_LY notify complete"), slotMAC);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: HT_LY notify complete"), slotMAC);
     } return 0;
 
     default:
@@ -1116,14 +1116,14 @@ int MI32advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
   }
   uint16_t UUID = *(uint16_t*)UUIDBig.getValue();
 
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: svc[0] UUID (%x)"), MIaddrStr(addr), UUID);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: svc[0] UUID (%x)"), MIaddrStr(addr), UUID);
   std::string ServiceDataStr = advertisedDevice->getServiceData(0);
 
   uint32_t  ServiceDataLength = ServiceDataStr.length();
   const uint8_t *ServiceData = (const uint8_t *)ServiceDataStr.data();
   char temp[60];
   BLE_ESP32::dump(temp, 60, ServiceData, ServiceDataLength);
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: SrvData %s"), MIaddrStr(addr), temp);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: SrvData %s"), MIaddrStr(addr), temp);
 
   if (UUID){
     // this will take and keep the mutex until the function is over
@@ -1254,11 +1254,11 @@ int MIDecryptPayload(const uint8_t *macin, const uint8_t *nonce, uint32_t tag, u
   uint8_t _bindkey[32] = {0x0};
   const unsigned char authData[16] = {0x11};
   bool foundNoKey = true;
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: Searching key"), MIaddrStr(mac));
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: Searching key"), MIaddrStr(mac));
   for(uint32_t i = 0; i < MIBLEbindKeys.size(); i++){
     if(!memcmp(mac, MIBLEbindKeys[i].MAC, 6)){
       memcpy(_bindkey, MIBLEbindKeys[i].key, 16);
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: Decryption key found"), MIaddrStr(mac));
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: Decryption key found"), MIaddrStr(mac));
       foundNoKey = false;
       break;
     }
@@ -1285,7 +1285,7 @@ int MIDecryptPayload(const uint8_t *macin, const uint8_t *nonce, uint32_t tag, u
   // returns 1 if matched, else 0
   int ret = br_ccm_check_tag(&ctx, &tag) - 1;
 
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: %sDecrypted %02x %02x %02x %02x %02x %02x"), MIaddrStr(mac), ret ? PSTR("ERROR ") : PSTR(""), payload[0], payload[1], payload[2], payload[3], payload[4], payload[5]);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: %sDecrypted %02x %02x %02x %02x %02x %02x"), MIaddrStr(mac), ret ? PSTR("ERROR ") : PSTR(""), payload[0], payload[1], payload[2], payload[3], payload[4], payload[5]);
   return ret; // -> -1=fail, 0=success
 }
 
@@ -1357,7 +1357,7 @@ int MIParsePacket(const uint8_t* slotmac, struct mi_beacon_data_t *parsed, const
   parsed->devicetype = *((uint16_t *)(data + byteindex));
   byteindex += 2;
   parsed->framecnt = data[byteindex];
-  //if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: MI frame %d"), parsed->framecnt);
+  //AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: MI frame %d"), parsed->framecnt);
   byteindex++;
 
 
@@ -1407,7 +1407,7 @@ int MIParsePacket(const uint8_t* slotmac, struct mi_beacon_data_t *parsed, const
       break;
     case 0: // suceeded
       parsed->needkey = KEY_REQUIRED_AND_FOUND;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s: Payload decrypted"), MIaddrStr(slotmac));
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s: Payload decrypted"), MIaddrStr(slotmac));
       break;
     case -1: // key failed to work
       parsed->needkey = KEY_REQUIRED_AND_INVALID;
@@ -1452,7 +1452,7 @@ int MIParsePacket(const uint8_t* slotmac, struct mi_beacon_data_t *parsed, const
   }
 
   if ((len - byteindex) == 0){
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s: No payload"), MIaddrStr(slotmac));
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s: No payload"), MIaddrStr(slotmac));
     parsed->payload.size = 0;
     parsed->payloadpresent = 0;
     return 0;
@@ -1461,7 +1461,7 @@ int MIParsePacket(const uint8_t* slotmac, struct mi_beacon_data_t *parsed, const
   // we have payload which did not need decrypt.
   if (decres == 1){
     parsed->needkey = KEY_NOT_REQUIRED;
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s: Payload unencrypted"), MIaddrStr(slotmac));
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s: Payload unencrypted"), MIaddrStr(slotmac));
   }
 
   // already decrypted if required
@@ -1513,12 +1513,12 @@ uint32_t MIBLEgetSensorSlot(const uint8_t *mac, uint16_t _type, uint8_t counter,
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Counters: %x %x"),MIBLEsensors[i].lastCnt, counter);
       if(MIBLEsensors[i].lastCnt==counter) {
         // AddLog(LOG_LEVEL_DEBUG,PSTR("Old packet"));
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: Slot %u/[0-%u] - ign repeat"), MIaddrStr(mac), i, MIBLEsensors.size() - 1);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: Slot %u/[0-%u] - ign repeat"), MIaddrStr(mac), i, MIBLEsensors.size() - 1);
         if(ignoreDuplicate) return 0xff; // packet received before, stop here
       }
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: Frame %d, last %d"), MIaddrStr(mac), counter, MIBLEsensors[i].lastCnt);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: Frame %d, last %d"), MIaddrStr(mac), counter, MIBLEsensors[i].lastCnt);
       MIBLEsensors[i].lastCnt = counter;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: Slot %u/[0-%u]"), MIaddrStr(mac), i, MIBLEsensors.size() - 1);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: Slot %u/[0-%u]"), MIaddrStr(mac), i, MIBLEsensors.size() - 1);
 
       if (MIBLEsensors[i].type != _type){
         // this happens on incorrectly configured pvvx ATC firmware
@@ -1642,7 +1642,7 @@ void MI32StatusInfo() {
 
 int MI32scanCompleteCallback(NimBLEScanResults results){
   // we actually don't need to do anything here....
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Scan complete"));
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: Scan complete"));
   return 0;
 }
 
@@ -1707,7 +1707,7 @@ int MIParseBatt(int slot, uint8_t *data, int len){
     MIBLEsensors[slot].eventType.bat  = 1;
     MIBLEsensors[slot].shallSendMQTT = 1;
     MI32.mode.shallTriggerTele = 1;
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Batt read for %s complete %d"), slotMAC, value);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: Batt read for %s complete %d"), slotMAC, value);
   } else {
     AddLog(LOG_LEVEL_ERROR,PSTR("M32: Batt read for %s complete but out of range 1-101 (%d)"), slotMAC, value);
   }
@@ -1739,7 +1739,7 @@ void MI32ParseATCPacket(const uint8_t * _buf, uint32_t length, const uint8_t *ad
       if(_slot == 0xff) return;
 
       if ((_slot >= 0) && (_slot < MIBLEsensors.size())){
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s: %s:pvvx at slot %u"), MIaddrStr(addr), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s: %s:pvvx at slot %u"), MIaddrStr(addr), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
         MIBLEsensors[_slot].RSSI=RSSI;
         MIBLEsensors[_slot].needkey=KEY_NOT_REQUIRED;
 
@@ -1786,7 +1786,7 @@ void MI32ParseATCPacket(const uint8_t * _buf, uint32_t length, const uint8_t *ad
   if(_slot == 0xff) return;
 
   if ((_slot >= 0) && (_slot < MIBLEsensors.size())){
-    if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
     MIBLEsensors[_slot].RSSI=RSSI;
     MIBLEsensors[_slot].needkey=KEY_NOT_REQUIRED;
 
@@ -1816,7 +1816,7 @@ void MI32ParseCGDK2Packet(const uint8_t * _buf, uint32_t length, const uint8_t *
         if(_slot == 0xff) return;
 
         if ((_slot >= 0) && (_slot < MIBLEsensors.size())){
-          if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s:pvvx at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
+          AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s:pvvx at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
           MIBLEsensors[_slot].RSSI=RSSI;
           MIBLEsensors[_slot].needkey=KEY_NOT_REQUIRED;
           MIBLEsensors[_slot].temp = (float)(cgdk_packet->temperature)/10.0f;
@@ -1857,7 +1857,7 @@ void MI32ParseMiScalePacket(const uint8_t * _buf, uint32_t length, const uint8_t
     if (_slot == 0xff) return;
 
     if ((_slot >= 0) && (_slot < MIBLEsensors.size())) {
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
       MIBLEsensors[_slot].RSSI = RSSI;
       MIBLEsensors[_slot].needkey = KEY_NOT_REQUIRED;
       MIBLEsensors[_slot].eventType.scale = 1;
@@ -1897,7 +1897,7 @@ void MI32ParseMiScalePacket(const uint8_t * _buf, uint32_t length, const uint8_t
     if (_slot == 0xff) return;
 
     if ((_slot >= 0) && (_slot < MIBLEsensors.size())) {
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s: at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: %s: at slot %u"), kMI32DeviceType[MIBLEsensors[_slot].type-1], _slot);
       MIBLEsensors[_slot].RSSI = RSSI;
       MIBLEsensors[_slot].needkey = KEY_NOT_REQUIRED;
       MIBLEsensors[_slot].eventType.scale = 1;
@@ -1953,7 +1953,7 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
 
   char tmp[20];
   BLE_ESP32::dump(tmp, 20, (uint8_t*)&(parsed->payload), parsed->payload.size + 3);
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: slot %d, payload %s"), MIaddrStr(MIBLEsensors[_slot].MAC), _slot, tmp);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: slot %d, payload %s"), MIaddrStr(MIBLEsensors[_slot].MAC), _slot, tmp);
 
   // clear this for every payload
   MIBLEsensors[_slot].pairing = 0;
@@ -2005,9 +2005,9 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
         MIBLEsensors[_slot].temp=_tempFloat;
         MIBLEsensors[_slot].feature.temp = 1;
         MIBLEsensors[_slot].eventType.temp = 1;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 4: temp updated"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 4: temp updated"));
       } else {
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 4: temp ignored > 60 (%2_f)"), &_tempFloat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 4: temp ignored > 60 (%2_f)"), &_tempFloat);
       }
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Mode 4: U16:  %u Temp"), _beacon.temp );
     } break;
@@ -2018,9 +2018,9 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
         MIBLEsensors[_slot].hum=_tempFloat;
         MIBLEsensors[_slot].feature.hum = 1;
         MIBLEsensors[_slot].eventType.hum = 1;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 6: hum updated"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 6: hum updated"));
       } else {
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 6: hum ignored > 101 (%2_f)"), &_tempFloat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 6: hum ignored > 101 (%2_f)"), &_tempFloat);
       }
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Mode 6: U16:  %u Hum"), _beacon.hum);
     } break;
@@ -2037,14 +2037,14 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
       MIBLEsensors[_slot].moisture=pld->moist;
       MIBLEsensors[_slot].eventType.moist  = 1;
       MIBLEsensors[_slot].feature.moist = 1;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 8: moisture updated"));
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 8: moisture updated"));
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Mode 8: U8: %u Moisture"), _beacon.moist);
     break;
     case 0x1009: // 'conductivity' / 'Soil EC value'
       MIBLEsensors[_slot].fertility=pld->fert;
       MIBLEsensors[_slot].eventType.fert  = 1;
       MIBLEsensors[_slot].feature.fert = 1;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode 9: fertility updated"));
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode 9: fertility updated"));
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Mode 9: U16: %u Fertility"), _beacon.fert);
     break;
     case 0x100a:// 'Electricity'
@@ -2056,10 +2056,10 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
       }
       if (pld->bat < 101) {
         MIBLEsensors[_slot].bat = pld->bat;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: Mode a: bat updated (%d)"), MIaddrStr(MIBLEsensors[_slot].MAC), pld->bat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: Mode a: bat updated (%d)"), MIaddrStr(MIBLEsensors[_slot].MAC), pld->bat);
       } else {
         MIBLEsensors[_slot].bat = 100;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: Mode a: bat > 100 (%d)"), MIaddrStr(MIBLEsensors[_slot].MAC), pld->bat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: Mode a: bat > 100 (%d)"), MIaddrStr(MIBLEsensors[_slot].MAC), pld->bat);
       }
       MIBLEsensors[_slot].eventType.bat  = 1;
       MIBLEsensors[_slot].feature.bat = 1;
@@ -2071,16 +2071,16 @@ int MI32parseMiPayload(int _slot, struct mi_beacon_data_t *parsed){
       float _tempFloat=(float)(pld->HT.temp)/10.0f;
       if(_tempFloat < 60){
         MIBLEsensors[_slot].temp = _tempFloat;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode d: temp updated"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode d: temp updated"));
       } else {
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode d: temp ignored > 60 (%2_f)"), &_tempFloat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode d: temp ignored > 60 (%2_f)"), &_tempFloat);
       }
       _tempFloat=(float)(pld->HT.hum)/10.0f;
       if(_tempFloat < 100){
         MIBLEsensors[_slot].hum = _tempFloat;
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode d: hum updated"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode d: hum updated"));
       } else {
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: Mode d: hum ignored > 100 (%2_f)"), &_tempFloat);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: Mode d: hum ignored > 100 (%2_f)"), &_tempFloat);
       }
       MIBLEsensors[_slot].eventType.tempHum  = 1;
       // AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Mode d: U16:  %x Temp U16: %x Hum"), _beacon.HT.temp,  _beacon.HT.hum);
@@ -2256,7 +2256,7 @@ void MI32ParseResponse(const uint8_t *buf, uint16_t bufsize, const uint8_t* addr
     }
     MIBLEsensors[_slot].RSSI=RSSI;
     if (!res){ // - if the payload is not valid
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: MIParsePacket returned %d"), MIaddrStr(addr), res);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: MIParsePacket returned %d"), MIaddrStr(addr), res);
       return;
     }
     MI32parseMiPayload(_slot, &parsed);
@@ -2285,25 +2285,23 @@ void MI32removeMIBLEsensor(uint8_t* MAC){
 \***********************************************************************/
 
 void MI32notifyHT_LY(int _slot, char *_buf, int len){
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("M32: %s: Raw data %02x%02x%02x%02x%02x%02x%02x"),MIaddrStr(MIBLEsensors[_slot].MAC), _buf[0], _buf[1], _buf[2], _buf[3], _buf[4], _buf[5], _buf[6]);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE],PSTR("M32: %s: Raw data %02x%02x%02x%02x%02x%02x%02x"),MIaddrStr(MIBLEsensors[_slot].MAC), _buf[0], _buf[1], _buf[2], _buf[3], _buf[4], _buf[5], _buf[6]);
   // the value 0b00 is 28.16 C?
   if (_buf[0] || _buf[1]){
     memcpy(&LYWSD0x_HT, (void *)_buf, sizeof(LYWSD0x_HT));
-    if (BLE_ESP32::BLEDebugMode) {
-      AddLog(LOG_LEVEL_DEBUG, PSTR("M32: %s: T * 100: %u, H: %u, V: %u"), MIaddrStr(MIBLEsensors[_slot].MAC), LYWSD0x_HT.temp, LYWSD0x_HT.hum, LYWSD0x_HT.volt);
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: Sensor slot %u"), MIaddrStr(MIBLEsensors[_slot].MAC), _slot);
-    }
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: %s: T * 100: %u, H: %u, V: %u"), MIaddrStr(MIBLEsensors[_slot].MAC), LYWSD0x_HT.temp, LYWSD0x_HT.hum, LYWSD0x_HT.volt);
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: Sensor slot %u"), MIaddrStr(MIBLEsensors[_slot].MAC), _slot);
     static float _tempFloat;
     _tempFloat = (float)(LYWSD0x_HT.temp) / 100.0f;
     if(_tempFloat < 60){
       MIBLEsensors[_slot].temp = _tempFloat;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: LYWSD0x Temp updated %1_f"), MIaddrStr(MIBLEsensors[_slot].MAC), &MIBLEsensors[_slot].temp);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: LYWSD0x Temp updated %1_f"), MIaddrStr(MIBLEsensors[_slot].MAC), &MIBLEsensors[_slot].temp);
         // MIBLEsensors[_slot].showedUp=255; // this sensor is real
     }
     _tempFloat=(float)LYWSD0x_HT.hum;
     if(_tempFloat < 100){
       MIBLEsensors[_slot].hum = _tempFloat;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: LYWSD0x Hum updated %1_f"), MIaddrStr(MIBLEsensors[_slot].MAC), &MIBLEsensors[_slot].hum);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: LYWSD0x Hum updated %1_f"), MIaddrStr(MIBLEsensors[_slot].MAC), &MIBLEsensors[_slot].hum);
     }
     MIBLEsensors[_slot].eventType.tempHum  = 1;
     if (MIBLEsensors[_slot].type == MI_LYWSD02MMC || MIBLEsensors[_slot].type == MI_LYWSD02MMC2 || MIBLEsensors[_slot].type == MI_LYWSD03MMC || MIBLEsensors[_slot].type == MI_MHOC401){
@@ -2317,7 +2315,7 @@ void MI32notifyHT_LY(int _slot, char *_buf, int len){
       if (percent > 100) percent = 100;
 
       MIBLEsensors[_slot].bat = (int)percent;
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: %s: LYWSD0x Bat updated %d"), MIaddrStr(MIBLEsensors[_slot].MAC), MIBLEsensors[_slot].bat);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG_MORE], PSTR("M32: %s: LYWSD0x Bat updated %d"), MIaddrStr(MIBLEsensors[_slot].MAC), MIBLEsensors[_slot].bat);
       MIBLEsensors[_slot].eventType.bat  = 1;
     }
     if(MI32.option.directBridgeMode) {
@@ -2457,7 +2455,7 @@ void CmndMi32Time(void) {
     if (MIBLEsensors.size() > slot) {
       int res = genericTimeWriteFn(slot);
       if (res > 0){
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: will set Time"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: will set Time"));
         ResponseCmndNumber(slot);
         return;
       }
@@ -2497,7 +2495,7 @@ void CmndMi32Unit(void) {
       // TOGGLE unit?
       int res = genericUnitWriteFn(slot, -1);
       if (res > 0){
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG, PSTR("M32: will toggle Unit"));
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], PSTR("M32: will toggle Unit"));
         ResponseCmndNumber(slot);
         return;
       }
@@ -2675,7 +2673,7 @@ void MI32KeyListResp(){
 void CmndMi32Keys(void){
 #ifdef BLE_ESP32_ALIASES
   int op = XdrvMailbox.index;
-  if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Key %d %s"), op, XdrvMailbox.data);
+  AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: Key %d %s"), op, XdrvMailbox.data);
 
   int res = -1;
   switch(op){
@@ -2725,7 +2723,7 @@ void CmndMi32Keys(void){
       } while (p);
 
       if (added){
-        if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Added %d Keys"), added);
+        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: Added %d Keys"), added);
         MI32KeyListResp();
       } else {
         MI32KeyListResp();
@@ -2733,7 +2731,7 @@ void CmndMi32Keys(void){
       return;
     } break;
     case 2:{ // clear
-      if (BLE_ESP32::BLEDebugMode) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Keys clearing %d"), MIBLEbindKeys.size());
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG],PSTR("M32: Keys clearing %d"), MIBLEbindKeys.size());
       for (int i = MIBLEbindKeys.size()-1; i >= 0; i--){
         MIBLEbindKeys.pop_back();
       }


### PR DESCRIPTION
## Description:
Enhance `BLEDebug` command and adapt to common command syntax:
- `BLEDebug0` - show debug logging status
- `BLEDebug1 <loglevel>` - Set log level for errors - default 0 -> off
- `BLEDebug2 <loglevel>` - Set log level for infos - default 0 -> off
- `BLEDebug3 <loglevel>` - Set log level for debug - default 0 -> off
- `BLEDebug4 <loglevel>` - Set log level for more debug - default 0 -> off

(for all details compile with `#define BLE_ESP32_DEBUG` and `#define EQ3_DEBUG`)

Code cleanup without functional changes.
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).