### PR TITLE
Fix/dsi dma2d psram buffers

### DIFF
--- a/lib/lib_display/UDisplay/src/uDisplay_DSI_panel.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay_DSI_panel.cpp
@@ -10,6 +10,7 @@
 #include "esp_ldo_regulator.h"
 #include "driver/gpio.h"
 #include <rom/cache.h>
+#include "esp_rom_sys.h"
 
 extern void AddLog(uint32_t loglevel, const char* formatP, ...);
 
@@ -215,7 +216,25 @@ bool DSIPanel::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
 }
 
 bool DSIPanel::pushColors(uint16_t *data, uint32_t len, bool not_swapped) {
-    esp_err_t ret = esp_lcd_panel_draw_bitmap(panel_handle, window_x0, window_y0, window_x1, window_y1, data);
+    esp_err_t ret;
+    uint16_t retries = 0;
+    // esp_lcd_panel_draw_bitmap's DMA2D path takes the draw semaphore with a 0 timeout and
+    // returns ESP_ERR_INVALID_STATE (without drawing anything) if the previous async transfer
+    // hasn't completed yet - retry instead of silently dropping this chunk, which would leave
+    // stale framebuffer content on screen for that region. A ~60KB chunk transfer typically
+    // completes in well under 1ms, so poll in short bursts rather than in 1ms FreeRTOS ticks -
+    // the completion ISR isn't blocked by this busy-wait, so it doesn't delay noticing success.
+    const uint16_t max_retries = 300;
+    do {
+        ret = esp_lcd_panel_draw_bitmap(panel_handle, window_x0, window_y0, window_x1, window_y1, data);
+        if (ret == ESP_ERR_INVALID_STATE) {
+            esp_rom_delay_us(50);
+            retries++;
+        }
+    } while (ret == ESP_ERR_INVALID_STATE && retries < max_retries);
+    if (ret != ESP_OK) {
+        AddLog(3, "DSI: draw_bitmap failed after %d retries: %d", retries, ret);
+    }
     return (ret == ESP_OK);
 }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_54_lvgl.ino
@@ -95,21 +95,14 @@ void lv_flush_callback(lv_display_t *disp, const lv_area_t *area, uint8_t *color
   }
 
   uint32_t pixels_len = width * height;
-  uint32_t chrono_start = millis();
+  uint32_t chrono_start = micros();
   renderer->setAddrWindow(area->x1, area->y1, area->x1+width, area->y1+height);
   renderer->pushColors((uint16_t *)color_p, pixels_len, true);
   renderer->setAddrWindow(0,0,0,0);
   renderer->Updateframe();
-  uint32_t chrono_time = millis() - chrono_start;
 
   lv_disp_flush_ready(disp);
 
-  if (pixels_len >= 10000 && (!renderer->lvgl_param.use_dma)) {
-    if (HighestLogLevel() >= LOG_LEVEL_DEBUG_MORE) {
-      AddLog(LOG_LEVEL_DEBUG_MORE, D_LOG_LVGL "Refreshed %d pixels in %d ms (%i pix/ms)", pixels_len, chrono_time,
-              chrono_time > 0 ? pixels_len / chrono_time : -1);
-    }
-  }
   // if there is a display callback, call it
   if (lvgl_glue->paint_cb != nullptr) {
     lvgl_glue->paint_cb(area->x1, area->y1, area->x2, area->y2, color_p);
@@ -118,6 +111,13 @@ void lv_flush_callback(lv_display_t *disp, const lv_area_t *area, uint8_t *color
   // if there is a stream callback, process it
   if (lvgl_glue->stream_cb != nullptr) {
     lv_process_stream(area->x1, area->y1, width, height, (const uint16_t*)color_p, pixels_len);
+  }
+  uint32_t chrono_time = micros() - chrono_start;
+  if (pixels_len >= 10000) {
+    if (HighestLogLevel() >= LOG_LEVEL_DEBUG_MORE) {
+      AddLog(LOG_LEVEL_DEBUG_MORE, D_LOG_LVGL "Refreshed %d pixels in %d us (%i pix/ms)", pixels_len, chrono_time,
+              chrono_time > 0 ? (pixels_len * 1000 / chrono_time) : -1);
+    }
   }
 }
 
@@ -484,9 +484,9 @@ void start_lvgl(const char * uconfig) {
     if (renderer->lvgl_pars()->use_dma) {
       lvgl_buffer_size /= 2;
       if (lvgl_buffer_size < 1000000) {
-        // allocate preferably in internal memory which is faster than PSRAM
-        AddLog(LOG_LEVEL_DEBUG, "LVG: Allocating buffer2 %i bytes in main memory (flushlines %i)", (lvgl_buffer_size * (LV_COLOR_DEPTH / 8)) / 1024, flushlines);
-        lvgl_glue->lv_pixel_buf2 = heap_caps_malloc_prefer(lvgl_buffer_size * (LV_COLOR_DEPTH / 8), 2, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL, MALLOC_CAP_8BIT);
+        // allocate preferably in PSRAM to conserve internal memory, falling back to internal if PSRAM is unavailable
+        AddLog(LOG_LEVEL_DEBUG, "LVG: Allocating buffer2 %i bytes in PSRAM (flushlines %i)", (lvgl_buffer_size * (LV_COLOR_DEPTH / 8)) / 1024, flushlines);
+        lvgl_glue->lv_pixel_buf2 = heap_caps_malloc_prefer(lvgl_buffer_size * (LV_COLOR_DEPTH / 8), 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
       }
       if (!lvgl_glue->lv_pixel_buf2) {
         status_ok = false;
@@ -494,9 +494,9 @@ void start_lvgl(const char * uconfig) {
       }
     }
 
-    // allocate preferably in internal memory which is faster than PSRAM
-    AddLog(LOG_LEVEL_DEBUG, "LVG: Allocating buffer1 %i KB in main memory (flushlines %i)", (lvgl_buffer_size * (LV_COLOR_DEPTH / 8)) / 1024, flushlines);
-    lvgl_glue->lv_pixel_buf = heap_caps_malloc_prefer(lvgl_buffer_size * (LV_COLOR_DEPTH / 8), 2, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL, MALLOC_CAP_8BIT);
+    // allocate preferably in PSRAM to conserve internal memory, falling back to internal if PSRAM is unavailable
+    AddLog(LOG_LEVEL_DEBUG, "LVG: Allocating buffer1 %i KB in PSRAM (flushlines %i)", (lvgl_buffer_size * (LV_COLOR_DEPTH / 8)) / 1024, flushlines);
+    lvgl_glue->lv_pixel_buf = heap_caps_malloc_prefer(lvgl_buffer_size * (LV_COLOR_DEPTH / 8), 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
     if (!lvgl_glue->lv_pixel_buf) {
       status_ok = false;
       break;


### PR DESCRIPTION
## Description:

Higher resolution displays on DSI can end up consuming considerable amounts of RAM. By default these buffers live in IRAM. To reduce memory footprint you need to specify a relatively small flush lines buffer size (e.g :B,60,01 in display.ini). 
After a lot of testing I found that moving LVGL buffers to  PSRAM actually improves performance. As it turns out the CPU overhead of rendering a full screen refresh such as a page switch in small blocks is significant.  Although PSRAM is slow this is far outweighed by the reduced CPU cycles to render a page in one hit. Setting flush lines to the height of the screen and moving all buffers to PSRAM results in significantly reduced page draw times and saves a lot of IRAM. For my 1024x600 display this saving was ~120K.

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
