### PR TITLE
Fix build error: use #ifdef for USE_UNIVERSAL_TOUCH in UDSP_DEBUG block

### DIFF
--- a/lib/lib_display/UDisplay/src/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/src/uDisplay.cpp
@@ -905,7 +905,7 @@ void UfsCheckSDCardInit(void);
   AddLog(LOG_LEVEL_DEBUG, "UDisplay: Device:%s xs:%d ys:%d bpp:%d", dname, gxs, gys, bpp);
 
   if (interface == _UDSP_SPI) {
-#if USE_UNIVERSAL_TOUCH
+#ifdef USE_UNIVERSAL_TOUCH
     AddLog(LOG_LEVEL_DEBUG, "UDisplay: Nr:%d CS:%d CLK:%d MOSI:%d DC:%d TS_CS:%d TS_RST:%d TS_IRQ:%d", 
        spiController->spi_config.bus_nr, spiController->spi_config.cs, spiController->spi_config.clk, spiController->spi_config.mosi, spiController->spi_config.dc, ut_spi_cs, ut_reset, ut_irq);
 #else


### PR DESCRIPTION
## Description

Building with `UDSP_DEBUG` enabled currently fails:

```
lib/lib_display/UDisplay/src/uDisplay.cpp:908:24: error: #if with no expression
  908 | #if USE_UNIVERSAL_TOUCH
      |                        ^
```

`USE_UNIVERSAL_TOUCH` is defined without a value, so `#if` expands to an empty expression and the preprocessor errors out. Changing it to `#ifdef` fixes the build.

This is consistent with every other test of the same macro in the codebase — including two elsewhere in this very file — which all already use `#ifdef`:

| location | form |
|---|---|
| `uDisplay.cpp:47` | `#ifdef USE_UNIVERSAL_TOUCH` |
| `uDisplay.cpp:792` | `#ifdef USE_UNIVERSAL_TOUCH` |
| `uDisplay_touch.cpp:4` | `#ifdef USE_UNIVERSAL_TOUCH` |
| `uDisplay.cpp:908` | `#if USE_UNIVERSAL_TOUCH` ← this PR |

so it appears to be a typo rather than an intentional value test.

## Why it has gone unnoticed

Introduced in a1639507d ("Udisp SPI fix for mono color display", #24899). The affected block is inside `#ifdef UDSP_DEBUG`, which ships commented out at `uDisplay.cpp:27`, so standard builds never compile it. It only surfaces for anyone who enables that debug logging.

Found on an ESP32-P4 build with `UDSP_DEBUG` turned on for MIPI-DSI init diagnostics.

## Checklist

- [x] The pull request is done against the latest `development` branch
- [x] Only relevant files were touched (one line, one file)
- [x] The code change is tested and works (build fails before, succeeds after — verified on `tasmota32p4`)
- [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md)