### PR TITLE
Fix Zigbee multi-endpoint attribute suffix using insertion order inst…

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1757,7 +1757,11 @@ void Z_Data::toAttributes(Z_attribute_list & attr_list) const {
         case Zint32:  ival32 = *(int32_t*)attr_address;   if (ival32 != -0x80000000) data_size = -32; break;
       }
       if (data_size != 0) {
-        Z_attribute & attr = attr_list.addAttribute(conv_name);
+        // suffix by true endpoint (matching Z_postProcessAttributes' src_ep convention), not by
+        // insertion-order count - device.data isn't guaranteed to be in endpoint order, so the
+        // default count-based suffix can mislabel attributes on devices with non-ascending
+        // per-endpoint data (e.g. a 4-gang relay reporting endpoints out of order).
+        Z_attribute & attr = attr_list.addAttribute(conv_name, false, getEndpoint());
 
         float fval;
         if (data_size > 0) { fval = uval32; }


### PR DESCRIPTION
## Description:

Some Tuya Zigbee devices can report their endpoints out of order, for instance the Tuya TS0004 4-gang relay sometimes reports Config":["O02","O01","O03","O04"].

When data is received the endpoints are assumed to be in order so the generated json and rule events can report the wrong endpoint.

This fixes the mapping.

Verified on hardware: a Tuya TS0004 4-gang relay with a non-ascending Config list now reports all 4 endpoints under their correct suffix, with no regression on a naturally-ordered multi-endpoint device.

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
