### PR TITLE
Fixes broken sensor table layout when HTTP/MQTT bridges run alongside local sensors

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -1731,6 +1731,9 @@ class Matter_UI
 
     if bridge_plugin_by_host == nil && bridge_plugin_by_mqtt_topic == nil     return    end         # no remote device, abort
 
+    # close the current sensor table, we need a dedicated bridge table
+    webserver.content_send("</table>")
+
     # set specific styles
     webserver.content_send("<hr>")
     webserver.content_send("<table style='width:100%'>")
@@ -1781,6 +1784,9 @@ class Matter_UI
 
 
     webserver.content_send("</table><hr>")
+
+    # reopen the sensor table for subsequent drivers
+    webserver.content_send("<table style='width:100%'>")
 
   end
 


### PR DESCRIPTION
Cosmetic bugfix - Matter remote devices (unrelated to HTTP or MQTT) create a table termination in the web UI, which would break the UI for later sensor entries.

This PR does it similar to special tables for ZigBee or DALI by re-opening a fresh table for what may be coming after.

There are other options to solve this and the changed file could be cleaned up by merging more `webserver.content_send` calls into a few calls by using multiline strings. But I would leave this for a future housekeeping task.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
