### PR TITLE
NeoPool fix issue with localized JSON key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Minor fixes in `LList` (#24927)
 - TLS fix public key fingerprint for ECDSA certificates (#24928)
 - HASPmota better support for `textarea` (#24946)
+- NeoPool fix issue with localized JSON keys
 
 ### Removed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -2055,7 +2055,7 @@ void NeoPoolShow(bool json)
     // Temperature
     if (NeoPoolGetData(MBF_PAR_TEMPERATURE_ACTIVE)) {
       fvalue = ConvertTemp((float)NeoPoolGetData(MBF_MEASURE_TEMPERATURE)/10);
-      ResponseAppend_P(PSTR(",\""  D_TEMPERATURE  "\":%*_f"), Settings->flag2.temperature_resolution, &fvalue);
+      ResponseAppend_P(PSTR(",\""  D_JSON_TEMPERATURE  "\":%*_f"), Settings->flag2.temperature_resolution, &fvalue);
     }
 
     // Voltage
@@ -2110,7 +2110,7 @@ void NeoPoolShow(bool json)
     // pH
     if (NeoPoolIspHModule()) {
       fvalue = (float)NeoPoolGetData(MBF_MEASURE_PH)/100;
-      ResponseAppend_P(PSTR(",\""  D_PH  "\":{\""  D_JSON_DATA  "\":"  NEOPOOL_FMT_PH), NeoPoolSettings.flags.ph, &fvalue);
+      ResponseAppend_P(PSTR(",\""  D_JSON_PH  "\":{\""  D_JSON_DATA  "\":"  NEOPOOL_FMT_PH), NeoPoolSettings.flags.ph, &fvalue);
 
       // S1
       float fphmin = (float)NeoPoolGetData(MBF_PAR_PH2)/100;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes [ha-sugar-valley-neopool #22](https://github.com/alexdelprete/ha-sugar-valley-neopool/issues/22)

JSON keys must never be language-dependent

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
