### PR TITLE
Matter: add remote devices via MQTT

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -188,6 +188,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_TCP_async.h"
 #include "solidify/solidified_Matter_HTTP_async.h"
 #include "solidify/solidified_Matter_HTTP_remote.h"
+#include "solidify/solidified_Matter_MQTT_remote.h"
 #include "solidify/solidified_Matter_Expirable.h"
 #include "solidify/solidified_Matter_Fabric.h"
 #include "solidify/solidified_Matter_Session.h"
@@ -399,6 +400,7 @@ module matter (scope: global, strings: weak) {
   TCP_async, class(be_class_Matter_TCP_async)
   HTTP_async, class(be_class_Matter_HTTP_async)
   HTTP_remote, class(be_class_Matter_HTTP_remote)
+  MQTT_remote, class(be_class_Matter_MQTT_remote)
 
   // Expirable
   Expirable, class(be_class_Matter_Expirable)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MQTT_remote.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MQTT_remote.be
@@ -1,0 +1,543 @@
+#
+# Matter_MQTT_remote.be - implements an interface to query remotely Tasmota device via MQTT
+#
+# Copyright (C) 2024  Stephan Hadinger, Christian Baars & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import matter
+
+#@ solidify:Matter_MQTT_remote,weak
+
+#############################################################
+# This class implements the MQTT transport for remote Tasmota devices.
+#
+# Subscriptions (4 total, per-device):
+#   - tele/<topic>/STATE             - full state (TelePeriod, default 300s)
+#   - tele/<topic>/SENSOR            - sensor data
+#   - tele/<topic>/LWT               - online/offline status
+#   - stat/<topic>/RESULT            - immediate command feedback
+#
+# Publishes:
+#   - cmnd/<topic>/<Command>         - send commands to remote device
+#
+# Design principles:
+#   - Subscribe-only, no polling
+#   - Discovery handled globally by Matter_Device (not per-remote)
+#   - Cached state for optimistic updates
+#   - LWT handling for reachability
+
+class Matter_MQTT_remote
+  var device                                        # reference to matter_device
+  var topic                                         # MQTT topic of the remote device
+  var reachable                                     # is the device reachable
+  var reachable_utc                                 # last tick when reachability was seen
+  var info                                          # map with name, version, mac, hardware
+  var cached_state                                  # cached state from RESULT/STATE
+  var subscribed                                    # list of subscribed topics for cleanup
+  var cmnd_base                                     # expanded MQTT command topic base
+  var stat_base                                     # expanded MQTT status topic base
+  var tele_base                                     # expanded MQTT telemetry topic base
+  var confirmed                                     # true after a live command response in the current epoch
+  var refresh_pending                               # true while a post-connect refresh is scheduled
+  var refresh_phase                                 # 0=idle, 1=StatusRetain probe, 2=Status10/11
+  var refresh_status                                # bit 0=Status10, bit 1=Status11 received live
+  var active                                        # false once close() has been called
+
+  #############################################################
+  # init
+  def init(device, topic, info)
+    self.device = device
+    self.topic = topic
+    self.reachable = false
+    self.reachable_utc = nil
+    self.info = info ? info : {}
+    self.cached_state = {}
+    self.subscribed = []
+    self.confirmed = false
+    self.refresh_pending = false
+    self.refresh_phase = 0
+    self.refresh_status = 0
+    self.active = true
+
+    self.configure_topics()
+    self.subscribe_topics()
+
+    import mqtt
+    if mqtt.connected()
+      self.schedule_refresh()
+    end
+  end
+
+  #############################################################
+  # topic_base
+  #
+  # Expand a discovery FullTopic for command (0), stat (1) or tele (2).
+  def topic_base(prefix_index)
+    import string
+    var fulltopic = self.info.find("_ft", "%prefix%/%topic%/")
+    var prefixes = self.info.find("_tp", ["cmnd", "stat", "tele"])
+    var prefix = prefixes[prefix_index]
+
+    # Tasmota appends %prefix% for commands if FullTopic does not contain it.
+    if prefix_index == 0 && string.find(fulltopic, "%prefix%") < 0
+      if fulltopic[-1] != '/'   fulltopic += '/'   end
+      fulltopic += "%prefix%"
+    end
+
+    fulltopic = string.replace(fulltopic, "%prefix%", prefix)
+    fulltopic = string.replace(fulltopic, "%topic%", self.topic)
+    fulltopic = string.replace(fulltopic, "%hostname%", self.info.find("_hn", ""))
+    fulltopic = string.replace(fulltopic, "%id%", self.info.find("_id", ""))
+    fulltopic = string.replace(fulltopic, "#", "")
+    while string.find(fulltopic, "//") >= 0
+      fulltopic = string.replace(fulltopic, "//", "/")
+    end
+    if fulltopic[-1] != '/'   fulltopic += '/'   end
+    return fulltopic
+  end
+
+  def configure_topics()
+    self.cmnd_base = self.topic_base(0)
+    self.stat_base = self.topic_base(1)
+    self.tele_base = self.topic_base(2)
+  end
+
+  #############################################################
+  # subscribe_topics
+  #
+  # Subscribe to all relevant MQTT topics
+  def subscribe_topics()
+    # tele topics
+    self.subscribe(self.tele_base + "STATE", / topic, idx, data, databytes -> self.handle_mqtt_state(data))
+    self.subscribe(self.tele_base + "SENSOR", / topic, idx, data, databytes -> self.handle_mqtt_sensor(data))
+    self.subscribe(self.tele_base + "LWT", / topic, idx, data, databytes -> self.handle_mqtt_lwt(data))
+
+    # RESULT with SetOption4 disabled, command-specific topics when enabled,
+    # and STATUS10/STATUS11 responses used to establish a fresh epoch.
+    self.subscribe(self.stat_base + "+", / topic, idx, data, databytes -> self.handle_mqtt_stat(topic, data))
+  end
+
+  #############################################################
+  # subscribe helper
+  #
+  # Subscribe to a topic and track it for cleanup
+  def subscribe(topic, closure)
+    import mqtt
+    mqtt.subscribe(topic, closure)
+    self.subscribed.push(topic)
+  end
+
+  #############################################################
+  # unsubscribe helper
+  #
+  # Unsubscribe from a specific topic
+  def unsubscribe(topic)
+    import mqtt
+    mqtt.unsubscribe(topic)
+    self.subscribed.remove(topic)
+  end
+
+  #############################################################
+  # discovery_info
+  #
+  # Convert Tasmota discovery fields to the canonical remote info map
+  static def discovery_info(config)
+    var info = {}
+    var value = config.find("dn")
+    if value != nil   info['name'] = value       end
+    value = config.find("sw")
+    if value != nil   info['version'] = value    end
+    value = config.find("mac")
+    if value != nil   info['mac'] = value        end
+    value = config.find("md")
+    if value != nil   info['hardware'] = value   end
+    value = config.find("ft")
+    if value != nil   info['_ft'] = value        end
+    value = config.find("tp")
+    if value != nil   info['_tp'] = value        end
+    value = config.find("hn")
+    if value != nil   info['_hn'] = value        end
+    value = config.find("mac")
+    if value != nil   info['_id'] = value        end
+    return info
+  end
+
+  # Update remote metadata from discovery, returning true only on change
+  def set_info_from_discovery(config)
+    var info = self.discovery_info(config)
+    if size(self.info) == size(info)
+      var same = true
+      for key: info.keys()
+        if self.info.find(key) != info[key]   same = false  break   end
+      end
+      if same   return false   end
+    end
+
+    var old_cmnd = self.cmnd_base
+    var old_stat = self.stat_base
+    var old_tele = self.tele_base
+    self.info = info
+    self.configure_topics()
+    if old_cmnd != self.cmnd_base || old_stat != self.stat_base || old_tele != self.tele_base
+      import mqtt
+      for topic: self.subscribed
+        mqtt.unsubscribe(topic)
+      end
+      self.subscribed = []
+      self.subscribe_topics()
+      self.begin_epoch(true)
+    end
+    return true
+  end
+
+  #############################################################
+  # generate_config_from_discovery
+  #
+  # Auto-generate endpoint configuration from discovery config and sensors
+  # Similar to Matter_UI.generate_config_from_status() but uses discovery data
+  static def generate_config_from_discovery(device, config, sensors)
+    var config_list = []
+
+    # rl entries are: 0=unused, 1=relay, 2=light, 3=shutter
+    var rl = config.find("rl")
+    if rl != nil && size(rl) > 0
+      var lt_st = config.find("lt_st", 0)
+      var so = config.find("so", {})
+      var pwm_multi = bool(so.find("68", 0))
+      for i: 0 .. size(rl) - 1
+        var relay_type = rl[i]
+        if relay_type == 1
+          config_list.push({'type': 'light0', 'relay': i + 1})
+        elif relay_type == 2
+          var light_type = 'light0'
+          if pwm_multi || lt_st == 1
+            light_type = 'light1'
+          elif lt_st == 2
+            light_type = 'light2'
+          elif lt_st >= 3
+            # RGB, RGBW and RGBCW all expose the Matter extended-color features
+            light_type = 'light3'
+          end
+          config_list.push({'type': light_type, 'relay': i + 1})
+        elif relay_type == 3
+          # No remote shutter bridge plug-in exists; never expose its relays as switches.
+          log(f"MTR: MQTT discovery skipping unsupported shutter relay {i + 1}", 3)
+        end
+      end
+    end
+
+    if sensors != nil
+      config_list += device.autoconf.autoconf_sensors_list(sensors.find("sn", {}))
+    end
+
+    return config_list
+  end
+
+  #############################################################
+  # handle_mqtt_state
+  #
+  # Handle tele/<topic>/STATE messages
+  # This is the full state published every TelePeriod
+  def handle_mqtt_state(data)
+    if data == nil || !self.confirmed   return   end
+
+    var j = data
+    if type(j) == 'string'
+      import json
+      j = json.load(j)
+    end
+
+    if j != nil
+      # mark device as alive
+      self.device_is_alive(true)
+
+      # merge into cached state
+      self.merge_state(j)
+
+      # dispatch to any registered callbacks
+      self.dispatch_cb(11, j)
+
+      log(f"MTR: MQTT STATE received from {self.topic}: {data}", 3)
+    end
+  end
+
+  #############################################################
+  # handle_mqtt_sensor
+  #
+  # Handle tele/<topic>/SENSOR messages
+  def handle_mqtt_sensor(data)
+    if data == nil || !self.confirmed   return   end
+
+    var j = data
+    if type(j) == 'string'
+      import json
+      j = json.load(j)
+    end
+
+    if j != nil
+      # mark device as alive
+      self.device_is_alive(true)
+
+      # merge into cached state
+      self.merge_state(j)
+
+      # dispatch to any registered callbacks
+      self.dispatch_cb(10, j)
+
+      log(f"MTR: MQTT SENSOR received from {self.topic}: {data}", 3)
+    end
+  end
+
+  #############################################################
+  # handle_mqtt_lwt
+  #
+  # Handle tele/<topic>/LWT messages
+  # "Online" or "Offline"
+  def handle_mqtt_lwt(data)
+    if data == nil   return   end
+
+    if data == "Online"
+      self.begin_epoch(true)
+      log(f"MTR: MQTT device {self.topic} came online", 3)
+    elif data == "Offline"
+      self.begin_epoch(false)
+      log(f"MTR: MQTT device {self.topic} went offline", 3)
+    end
+  end
+
+  #############################################################
+  # handle_mqtt_stat
+  #
+  # Handle RESULT, STATUS10/11 and SetOption4 command-specific responses.
+  def handle_mqtt_stat(topic, data)
+    if data == nil   return   end
+
+    var j = data
+    if type(j) == 'string'
+      # SetOption4 POWER topics may also carry a raw ON/OFF payload.
+      if size(j) == 0 || j[0] != '{'   return   end
+      import json
+      j = json.load(j)
+    end
+
+    if j == nil || !isinstance(j, map)   return   end
+
+    if !self.confirmed
+      # STATUS10/11 themselves may be retained. First require the ordinary,
+      # non-retained response to our StatusRetain query before accepting them.
+      if self.refresh_phase == 1
+        if !j.contains("StatusRetain")   return   end
+        self.refresh_phase = 2
+        import mqtt
+        mqtt.publish(self.cmnd_base + "Status", "10")
+        mqtt.publish(self.cmnd_base + "Status", "11")
+        return
+      elif self.refresh_phase == 2
+        if j.contains("StatusSNS")
+          var payload = j["StatusSNS"]
+          self.merge_state(payload)
+          self.dispatch_cb(10, payload)
+          self.refresh_status |= 1
+        elif j.contains("StatusSTS")
+          var payload = j["StatusSTS"]
+          self.merge_state(payload)
+          self.dispatch_cb(11, payload)
+          self.refresh_status |= 2
+        else
+          return
+        end
+        if self.refresh_status == 3
+          self.confirmed = true
+          self.refresh_phase = 0
+          self.device_is_alive(true)
+        end
+        return
+      else
+        return
+      end
+    end
+
+    self.device_is_alive(true)
+
+    if j.contains("StatusSNS")
+      var payload = j["StatusSNS"]
+      self.merge_state(payload)
+      self.dispatch_cb(10, payload)
+    elif j.contains("StatusSTS")
+      var payload = j["StatusSTS"]
+      self.merge_state(payload)
+      self.dispatch_cb(11, payload)
+    else
+      # Command responses are often partial; dispatch the merged snapshot so
+      # unrelated endpoints retain their last known fields within this epoch.
+      self.merge_state(j)
+      self.dispatch_cb(11, self.cached_state)
+    end
+
+    log(f"MTR: MQTT stat received from {self.topic}: {data}", 3)
+  end
+
+  #############################################################
+  # merge_state
+  #
+  # Merge new state into cached_state
+  def merge_state(new_state)
+    for k: new_state.keys()
+      self.cached_state[k] = new_state[k]
+    end
+  end
+
+  #############################################################
+  # get/set remote_info map
+  def get_info()      return self.info                    end
+  def set_info(v)     self.info = v                       end
+  def info_changed()  self.device.save_param()            end
+
+  #############################################################
+  # device is alive, update reachable_utc
+  def device_is_alive(alive)
+    var changed = self.reachable != alive
+    if alive
+      self.reachable = true
+      self.reachable_utc = tasmota.rtc_utc()
+    else
+      self.reachable = false
+    end
+    if changed
+      self.device.mqtt_reachable_changed(self)
+    end
+  end
+
+  #############################################################
+  # Start a new remote freshness epoch.
+  def begin_epoch(refresh)
+    self.confirmed = false
+    self.cached_state = {}
+    self.refresh_phase = 0
+    self.refresh_status = 0
+    self.device_is_alive(false)
+    if refresh   self.schedule_refresh()   end
+  end
+
+  def mqtt_connected()
+    self.begin_epoch(true)
+  end
+
+  def mqtt_disconnected()
+    self.begin_epoch(false)
+  end
+
+  def schedule_refresh()
+    if !self.active || self.refresh_pending   return   end
+    self.refresh_pending = true
+    tasmota.set_timer(100, / -> self.refresh_state())
+  end
+
+  def refresh_state()
+    self.refresh_pending = false
+    if !self.active   return   end
+    import mqtt
+    if !mqtt.connected()   return   end
+    self.refresh_phase = 1
+    self.refresh_status = 0
+    mqtt.publish(self.cmnd_base + "StatusRetain", "")
+    log(f"MTR: MQTT freshness probe requested from {self.topic}", 3)
+  end
+
+  def can_send()
+    import mqtt
+    return mqtt.connected() && self.confirmed && self.reachable
+  end
+
+  #############################################################
+  # call_sync
+  #
+  # Synchronous (non-blocking for MQTT)
+  # Returns nil - actual state update comes via RESULT subscription
+  def call_sync(cmd, timeout)
+    import mqtt
+    import string
+    if !self.can_send()   return nil   end
+    # publish command via MQTT
+    var space_idx = string.find(cmd, " ")
+    var cmnd_topic = self.cmnd_base
+    var payload = ""
+    if space_idx > 0
+      cmnd_topic += cmd[0 .. space_idx - 1]
+      payload = cmd[space_idx + 1 ..]
+    else
+      cmnd_topic += cmd
+    end
+    mqtt.publish(cmnd_topic, payload)
+    log(f"MTR: MQTT command sent to {self.topic}: {cmnd_topic} payload='{payload}'", 3)
+
+    # return nil - actual state update comes via RESULT subscription
+    return nil
+  end
+
+  #############################################################
+  # dispatch_cb
+  #
+  # Dispatch status response to registered callbacks
+  var async_cb_map
+
+  def add_async_cb(cb, cmd)
+    if self.async_cb_map == nil    self.async_cb_map = {}    end
+    self.async_cb_map[cb] = cmd
+  end
+
+  def dispatch_cb(status, payload)
+    if self.async_cb_map == nil    return    end
+    for cb: self.async_cb_map.keys()
+      var cmd_filter = self.async_cb_map[cb]
+      if cmd_filter == nil || cmd_filter == status
+        cb(status, payload, nil)
+      end
+    end
+  end
+
+  #############################################################
+  # web_last_seen
+  #
+  # Show when the device was last seen
+  def web_last_seen()
+    var seconds = -1                      # default if no known value
+    if self.reachable_utc != nil
+      seconds = tasmota.rtc_utc() - self.reachable_utc
+    end
+    return matter.seconds_to_dhm(seconds)
+  end
+
+  #############################################################
+  # close
+  #
+  # Unsubscribe from all topics and clean up
+  def close()
+    import mqtt
+    self.active = false
+    for topic: self.subscribed
+      mqtt.unsubscribe(topic)
+      log(f"MTR: MQTT unsubscribed from {topic}", 3)
+    end
+    self.subscribed = []
+    self.reachable = false
+    self.cached_state = {}
+    self.info = {}
+    self.async_cb_map = nil
+    log(f"MTR: MQTT remote {self.topic} closed", 3)
+  end
+end
+matter.MQTT_remote = Matter_MQTT_remote

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_1_Device.be
@@ -132,6 +132,7 @@ class Matter_Plugin_Device : Matter_Plugin
   static var SYNC_TIMEOUT = 500                     # timeout of 700 ms for probing
 
   var http_remote                                   # instance of Matter_HTTP_remote
+  var mqtt_remote                                   # instance of Matter_MQTT_remote
 
   # clusters for general devices
   static var CLUSTERS  = matter.consolidate_clusters(_class, {
@@ -162,8 +163,15 @@ class Matter_Plugin_Device : Matter_Plugin
     super(self).init(device, endpoint, arguments)
 
     if self.BRIDGE
-      var addr = arguments.find(self.ARG_HTTP)
-      self.http_remote = self.device.register_http_remote(addr, self.PROBE_TIMEOUT)
+      var topic = arguments.find("topic")
+      if topic
+        # MQTT bridge mode
+        self.mqtt_remote = self.device.register_mqtt_remote(topic)
+      else
+        # HTTP bridge mode (default)
+        var addr = arguments.find(self.ARG_HTTP)
+        self.http_remote = self.device.register_http_remote(addr, self.PROBE_TIMEOUT)
+      end
       self.register_cmd_cb()
     end
   end
@@ -250,7 +258,8 @@ class Matter_Plugin_Device : Matter_Plugin
 
       if   attribute == 0x0003          #  ---------- ProductName / string (not nullable) ----------
         if self.BRIDGE
-          var name = self.http_remote.get_info().find("name", "")
+          var remote = self.mqtt_remote ? self.mqtt_remote : self.http_remote
+          var name = remote ? remote.get_info().find("name", "") : ""
           return tlv_solo.set(0x0C #-TLV.UTF1-#, name)
         else
           return tlv_solo.set(0x0C #-TLV.UTF1-#, tasmota.cmd("DeviceName", true)['DeviceName'])
@@ -259,7 +268,8 @@ class Matter_Plugin_Device : Matter_Plugin
         return tlv_solo.set(0x0C #-TLV.UTF1-#, self.get_name())
       elif attribute == 0x000A          #  ---------- SoftwareVersionString / string (not nullable) ----------
         if self.BRIDGE
-          var version_full = self.http_remote.get_info().find("version")
+          var remote = self.mqtt_remote ? self.mqtt_remote : self.http_remote
+          var version_full = remote ? remote.get_info().find("version") : nil
           if version_full
             var version_end = string.find(version_full, '(')
             if version_end > 0    version_full = version_full[0..version_end - 1]   end
@@ -275,14 +285,17 @@ class Matter_Plugin_Device : Matter_Plugin
         end
       elif attribute == 0x000F || attribute == 0x0012          #  ---------- SerialNumber / UniqueID / string (not nullable) ----------
         if self.BRIDGE
-          var mac = self.http_remote.get_info().find("mac", "")
+          var remote = self.mqtt_remote ? self.mqtt_remote : self.http_remote
+          var mac = remote ? remote.get_info().find("mac", "") : ""
           return tlv_solo.set(0x0C #-TLV.UTF1-#, mac)
         else
           return tlv_solo.set(0x0C #-TLV.UTF1-#, tasmota.wifi().find("mac", ""))
         end
       elif attribute == 0x0011          #  ---------- Reachable / bool ----------
         if self.BRIDGE
-          return tlv_solo.set(0x08 #-TLV.BOOL-#, self.http_remote.reachable)     # TODO find a way to do a ping
+          var remote = self.mqtt_remote ? self.mqtt_remote : self.http_remote
+          var reachable = remote ? remote.reachable : false
+          return tlv_solo.set(0x08 #-TLV.BOOL-#, reachable)
         else
           return tlv_solo.set(0x08 #-TLV.BOOL-#, 1)     # by default we are reachable
         end
@@ -398,12 +411,30 @@ class Matter_Plugin_Device : Matter_Plugin
   #############################################################
   # For Bridge devices
   #############################################################
+  # Return false and set a Matter failure when an MQTT command cannot be sent.
+  def mqtt_command_ready(ctx)
+    if self.mqtt_remote && !self.mqtt_remote.can_send()
+      ctx.status = 0x01 #-matter.FAILURE-#
+      return false
+    end
+    return true
+  end
+
   #############################################################
   # register_cmd_cb
   #
   # Register recurrent command and callback
   # Defined as a separate method to allow override
   def register_cmd_cb()
+    # MQTT bridge mode - register callbacks for state updates via subscriptions
+    if self.mqtt_remote
+      # Register parse_status as callback for all status codes
+      # Status 0=Status, 2=StatusFWR, 5=StatusNET, 10=StatusSNS, 11=StatusSTS
+      self.mqtt_remote.add_async_cb(/ status,payload,cmd -> self.parse_status(payload, status), nil)
+      return
+    end
+
+    # HTTP bridge mode
     self.http_remote.add_schedule(self.UPDATE_CMD, self.UPDATE_TIME,
                                   / status,payload,cmd -> self.parse_http_response(status,payload,cmd))
   end
@@ -415,6 +446,13 @@ class Matter_Plugin_Device : Matter_Plugin
   # and call `parse_status(<data>, <index>)` when data is available.
   def update_shadow()
     if self.BRIDGE && self.tick != self.device.tick     # don't force an update if we just received it
+      # MQTT bridge mode - no polling, state updates come via subscriptions
+      if self.mqtt_remote
+        self.tick = self.device.tick
+        return
+      end
+
+      # HTTP bridge mode
       var ret = self.call_remote_sync(self.UPDATE_CMD)
       if ret
         self.parse_http_response(1, ret, self.UPDATE_CMD)
@@ -442,6 +480,14 @@ class Matter_Plugin_Device : Matter_Plugin
 
       var retry = 2         # try 2 times if first failed
       if arg != nil     cmd = cmd + ' ' + str(arg)      end
+
+      # MQTT bridge mode - return cached state
+      if self.mqtt_remote
+        var ret = self.mqtt_remote.call_sync(cmd, self.SYNC_TIMEOUT)
+        return ret
+      end
+
+      # HTTP bridge mode
       while retry > 0
         var ret = self.http_remote.call_sync(cmd, self.SYNC_TIMEOUT)
         if ret != nil
@@ -466,7 +512,7 @@ class Matter_Plugin_Device : Matter_Plugin
   #     `Status 11`: {"StatusSTS":{ [...] }}
   #     `Status 13`: {"StatusSHT":{ [...] }}
   def parse_http_response(status, payload, cmd)
-    if self.BRIDGE
+    if self.BRIDGE && self.http_remote
       self.tick = self.device.tick        # avoid new force update in same tick
       self.http_remote.parse_status_response_and_call_method(status, payload, cmd, self, self.parse_status)
     end
@@ -478,9 +524,15 @@ class Matter_Plugin_Device : Matter_Plugin
   # check if the timer expired and update_shadow() needs to be called
   def every_250ms()
     if self.BRIDGE
+      # MQTT bridge mode - no polling needed
+      if self.mqtt_remote
+        return
+      end
+
+      # HTTP bridge mode
       self.http_remote.scheduler()          # defer to HTTP scheduler
       # avoid calling update_shadow() since it's not applicable for HTTP remote
-  else
+    else
       super(self).every_250ms()
     end
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Light0.be
@@ -243,6 +243,7 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
 
     # ====================================================================================================
     if   cluster == 0x0006              # ========== On/Off 1.5 p.48 ==========
+      if !self.mqtt_command_ready(ctx)   return nil   end
       self.update_shadow_lazy()
       if   command == 0x0000            # ---------- Off ----------
         self.set_onoff(false)
@@ -328,13 +329,13 @@ class Matter_Plugin_Light0 : Matter_Plugin_Device
   # This call is synnchronous and blocking.
   def parse_status(data, index)
     if index == 11                              # Status 11
-      var state = false
+      var power_key = "POWER" + str(self.tasmota_relay_index)
 
       if self.tasmota_relay_index == 1 && data.contains("POWER")        # special case, can be `POWER` or `POWER1`
-        state = (data.find("POWER") == "ON")
-      else
-        state = (data.find("POWER" + str(self.tasmota_relay_index)) == "ON")
+        power_key = "POWER"
       end
+      if !data.contains(power_key)   return   end
+      var state = (data.find(power_key) == "ON")
 
       if self.shadow_onoff != bool(state)
         self.attribute_updated(0x0006, 0x0000)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor.be
@@ -103,7 +103,9 @@ class Matter_Plugin_Sensor : Matter_Plugin_Device
   # arguments: (map) the map for all complementary arguments that are plugin specific
   def init(device, endpoint, config)
     super(self).init(device, endpoint, config)
-    device.add_read_sensors_schedule(self.UPDATE_TIME)
+    if !self.BRIDGE
+      device.add_read_sensors_schedule(self.UPDATE_TIME)
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Air_Quality.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Air_Quality.be
@@ -201,7 +201,9 @@ class Matter_Plugin_Sensor_Air_Quality : Matter_Plugin_Device
   def init(device, endpoint, config)
     super(self).init(device, endpoint, config)
     self.shadow_air_quality = 0
-    device.add_read_sensors_schedule(self.UPDATE_TIME)
+    if !self.BRIDGE
+      device.add_read_sensors_schedule(self.UPDATE_TIME)
+    end
   end
 
   #############################################################

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Boolean.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Sensor_Boolean.be
@@ -128,7 +128,7 @@ class Matter_Plugin_Sensor_Boolean : Matter_Plugin_Device
   #
   def update_shadow()
     super(self).update_shadow()
-    if !self.VIRTUAL
+    if !self.VIRTUAL && !self.mqtt_remote
       var switch_str = "Switch" + str(self.tasmota_switch_index)
 
       var j = tasmota.cmd("Status 10", true)
@@ -171,9 +171,9 @@ class Matter_Plugin_Sensor_Boolean : Matter_Plugin_Device
   # This call is synnchronous and blocking.
   def parse_status(data, index)
     if index == 10                             # Status 10
-      var state = false
-
-      state = (data.find("Switch" + str(self.tasmota_switch_index)) == "ON")
+      var switch_key = "Switch" + str(self.tasmota_switch_index)
+      if !data.contains(switch_key)   return   end
+      var state = (data.find(switch_key) == "ON")
 
       if self.shadow_bool_value != nil && self.shadow_bool_value != bool(state)
         self.value_updated()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Shutter.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_2_Shutter.be
@@ -198,7 +198,7 @@ class Matter_Plugin_Shutter : Matter_Plugin_Device
   # Update shadow
   #
   def update_shadow()
-    if !self.VIRTUAL
+    if !self.VIRTUAL && !self.BRIDGE
       self.update_inverted()
       var sp = tasmota.cmd("ShutterPosition" + str(self.tasmota_shutter_index + 1), true)
       if sp

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Light1.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Light1.be
@@ -300,6 +300,7 @@ class Matter_Plugin_Light1 : Matter_Plugin_Light0
 
     # ====================================================================================================
     if   cluster == 0x0008              # ========== Level Control 1.6 p.57 ==========
+      if !self.mqtt_command_ready(ctx)   return nil   end
       self.update_shadow_lazy()
       if   command == 0x0000            # ---------- MoveToLevel ----------
         var bri_254 = val.findsubval(0)  # Hue 0..254

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Temp.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_3_Sensor_Temp.be
@@ -111,7 +111,7 @@ class Matter_Plugin_Sensor_Temp : Matter_Plugin_Sensor
   # This allows to convert the raw sensor value to the target one, typically int
   def pre_value(val)
     # TODO simplify
-    if self.BRIDGE
+    if self.BRIDGE || self.mqtt_remote
       if self.temp_unit == self.TEMP_F          # Fahrenheit
         val = (val - 32) / 1.8
       end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light2.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light2.be
@@ -250,6 +250,7 @@ class Matter_Plugin_Light2 : Matter_Plugin_Light1
 
     # ====================================================================================================
     if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
+      if !self.mqtt_command_ready(ctx)   return nil   end
       self.update_shadow_lazy()
       if   command == 0x000A            # ---------- MoveToColorTemperature ----------
         var ct_in = val.findsubval(0)  # CT

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light3.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light3.be
@@ -270,6 +270,7 @@ class Matter_Plugin_Light3 : Matter_Plugin_Light1
 
     # ====================================================================================================
     if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
+      if !self.mqtt_command_ready(ctx)   return nil   end
       self.update_shadow_lazy()
       if   command == 0x0000            # ---------- MoveToHue ----------
         var hue_in = val.findsubval(0)  # Hue 0..254

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_z_All.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_z_All.be
@@ -43,6 +43,19 @@ def register_native_classes()
         end
     end
   end
+
+  # Dynamic MQTT bridge type registration
+  # Map mqtt_* types to existing HTTP bridge plugin classes
+  var mqtt_prefix = "mqtt_"
+  var http_prefix = "http_"
+  for k: plugins_classes.keys()
+    if string.find(k, http_prefix) == 0
+      # Found an http_* type, create mqtt_* alias
+      var mqtt_type = mqtt_prefix + k[size(http_prefix)..]
+      plugins_classes[mqtt_type] = plugins_classes[k]
+    end
+  end
+
   return plugins_classes
 end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -78,6 +78,7 @@ class Matter_UI
   "for(var t in dn){"
   "if(t==='-virtual'){h+='<option disabled>--- Virtual ---</option>';continue;}"
   "if(t==='-zigbee'){h+='<option disabled>--- Zigbee ---</option>';continue;}"
+  "if(t.indexOf('mqtt_')===0&&typeof remtopic==='undefined')continue;"
   "h+='<option value=\"'+t+'\"'+(t===sel?' selected':'')+'>'+dn[t]+'</option>';}"
   "return h;};"
   # Generate parameter rows as table rows (indented under the header row)
@@ -111,7 +112,7 @@ class Matter_UI
   "if(isNew){"
   "h+='<td style=\"font-size:smaller\"><select id=\"epTyp'+ep+'\" onchange=\"chgType('+ep+',this.value)\">'+typeOpts(typ)+'</select></td>';"
   "}else{"
-  "var dnam=dn[typ]||(typ.indexOf('http_')===0?'&#x1F517; '+(dn[typ.substring(5)]||typ.substring(5)):typ);"
+  "var dnam=dn[typ]||(typ.indexOf('http_')===0?'&#x1F517; '+(dn[typ.substring(5)]||typ.substring(5)):(typ.indexOf('mqtt_')===0?'&#x1F4E1; '+(dn[typ.substring(5)]||typ.substring(5)):typ));"
   "h+='<td style=\"font-size:smaller\"><b>'+dnam+'</b></td>';}"
   "h+='<td style=\"text-align:center\"><button type=\"button\" title=\"Delete\" "
   "style=\"background:none;border:none;line-height:1;cursor:pointer\" "
@@ -199,6 +200,10 @@ class Matter_UI
                               "|http_temperature|http_pressure|http_illuminance|http_humidity"
                               "|http_occupancy|http_contact|http_flow|http_rain|http_waterleak"
                               "|http_airquality"
+  static var _CLASSES_TYPES3= "|mqtt_relay|mqtt_light0|mqtt_light1|mqtt_light2|mqtt_light3"
+                              "|mqtt_temperature|mqtt_pressure|mqtt_illuminance|mqtt_humidity"
+                              "|mqtt_occupancy|mqtt_contact|mqtt_flow|mqtt_rain|mqtt_waterleak"
+                              "|mqtt_airquality"
   var device
   var matter_enabled
 
@@ -363,6 +368,7 @@ class Matter_UI
   def handle_config_json()
     import webserver
     import json
+    import string
     
     var config_json_str = webserver.arg("config_json")
     if config_json_str == nil || config_json_str == ""
@@ -383,6 +389,12 @@ class Matter_UI
       end
       if self.device.plugins_classes.find(typ) == nil
         raise "value_error", "Unknown type '" + typ + "' for endpoint " + ep_str
+      end
+      if string.find(typ, "mqtt_") == 0 && !conf.find("topic")
+        raise "value_error", "MQTT endpoint " + ep_str + " missing topic"
+      end
+      if string.find(typ, "http_") == 0 && !conf.find("url")
+        raise "value_error", "HTTP endpoint " + ep_str + " missing url"
       end
     end
     
@@ -807,9 +819,9 @@ class Matter_UI
 
     # Emit JavaScript data and functions first (before the HTML that uses them)
     if self.device.zigbee
-      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self.device.zigbee._CLASSES_TYPES, self._CLASSES_TYPES_VIRTUAL)
+      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self.device.zigbee._CLASSES_TYPES, self._CLASSES_TYPES_VIRTUAL, self._CLASSES_TYPES3)
     else
-      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self._CLASSES_TYPES_VIRTUAL)
+      self.show_plugins_hints_js(self._CLASSES_TYPES_STD, self._CLASSES_TYPES_VIRTUAL, self._CLASSES_TYPES3)
     end
 
     webserver.content_send("<fieldset><legend><b>&nbsp;Configuration&nbsp;</b></legend><p></p>")
@@ -838,6 +850,7 @@ class Matter_UI
 
       # skip any remote class
       if string.find(typ, "http_") == 0   i += 1   continue    end
+      if string.find(typ, "mqtt_") == 0   i += 1   continue    end
 
       found = true
       webserver.content_send(f"<script>document.write(genEpRows({ep:i},cfg['{ep:i}'],false))</script>")
@@ -899,6 +912,50 @@ class Matter_UI
       end
     end
 
+    # --- MQTT Remote devices ---
+    var mqtt_remotes = []
+    for conf: self.device.plugins_config
+      var topic = conf.find("topic")
+      if topic != nil
+        mqtt_remotes.push(topic)
+      end
+    end
+    self.device.sort_distinct(mqtt_remotes)
+
+    for remote: mqtt_remotes
+      var remote_html = webserver.html_escape(remote)
+      var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(remote).find('name', remote) )
+      webserver.content_send(f"&#x1F4E1; <b>{host_device_name}</b> <i>(MQTT: {remote_html})</i>")
+      webserver.content_send("<table style='width:100%'>"
+                             "<tr>"
+                             "<td width='25'></td>"
+                             "<td width='78'></td>"
+                             "<td width='115'></td>"
+                             "<td width='15'></td>"
+                             "</tr>")
+
+      found = false
+      i = 0
+      while i < size(endpoints)
+        var ep = endpoints[i]
+        var conf = self.device.plugins_config.find(str(ep))
+        var typ = conf.find('type')
+        if !typ   i += 1   continue    end
+        if string.find(typ, "mqtt_") != 0   i += 1   continue    end
+        if conf.find("topic") != remote   i += 1   continue    end
+
+        found = true
+        webserver.content_send(f"<script>document.write(genEpRows({ep:i},cfg['{ep:i}'],false))</script>")
+        i += 1
+      end
+
+      webserver.content_send("</table><p></p>")
+
+      if !found
+        webserver.content_send("<p>&lt;none&gt;</p>")
+      end
+    end
+
     # Save configuration button
     webserver.content_send("<button name='config' class='button bgrn'"
                            " onclick='return submitConfig(this.form)'>"
@@ -915,7 +972,28 @@ class Matter_UI
                            "<td width='10' style='font-size:smaller;'><b>/</b></td></tr>"
                            "</table>"
                            "<div style='display: block;'></div>"
-                           "<button class='button bgrn'>Auto-configure remote Tasmota</button></form><hr>")
+                           "<button class='button bgrn'>Auto-configure remote Tasmota</button></form>")
+
+    # Discovered MQTT devices (AJAX live, 1s polling)
+    webserver.content_send("<hr><p><b>Discovered MQTT Devices</b></p>"
+                           "<div id='mqtt_disc'><i>Subscribing to tasmota/discovery...</i></div>")
+
+    webserver.content_send("<script>")
+    webserver.content_send("function updDisc(d){")
+    webserver.content_send("var el=document.getElementById('mqtt_disc');")
+    webserver.content_send("if(!el)return;")
+    webserver.content_send("var k=Object.keys(d);")
+    webserver.content_send("if(!k.length){el.innerHTML='<i>No devices discovered yet. Reboot a Tasmota device on this broker.</i>';return;}")
+    webserver.content_send("el.textContent='';var tb=document.createElement('table');tb.style.width='100%';")
+    webserver.content_send("var hr=tb.insertRow();['IP','MAC','Topic',''].forEach(function(v){var c=hr.insertCell();c.style.fontSize='smaller';c.style.paddingRight='10px';var b=document.createElement('b');b.textContent=v;c.appendChild(b);});")
+    webserver.content_send("for(var i=0;i<k.length;i++){")
+    webserver.content_send("var t=k[i],n=d[t],r=tb.insertRow();[n.ip,n.mac,t].forEach(function(v){var c=r.insertCell();c.style.paddingRight='10px';c.textContent=v==null?'':v;});var a=r.insertCell();")
+    webserver.content_send("if(n.added)a.textContent='✓ added';")
+    webserver.content_send("else{var l=document.createElement('a');l.className='button bgrn';l.href='/matteradd?topic='+encodeURIComponent(t);l.textContent='Add';a.appendChild(l);}}")
+    webserver.content_send("el.appendChild(tb);}")
+    webserver.content_send("setInterval(function(){fetch('/matter_api/disc').then(function(r){return r.json()}).then(updDisc)},1000);")
+    webserver.content_send("updDisc({});")
+    webserver.content_send("</script><hr>")
 
     # button "Reset and Auto-discover"
     webserver.content_send("<form action='/matterc' method='post'"
@@ -990,6 +1068,8 @@ class Matter_UI
     import webserver
 
     if !webserver.check_privileged_access() return nil end
+
+    self.device.ensure_discovery()          # lazy subscribe to tasmota/discovery/# on first visit
 
     webserver.content_start("Matter")           #- title of the web page -#
     webserver.content_send_style()                  #- send standard Tasmota styles -#
@@ -1190,6 +1270,179 @@ class Matter_UI
   end
 
   #######################################################################
+  # AJAX endpoint: return discovered MQTT devices as JSON
+  #######################################################################
+  def page_api_discovered()
+    import webserver
+    if !webserver.check_privileged_access() return nil end
+    webserver.content_open(200, "application/json")
+    webserver.content_send(self.device.get_discovered_mqtt_json())
+  end
+
+  #######################################################################
+  # Show MQTT remote device add form
+  #######################################################################
+  def show_mqtt_add(topic)
+    import webserver
+    import json
+
+    if topic == ''  return end
+
+    # check if we have discovery data for this topic
+    var discovered = self.device.discovered_devices
+    if discovered != nil && discovered.contains(topic)
+      var config_data = discovered[topic].find('config', {})
+      var sensors_data = discovered[topic].find('sensors')
+      var config_list = matter.MQTT_remote.generate_config_from_discovery(self.device, config_data, sensors_data)
+      if config_list != nil && size(config_list) > 0
+        self.show_mqtt_add_discovered(topic, matter.MQTT_remote.discovery_info(config_data), config_list)
+        return
+      end
+    end
+    # no discovery data yet - show waiting page with AJAX polling
+    self.show_mqtt_add_waiting(topic)
+  end
+
+  #######################################################################
+  # Show MQTT add page waiting for discovery - user needs to reboot device
+  #######################################################################
+  def show_mqtt_add_waiting(topic)
+    import webserver
+
+    var topic_html = webserver.html_escape(topic)
+    webserver.content_send("<fieldset><legend><b>&nbsp;Matter MQTT Remote Device&nbsp;</b></legend><p></p>"
+                           "<p><b>Add Remote MQTT sensor or device</b></p>")
+
+    webserver.content_send(f"<p>&#x1F4E1; Topic: <b>{topic_html}</b></p>")
+
+    webserver.content_send("<p>Waiting for device discovery...</p>"
+                           "<p>Please <b>reboot</b> the remote device now.</p>"
+                           "<p>The page will redirect automatically when discovered.</p>")
+
+    # AJAX polling: check every 1s if device appears in discovery
+    webserver.content_send("<script type='text/javascript'>")
+    webserver.content_send("var waitingTopic=new URLSearchParams(location.search).get('topic')||'';")
+    webserver.content_send("setInterval(function(){")
+    webserver.content_send("  fetch('/matter_api/disc').then(function(r){return r.json()}).then(function(d){")
+    webserver.content_send("    if(d[waitingTopic])location.href='/matteradd?topic='+encodeURIComponent(waitingTopic);")
+    webserver.content_send("  })")
+    webserver.content_send("},1000);")
+    webserver.content_send("</script>")
+
+    webserver.content_send("</fieldset>")
+  end
+
+  #######################################################################
+  # Show MQTT add page with discovered endpoints
+  #######################################################################
+  def show_mqtt_add_discovered(topic, info, config_list)
+    import webserver
+    import json
+    import string
+
+    var topic_html = webserver.html_escape(topic)
+
+    # Emit JS data: schemas (ps), display names (dn) for mqtt types
+    webserver.content_send("<script type='text/javascript'>")
+    self.generate_schema_js()
+    self.generate_display_names_js([self._CLASSES_TYPES3])
+    webserver.content_send("var remtopic=new URLSearchParams(location.search).get('topic')||'';")
+    webserver.content_send("</script>")
+    webserver.content_send(self._ADD_ENDPOINT_JS)
+
+    webserver.content_send("<fieldset><legend><b>&nbsp;Matter MQTT Remote Device&nbsp;</b></legend><p></p>"
+                           "<p><b>Add Remote MQTT sensor or device</b></p>")
+
+    webserver.content_send(f"<p>&#x1F4E1; Topic: <b>{topic_html}</b></p>")
+
+    # show device info from discovery
+    if info.contains('name')
+      webserver.content_send(f"<p>Device: <b>{webserver.html_escape(info.find('name', ''))}</b></p>")
+    end
+    if info.contains('version')
+      webserver.content_send(f"<p>Version: {webserver.html_escape(info.find('version', ''))}</p>")
+    end
+
+    # Emit the detected config as a JS array for client-side rendering
+    # Each entry has 'type' prefixed with 'mqtt_' and parameter values
+    var rem_configs = []
+    for config: config_list
+      var entry = {}
+      for k: config.keys()
+        if k == 'type'
+          entry['type'] = 'mqtt_' + config['type']
+        else
+          entry[k] = config[k]
+        end
+      end
+      rem_configs.push(entry)
+    end
+    # JSON embedded in a script must not contain a literal '<' (for example </script> from a sensor name).
+    var rem_configs_json = string.replace(json.dump(rem_configs), '<', '\\u003C')
+    webserver.content_send("<script type='text/javascript'>")
+    webserver.content_send(format("var remcfg=%s;", rem_configs_json))
+    webserver.content_send("</script>")
+
+    # Form with hidden JSON field, rendered by JS
+    webserver.content_send("<form action='/matterc' method='post' onsubmit='return submitMqttRemote(this)'>"
+                           "<input name='topic' type='hidden' value='" + topic_html + "'>"
+                           "<input name='rem_json' type='hidden' value=''>"
+                           "<table id='mqttTbl' style='width:100%'>"
+                           "<tr>"
+                           "<td width='25' style='font-size:smaller;'>#</td>"
+                           "<td width='78' style='font-size:smaller;'>Name</td>"
+                           "<td width='115' style='font-size:smaller;'>Type</td>"
+                           "<td width='15'></td>"
+                           "</tr>"
+                           "</table>"
+                           "<div style='display: block;'></div>"
+                           "<button name='addrem' class='button bgrn'>Add endpoints</button>"
+                           "</form>")
+
+    # JS to populate the table from remcfg and handle submission
+    webserver.content_send(
+      "<script type='text/javascript'>"
+      "var mri=0;"
+      # Render detected endpoints
+      "remcfg.forEach(function(c){"
+      "var tbl=eb('mqttTbl');"
+      "if(tbl)tbl.insertAdjacentHTML('beforeend',genEpRows('mr'+mri,c,false));"
+      "mri++;});"
+      # Add one empty row for new endpoint
+      "(function(){"
+      "var tbl=eb('mqttTbl');"
+      "if(tbl)tbl.insertAdjacentHTML('beforeend',genEpRows('mr'+mri,{type:''},true));"
+      "mri++;})();"
+      # submitMqttRemote: collect all endpoint data into JSON
+      "function submitMqttRemote(f){"
+      "var eps=[];"
+      "for(var i=0;i<mri;i++){"
+      "var ne=eb('epNammr'+i);"
+      "var te=eb('epTypmr'+i);"
+      "var typ=te?te.value:remcfg[i]?remcfg[i].type:'';"
+      "if(!typ)continue;"
+      "var ep={type:typ};"
+      "if(ne){var v=ne.value.trim();if(v)ep.name=v;}"
+      "var schema=ps?ps[typ]:null;"
+      "if(schema){"
+      "for(var key in schema){"
+      "var def=parseSchema(schema[key]);"
+      "var akey=def.a||key;"
+      "var fe=eb('epmr'+i+'_'+key);"
+      "if(fe){"
+      "var v=fe.type==='checkbox'?(fe.checked?1:0):fe.value;"
+      "if(v!==''&&v!==null&&v!==undefined){"
+      "ep[akey]=(def.t==='i')?parseInt(v,10):v;"
+      "}}}}"
+      "eps.push(ep);}"
+      "f.elements['rem_json'].value=JSON.stringify(eps);"
+      "return true;}"
+      "</script>")
+
+    webserver.content_send("</fieldset>")
+  end
+
+  #######################################################################
   # Display the page for adding a new endpoint
   #######################################################################
   def page_part_mgr_add()
@@ -1201,8 +1454,13 @@ class Matter_UI
     webserver.content_send_style()                  #- send standard Tasmota styles -#
 
     var url = webserver.arg("url")
+    var topic = webserver.arg("topic")
     if self.matter_enabled
-      self.show_remote_autoconf(url)
+      if topic != nil && topic != ''
+        self.show_mqtt_add(topic)
+      elif url != nil && url != ''
+        self.show_remote_autoconf(url)
+      end
     end
     webserver.content_button(webserver.BUTTON_CONFIGURATION)
     webserver.content_stop()                        #- end of web page -#
@@ -1320,6 +1578,64 @@ class Matter_UI
       #---------------------------------------------------------------------#
       elif webserver.has_arg("addrem")
         var url = webserver.arg('url')
+        var topic = webserver.arg('topic')
+
+        # Handle MQTT remote
+        if topic != nil && topic != ''
+          var rem_json_str = webserver.arg('rem_json')
+          if rem_json_str != nil && rem_json_str != ''
+            import json
+            var endpoints = json.load(rem_json_str)
+            if endpoints != nil
+              for ep_conf: endpoints
+                var typ = ep_conf.find('type', '')
+                if typ == ''    continue    end
+                # Convert http_* to mqtt_* type
+                if string.find(typ, "http_") == 0
+                  typ = "mqtt_" + typ[5..]
+                end
+                var typ_class = self.device.plugins_classes.find(typ)
+                if typ_class == nil   continue   end
+
+                var config = {'topic': topic, 'type': typ}
+                var nam = ep_conf.find('name')
+                if nam    config['name'] = nam    end
+                # copy all schema parameters from the submitted config
+                for k: ep_conf.keys()
+                  if k != 'type' && k != 'name'
+                    config[k] = ep_conf[k]
+                  end
+                end
+
+                # check if configuration is already present
+                var duplicate = false
+                for c: self.device.plugins_config   # iterate on values, not on keys()
+                  if self.equal_map(c, config)   duplicate = true  break   end
+                end
+                # not a duplicate, add it
+                if !duplicate
+                  log(format("MTR: mqtt remote add topic='%s' type='%s'", topic, typ), 3)
+                  self.device.bridge_add_endpoint(typ, config)
+                end
+              end
+            end
+          end
+          # Endpoint construction registers the remote. Attach discovery metadata
+          # only after a configured endpoint exists, then persist it once.
+          if self.device.mqtt_remotes != nil && self.device.mqtt_remotes.contains(topic)
+            var discovered = self.device.discovered_devices.find(topic, {})
+            var discovery_config = discovered.find('config')
+            var mqtt_remote = self.device.mqtt_remotes[topic]
+            if discovery_config != nil && mqtt_remote.set_info_from_discovery(discovery_config)
+              mqtt_remote.info_changed()
+            end
+          end
+          #- and go back to Matter configuration -#
+          webserver.redirect("/matterc?")
+          return
+        end
+
+        # Handle HTTP remote (existing code)
         if url == nil || url == ''    raise "value_error", "url shouldn't be null"  end
 
         var rem_json_str = webserver.arg('rem_json')
@@ -1389,23 +1705,31 @@ class Matter_UI
     if (self.device.plugins == nil)   return  end
     import webserver
     var bridge_plugin_by_host
+    var bridge_plugin_by_mqtt_topic
     
     var idx = 0
     while idx < size(self.device.plugins)
       var plg = self.device.plugins[idx]
 
       if plg.BRIDGE
-        if bridge_plugin_by_host == nil     bridge_plugin_by_host = {}   end
-        var host = plg.http_remote.addr
-
-        if !bridge_plugin_by_host.contains(host)    bridge_plugin_by_host[host] = []    end
-        bridge_plugin_by_host[host].push(plg)
-
+        if plg.mqtt_remote
+          # MQTT bridge
+          if bridge_plugin_by_mqtt_topic == nil     bridge_plugin_by_mqtt_topic = {}   end
+          var topic = plg.mqtt_remote.topic
+          if !bridge_plugin_by_mqtt_topic.contains(topic)    bridge_plugin_by_mqtt_topic[topic] = []    end
+          bridge_plugin_by_mqtt_topic[topic].push(plg)
+        elif plg.http_remote
+          # HTTP bridge
+          if bridge_plugin_by_host == nil     bridge_plugin_by_host = {}   end
+          var host = plg.http_remote.addr
+          if !bridge_plugin_by_host.contains(host)    bridge_plugin_by_host[host] = []    end
+          bridge_plugin_by_host[host].push(plg)
+        end
       end
       idx += 1
     end
 
-    if bridge_plugin_by_host == nil     return    end         # no remote device, abort
+    if bridge_plugin_by_host == nil && bridge_plugin_by_mqtt_topic == nil     return    end         # no remote device, abort
 
     # set specific styles
     webserver.content_send("<hr>")
@@ -1421,17 +1745,37 @@ class Matter_UI
         "</style>"
     )
 
-    for host: self.device.k2l(bridge_plugin_by_host)
-      var host_html = webserver.html_escape(host)
-      var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(host).find('name', host) )
-      webserver.content_send(f"<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://{host_html}/' href=\"http://{host_html}/?\"'>{host_device_name}</a></td>")
-      var http_remote = bridge_plugin_by_host[host][0].http_remote    # get the http_remote object from the first in list
-      webserver.content_send(http_remote.web_last_seen())
+    # HTTP remotes
+    if bridge_plugin_by_host
+      for host: self.device.k2l(bridge_plugin_by_host)
+        var host_html = webserver.html_escape(host)
+        var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(host).find('name', host) )
+        webserver.content_send(f"<tr class='ztdm htrm'><td>&#x1F517; <a target='_blank' title='http://{host_html}/' href=\"http://{host_html}/?\"'>{host_device_name}</a></td>")
+        var http_remote = bridge_plugin_by_host[host][0].http_remote    # get the http_remote object from the first in list
+        webserver.content_send(http_remote.web_last_seen())
 
-      for plg: bridge_plugin_by_host[host]
-        webserver.content_send("<tr class='htrm'><td colspan='2'>")
-        plg.web_values()                                      # show values
-        webserver.content_send("</td></tr>")
+        for plg: bridge_plugin_by_host[host]
+          webserver.content_send("<tr class='htrm'><td colspan='2'>")
+          plg.web_values()                                      # show values
+          webserver.content_send("</td></tr>")
+        end
+      end
+    end
+
+    # MQTT remotes
+    if bridge_plugin_by_mqtt_topic
+      for topic: self.device.k2l(bridge_plugin_by_mqtt_topic)
+        var topic_html = webserver.html_escape(topic)
+        var host_device_name = webserver.html_escape( self.device.get_plugin_remote_info(topic).find('name', topic) )
+        webserver.content_send(f"<tr class='ztdm htrm'><td>&#x1F4E1; <b>{host_device_name}</b> <i>(MQTT: {topic_html})</i></td>")
+        var mqtt_remote = bridge_plugin_by_mqtt_topic[topic][0].mqtt_remote    # get the mqtt_remote object from the first in list
+        webserver.content_send(mqtt_remote.web_last_seen())
+
+        for plg: bridge_plugin_by_mqtt_topic[topic]
+          webserver.content_send("<tr class='htrm'><td colspan='2'>")
+          plg.web_values()                                      # show values
+          webserver.content_send("</td></tr>")
+        end
       end
     end
 
@@ -1484,6 +1828,7 @@ class Matter_UI
     webserver.on("/matterc", / -> self.page_part_ctl(), webserver.HTTP_POST)
     webserver.on("/mattera", / -> self.page_part_mgr_adv(), webserver.HTTP_GET)   # advanced
     webserver.on("/matteradd", / -> self.page_part_mgr_add(), webserver.HTTP_GET)   # add endpoint
+    webserver.on("/matter_api/disc", / -> self.page_api_discovered(), webserver.HTTP_GET)   # AJAX discovered MQTT devices
   end
 end
 matter.UI = Matter_UI

--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -46,6 +46,11 @@ class Matter_Device
   var events                          # Event handler
   # for brige mode, list of HTTP_remote objects (only one instance per remote object)
   var http_remotes                    # map of 'domain:port' to `Matter_HTTP_remote` instance or `nil` if no bridges
+  var mqtt_remotes                    # map of 'topic' to `Matter_MQTT_remote` instance or `nil` if no MQTT bridges
+  # MQTT auto-discovery
+  var discovered_devices              # map keyed by topic: {config: {...}, sensors: {...}} from tasmota/discovery
+  var discovered_sensors              # map keyed by MAC, allowing retained sensors to arrive before config
+  var discovery_subscribed            # true if already subscribed to tasmota/discovery/#
   # saved in parameters
   var root_discriminator              # as `int`
   var root_passcode                   # as `int`
@@ -72,6 +77,9 @@ class Matter_Device
     self.plugins = []
     self.plugins_persist = false                  # plugins need to saved only when the first fabric is associated
     self.plugins_config_remotes = {}
+    self.discovered_devices = {}
+    self.discovered_sensors = {}
+    self.discovery_subscribed = false
     self.next_ep = self.EP                        # start at endpoint 2 for dynamically allocated endpoints (1 reserved for aggregator)
     self.ipv4only = false
     self.disable_bridge_mode = false
@@ -88,6 +96,8 @@ class Matter_Device
     tasmota.when_network_up(def () self.start() end)    # start when network is connected
     self.commissioning.init_basic_commissioning()
     tasmota.add_driver(self)
+    tasmota.add_rule("Mqtt#Connected", / -> self.mqtt_connected())
+    tasmota.add_rule("Mqtt#Disconnected", / -> self.mqtt_disconnected())
 
     self.register_commands()
   end
@@ -503,6 +513,16 @@ class Matter_Device
       end
     end
 
+    # Add MQTT remotes info
+    if self.mqtt_remotes != nil
+      for topic:self.mqtt_remotes.keys()
+        var info = self.mqtt_remotes[topic].get_info()
+        if info != nil && size(info) > 0
+          ret[topic] = info
+        end
+      end
+    end
+
     self.plugins_config_remotes = ret
     return ret
   end
@@ -808,7 +828,147 @@ class Matter_Device
   end
 
   #####################################################################
-  # Remove HTTP remotes that are no longer referenced
+  # Manager MQTT remotes
+  #####################################################################
+  # register new mqtt remote
+  #
+  # If already registered, return current instance
+  def register_mqtt_remote(topic)
+    if self.mqtt_remotes == nil     self.mqtt_remotes = {}    end     # lazy initialization
+    var mqtt_remote
+
+    if self.mqtt_remotes.contains(topic)
+      mqtt_remote = self.mqtt_remotes[topic]
+    else
+      var info = self.plugins_config_remotes.find(topic, {})
+      mqtt_remote = matter.MQTT_remote(self, topic, info)
+      self.mqtt_remotes[topic] = mqtt_remote
+    end
+    return mqtt_remote
+  end
+
+  # Broker lifecycle is separate from listener replay, which mqtt.be handles.
+  def mqtt_connected()
+    if self.mqtt_remotes
+      for remote: self.mqtt_remotes
+        remote.mqtt_connected()
+      end
+    end
+    return false
+  end
+
+  def mqtt_disconnected()
+    if self.mqtt_remotes
+      for remote: self.mqtt_remotes
+        remote.mqtt_disconnected()
+      end
+    end
+    return false
+  end
+
+  # Notify all endpoints sharing a remote when BridgedDeviceBasic Reachable changes.
+  def mqtt_reachable_changed(remote)
+    import introspect
+    for plugin: self.plugins
+      if introspect.get(plugin, "mqtt_remote") == remote
+        plugin.attribute_updated(0x0039, 0x0011)
+      end
+    end
+  end
+
+  #####################################################################
+  # MQTT Auto-Discovery
+  #
+  # Lazy subscription to tasmota/discovery/# — only on first config page visit
+  #####################################################################
+  def ensure_discovery()
+    if !self.discovery_subscribed
+      self.subscribe_discovery()
+      self.discovery_subscribed = true
+    end
+  end
+
+  # Subscribe to tasmota/discovery/# permanently
+  def subscribe_discovery()
+    import mqtt
+    mqtt.subscribe("tasmota/discovery/#", / topic, idx, data, databytes -> self.handle_global_discovery(topic, data))
+    log("MTR: Subscribed to tasmota/discovery/#", 3)
+  end
+
+  # Parse discovery messages, store by topic
+  def handle_global_discovery(mqtt_topic, data)
+    if data == nil   return   end
+    import json
+    import string
+    var j = type(data) == 'string' ? json.load(data) : data
+    if j == nil   return   end
+
+    # tasmota/discovery/<MAC>/config or tasmota/discovery/<MAC>/sensors
+    var discovery_prefix_len = size("tasmota/discovery/")
+    var mac_end = string.find(mqtt_topic, "/", discovery_prefix_len)
+    if mac_end < 0   return   end
+    var mac_part = mqtt_topic[discovery_prefix_len .. mac_end - 1]
+    var msg_type = mqtt_topic[mac_end + 1 ..]
+
+    if msg_type == "config"
+      var config_topic = j.find("t")
+      if config_topic == nil   return   end
+      if !self.discovered_devices.contains(config_topic)
+        self.discovered_devices[config_topic] = {}
+      end
+      self.discovered_devices[config_topic]['config'] = j
+      var config_mac = j.find('mac', mac_part)
+      if self.discovered_sensors.contains(config_mac)
+        self.discovered_devices[config_topic]['sensors'] = self.discovered_sensors[config_mac]
+      end
+      if self.mqtt_remotes != nil && self.mqtt_remotes.contains(config_topic)
+        var mqtt_remote = self.mqtt_remotes[config_topic]
+        if mqtt_remote.set_info_from_discovery(j)
+          mqtt_remote.info_changed()
+        end
+      end
+      log(f"MTR: discovered MQTT device '{config_topic}' name='{j.find('dn','?')}'", 3)
+
+    elif msg_type == "sensors"
+      self.discovered_sensors[mac_part] = j
+      for topic: self.discovered_devices.keys()
+        var cfg = self.discovered_devices[topic]
+        if cfg.contains('config') && cfg['config'].find('mac', '') == mac_part
+          cfg['sensors'] = j
+          break
+        end
+      end
+    end
+  end
+
+  # JSON for AJAX endpoint (lightweight)
+  def get_discovered_mqtt_json()
+    import json
+    var ret = {}
+    if self.discovered_devices != nil
+      for topic: self.discovered_devices.keys()
+        var c = self.discovered_devices[topic].find('config', {})
+        var added = false
+        for conf: self.plugins_config
+          if conf.find('topic') == topic   added = true  break   end
+        end
+        ret[topic] = {
+          'name': c.find('dn', topic),
+          'ip': c.find('ip', ''),
+          'version': c.find('sw', ''),
+          'mac': c.find('mac', ''),
+          'hw': c.find('md', ''),
+          'relay_cnt': c.find('rl', []),
+          'lt_st': c.find('lt_st', 0),
+          'added': added
+        }
+      end
+    end
+    return json.dump(ret)
+  end
+
+  #####################################################################
+  # Remove HTTP and MQTT remotes that are no longer referenced
   def clean_remotes()
     import introspect
 
@@ -847,6 +1007,36 @@ class Matter_Device
         self.http_remotes.remove(remote.addr)
       end
 
+    end
+
+    # Handle MQTT remotes
+    if self.mqtt_remotes
+      var mqtt_remotes_map = {}
+
+      for mqtt_remote: self.mqtt_remotes
+        mqtt_remotes_map[mqtt_remote] = 0
+      end
+
+      # scan all endpoints
+      for pi: self.plugins
+        var mqtt_remote = introspect.get(pi, "mqtt_remote")
+        if mqtt_remote != nil
+          mqtt_remotes_map[mqtt_remote] = mqtt_remotes_map.find(mqtt_remote, 0) + 1
+        end
+      end
+
+      var mqtt_remote_to_remove = []
+      for remote: mqtt_remotes_map.keys()
+        if mqtt_remotes_map[remote] == 0
+          mqtt_remote_to_remove.push(remote)
+        end
+      end
+
+      for remote: mqtt_remote_to_remove
+        log("MTR: remove unused mqtt remote: " + remote.topic, 3)
+        remote.close()
+        self.mqtt_remotes.remove(remote.topic)
+      end
     end
 
   end


### PR DESCRIPTION
## Description:

While I was migrating some of my existing ESP8266 devices from "Homebridge" to Tasmotas own Matter bridge I had to learn, that performance under my local network conditions is horrible, which may be related to network congestion in a dense environment.
So I tried the MQTT way (remember the M in Tasmota) as by design it is much more efficient than HTTP polling for the weak end devices. In my local scenario this was a complete game changer.

This PR does add optional bridging of remote devices to Matter, when both (bridge and remote) are connected to the same MQTT broker. No change for HTTP, this can be used as before.
I tried to preserve the HTTP code path as good as possible, but code parts could be merged in the future.

Setup:
1. Configure all involved ESP devices in the "usual Tasmota way" to connect to the same MQTT broker.

3. In the existing Matter web config page, there is a new entry with discovered MQTT devices:
<img width="539" height="415" alt="matter_mqtt_remote" src="https://github.com/user-attachments/assets/a6d280b8-1f9c-4b94-bdd2-6a9d7caf118d" />

4. Click on "add" for the desired device and you should see the familiar dialogue for setting it up, that was already existent for HTTP remote devices.

6. Then add the bridge to the Matter network and configure devices as it was done for HTTP remotes.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
