### PR TITLE
NeoPool delocalize all JSON outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - TLS fix public key fingerprint for ECDSA certificates (#24928)
 - HASPmota better support for `textarea` (#24946)
 - NeoPool issue with localized JSON keys (#24962)
+- NeoPool delocalize all JSON outputs
 
 ### Removed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -846,9 +846,9 @@ TNeoPoolSettings NeoPoolSettings;
 #define D_NEOPOOL_JSON_CELL_RUNTIME           "Runtime"
 #define D_NEOPOOL_JSON_CELL_RUNTIME_TOTAL     "Total"
 #define D_NEOPOOL_JSON_CELL_RUNTIME_PART      "Part"
-#define D_NEOPOOL_JSON_CELL_RUNTIME_POL1      "Pol1"
-#define D_NEOPOOL_JSON_CELL_RUNTIME_POL2      "Pol2"
 #define D_NEOPOOL_JSON_CELL_RUNTIME_CHANGES   "Changes"
+#define D_NEOPOOL_JSON_CELL_POL1              "Pol1"
+#define D_NEOPOOL_JSON_CELL_POL2              "Pol2"
 #define D_NEOPOOL_JSON_IONIZATION             "Ionization"
 #define D_NEOPOOL_JSON_LIGHT                  "Light"
 #define D_NEOPOOL_JSON_LIGHT_MODE             "Mode"
@@ -875,7 +875,9 @@ TNeoPoolSettings NeoPoolSettings;
 #define D_NEOPOOL_JSON_MIN                    "Min"
 #define D_NEOPOOL_JSON_MAX                    "Max"
 #define D_NEOPOOL_JSON_PHPUMP                 "Pump"
+#define D_NEOPOOL_JSON_STATUS_FLOW            "Flow"
 #define D_NEOPOOL_JSON_FLOW1                  "FL1"
+#define D_NEOPOOL_JSON_FLOW2                  "FL2"
 #define D_NEOPOOL_JSON_TANK                   "Tank"
 #define D_NEOPOOL_JSON_BIT                    "Bit"
 #define D_NEOPOOL_JSON_NODE_ID                "NodeID"
@@ -2161,7 +2163,7 @@ void NeoPoolShow(bool json)
 
     // Conductivity
     if (NeoPoolIsConductivity()) {
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_CONDUCTIVITY  "\":" NEOPOOL_FMT_CD), NeoPoolGetData(MBF_MEASURE_CONDUCTIVITY));
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CONDUCTIVITY  "\":" NEOPOOL_FMT_CD), NeoPoolGetData(MBF_MEASURE_CONDUCTIVITY));
     }
 
     // Ionization
@@ -2199,21 +2201,21 @@ void NeoPoolShow(bool json)
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME  "\":{"));
       ResponseAppend_P(PSTR( "\""  D_NEOPOOL_JSON_CELL_RUNTIME_TOTAL  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_LOW)).c_str());
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME_PART  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_PART_LOW)).c_str());
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME_POL1  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_POLA_LOW)).c_str());
-      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME_POL2  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_POLB_LOW)).c_str());
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_POL1  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_POLA_LOW)).c_str());
+      ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_POL2  "\":\"%s\""), GetDuration(NeoPoolGetDataLong(MBF_CELL_RUNTIME_POLB_LOW)).c_str());
       ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_CELL_RUNTIME_CHANGES  "\":%ld"), NeoPoolGetDataLong(MBF_CELL_RUNTIME_POL_CHANGES_LOW));
       ResponseJsonEnd();
 
       // S1
       const char *state = PSTR("");
       if (0 == (NeoPoolGetData(MBF_HIDRO_STATUS) & MBMSK_HIDRO_STATUS_MODULE_ACTIVE)) {
-        state = PSTR(D_NEOPOOL_STATUS_OFF);
+        state = PSTR(D_NEOPOOL_JSON_OFF);
       } else if (0 == (NeoPoolGetData(MBF_HIDRO_STATUS) & MBMSK_HIDRO_STATUS_FL1)) {
-        state = PSTR(D_NEOPOOL_STATUS_FLOW);
+        state = PSTR(D_NEOPOOL_JSON_STATUS_FLOW);
       } else if (NeoPoolGetData(MBF_HIDRO_STATUS) & MBMSK_HIDRO_STATUS_POL1) {
-        state = PSTR(D_NEOPOOL_POLARIZATION "1");
+        state = PSTR(D_NEOPOOL_JSON_CELL_POL1);
       } else if (NeoPoolGetData(MBF_HIDRO_STATUS) & MBMSK_HIDRO_STATUS_POL2) {
-        state = PSTR(D_NEOPOOL_POLARIZATION "2");
+        state = PSTR(D_NEOPOOL_JSON_CELL_POL2);
       } else {
         state = PSTR(D_NEOPOOL_STATUS_OFF);
       }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** [ha-sugar-valley-neopool #22](https://github.com/alexdelprete/ha-sugar-valley-neopool/issues/22)

JSON keys/values must be language-independent 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
