### PR TITLE
Berry make `sortedmap` subclass of `map`

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
@@ -5,7 +5,7 @@
 # see https://github.com/berry-lang/berry/wiki/Chapter-8
 #################################################################################
 #@ solidify:sortedmap
-class sortedmap
+class sortedmap : map
   var _data    # internal map for storing key-value pairs
   var _keys    # list for maintaining sorted keys
   


### PR DESCRIPTION
## Description:

Berry make `sortedmap` subclass of `map`. No functional change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
