### PR TITLE
Berry extend `sortedmap` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for baudrate 74880 replacing 74700 (#24924)
 - Support for WiZ compatible IoTorero ESP-Now Remote Control additional buttons P5 to P7
 - Limited support for BLE BTHome (#20763)
+- Berry extend `sortedmap` constructor
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
@@ -10,11 +10,26 @@ class sortedmap
   var _keys    # list for maintaining sorted keys
   
   # Constructor
-  def init()
+  def init(base)
     self._data = {}
     self._keys = []
+    if isinstance(base, map) || isinstance(base, sortedmap)
+      self._load(base, self)
+    end
   end
 
+  # Shallow copy from existing map  
+  def _load(org, copy)
+    for key : org.keys()
+      var value = org.item(key)
+      if isinstance(value, map) || isinstance(value, sortedmap)
+        value = self._load(value, sortedmap())
+      end
+      copy.insert(key, value)
+    end
+    return copy
+  end
+  
   # Insert a new key-value pair or update existing value
   def insert(key, value)
     var is_new = !self._data.contains(key)


### PR DESCRIPTION
## Description:

Change suggested by @sfromis on Discord:

This allows easy loading of an existing hashed map to have it sorted (like from `energy.read()` or `json.load(tasmota.read_sensors())`, and should not affect the normal operation of the class.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
