### PR TITLE
Berry `json.dump()` works with subclasses of `map` and `list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Library `PubSubClient` renamed to `TasmotaPubSub`, hardening fixes and comprehensive non-regression tests (#24916)
+- Berry `json.dump()` works with subclasses of `map` and `list`
 
 ### Fixed
 - Can sniffer functionality (#18287)

--- a/lib/libesp32/berry/berry_port/be_jsonlib.py
+++ b/lib/libesp32/berry/berry_port/be_jsonlib.py
@@ -83,42 +83,6 @@ def match_char(s, pos, ch):
         return skip_space(s, pos + 1)
     return -1
 
-# static int is_object(bvm *vm, const char *class, int idx)
-# {
-#     if (be_isinstance(vm, idx)) {
-#         be_pushvalue(vm, idx);
-#         while (1) {
-#             be_getsuper(vm, -1);
-#             if (be_isnil(vm, -1)) {
-#                 be_pop(vm, 1);
-#                 break;
-#             }
-#             be_remove(vm, -2);
-#         }
-#         const char *name = be_classname(vm, -1);
-#         bbool ret = !strcmp(name, class);
-#         be_pop(vm, 1);
-#         return ret;
-#     }
-#     return  0;
-# }
-def is_object(vm, classname, idx):
-    """Check if value at idx is an instance whose root class matches classname."""
-    be_api = _lazy_be_api()
-    if be_api.be_isinstance(vm, idx):
-        be_api.be_pushvalue(vm, idx)
-        while True:
-            be_api.be_getsuper(vm, -1)
-            if be_api.be_isnil(vm, -1):
-                be_api.be_pop(vm, 1)
-                break
-            be_api.be_remove(vm, -2)
-        name = be_api.be_classname(vm, -1)
-        ret = (name == classname)
-        be_api.be_pop(vm, 1)
-        return ret
-    return False
-
 # /* Calculate the actual buffer size needed for JSON string parsing
 #  * accounting for Unicode expansion and security limits */
 # static size_t json_strlen_safe(const char *json, size_t *actual_len)
@@ -815,9 +779,10 @@ def array_dump(vm, indent, idx, fmt):
 
 # static void value_dump(bvm *vm, int *indent, int idx, int fmt)
 # {
-#     if (is_object(vm, "map", idx)) {
+#     be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
+#     if (be_ismapinstance(vm, idx)) {
 #         object_dump(vm, indent, idx, fmt);
-#     } else if (is_object(vm, "list", idx)) {
+#     } else if (be_islistinstance(vm, idx)) {
 #         array_dump(vm, indent, idx, fmt);
 #     } else if (be_isnil(vm, idx)) {
 #         be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
@@ -842,9 +807,13 @@ def array_dump(vm, indent, idx, fmt):
 def value_dump(vm, indent, idx, fmt):
     """Serialize any Berry value to JSON string and push result to top."""
     be_api = _lazy_be_api()
-    if is_object(vm, "map", idx):
+    be_api.be_stack_require(vm, 1 + BE_STACK_FREE_MIN)
+    # `be_ismapinstance()` / `be_islistinstance()` walk the class hierarchy and
+    # compare against the actual builtin `map` / `list` classes, so subclasses
+    # are handled, and a user class that merely shares the name is not.
+    if be_api.be_ismapinstance(vm, idx):
         object_dump(vm, indent, idx, fmt)
-    elif is_object(vm, "list", idx):
+    elif be_api.be_islistinstance(vm, idx):
         array_dump(vm, indent, idx, fmt)
     elif be_api.be_isnil(vm, idx):
         be_api.be_stack_require(vm, 1 + BE_STACK_FREE_MIN)

--- a/lib/libesp32/berry/src/be_jsonlib.c
+++ b/lib/libesp32/berry/src/be_jsonlib.c
@@ -46,26 +46,6 @@ static const char* match_char(const char *json, int ch)
     return NULL;
 }
 
-static int is_object(bvm *vm, const char *class, int idx)
-{
-    if (be_isinstance(vm, idx)) {
-        be_pushvalue(vm, idx);
-        while (1) {
-            be_getsuper(vm, -1);
-            if (be_isnil(vm, -1)) {
-                be_pop(vm, 1);
-                break;
-            }
-            be_remove(vm, -2);
-        }
-        const char *name = be_classname(vm, -1);
-        bbool ret = !strcmp(name, class);
-        be_pop(vm, 1);
-        return ret;
-    }
-    return  0;
-}
-
 /* Calculate the actual buffer size needed for JSON string parsing
  * accounting for Unicode expansion and security limits */
 static size_t json_strlen_safe(const char *json, size_t *actual_len)
@@ -587,10 +567,13 @@ static void array_dump(bvm *vm, int *indent, int idx, int fmt)
 
 static void value_dump(bvm *vm, int *indent, int idx, int fmt)
 {
-    // be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
-    if (is_object(vm, "map", idx)) { /* convert to json object */
+    be_stack_require(vm, 1 + BE_STACK_FREE_MIN); /* the isinstance checks below push 1 value */
+    /* `be_ismapinstance()` / `be_islistinstance()` walk the class hierarchy and
+     * compare against the actual builtin `map` / `list` classes, so subclasses
+     * are handled, and a user class that merely shares the name is not. */
+    if (be_ismapinstance(vm, idx)) { /* convert to json object */
         object_dump(vm, indent, idx, fmt);
-    } else if (is_object(vm, "list", idx)) { /* convert to json array */
+    } else if (be_islistinstance(vm, idx)) { /* convert to json array */
         array_dump(vm, indent, idx, fmt);
     } else if (be_isnil(vm, idx)) { /* convert to json null */
         be_stack_require(vm, 1 + BE_STACK_FREE_MIN); 

--- a/lib/libesp32/berry/tests/json_subclass.be
+++ b/lib/libesp32/berry/tests/json_subclass.be
@@ -1,0 +1,68 @@
+#- json.dump() must recognize subclasses of `map` and `list`,
+   and must NOT be fooled by unrelated classes named `map`/`list` -#
+
+import json
+
+#- direct subclass of map -#
+class MyMap : map end
+var m = MyMap()
+m["a"] = 1
+assert(json.dump(m) == '{"a":1}')
+
+#- direct subclass of list -#
+class MyList : list end
+var l = MyList()
+l.push(1)
+l.push("x")
+assert(json.dump(l) == '[1,"x"]')
+
+#- deeper hierarchy -#
+class MyMap2 : MyMap end
+var m2 = MyMap2()
+m2["b"] = true
+assert(json.dump(m2) == '{"b":true}')
+
+#- subclass with its own instance variables and init -#
+class MyMap3 : map
+  var extra
+  def init()
+    super(self).init()
+    self.extra = 42
+  end
+end
+var m3 = MyMap3()
+m3["c"] = nil
+assert(json.dump(m3) == '{"c":null}')
+
+#- nested inside plain containers and inside each other -#
+assert(json.dump({"k": m, "j": l}) == '{"k":{"a":1},"j":[1,"x"]}')
+var nested = MyList()
+nested.push(m)
+assert(json.dump(nested) == '[{"a":1}]')
+
+#- formatted output still works for subclasses -#
+assert(json.dump(m, "format") == '{\n  "a": 1\n}')
+
+#- A user class that merely shares the name `map`/`list` must be dumped as a
+   string, not treated as a json container. The previous root-class-name
+   comparison matched on the name only and aborted in `be_strconcat()`.
+   The classes are declared inside a function so that the builtins are not
+   shadowed. -#
+def make_fake_map()
+  class map
+    def tostring() return "not-a-map" end
+  end
+  return map()
+end
+assert(json.dump(make_fake_map()) == '"not-a-map"')
+
+def make_fake_list()
+  class list
+    def tostring() return "not-a-list" end
+  end
+  return list()
+end
+assert(json.dump(make_fake_list()) == '"not-a-list"')
+
+#- sanity: builtins still work -#
+assert(json.dump({"a": [1, 2]}) == '{"a":[1,2]}')


### PR DESCRIPTION
## Description:

Fix Berry `json.dump()` to work with subclasses of `map` and `list`, cf discussion on Discord.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
