### PR TITLE
[EQ3-TRV] More code refactoring

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -136,7 +136,7 @@ print("".join(pin))
 #ifdef USE_BLE_ESP32
 
 #define XDRV_85                    85
-#define D_CMND_EQ3 "Trv"
+#define D_CMND_EQ3 "TRV"
 
 // uncomment for more debug messages
 //#define EQ3_DEBUG

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -379,15 +379,11 @@ char *topicPrefix(int prefix, const uint8_t *addr, int useAlias) {
   return stopic;
 }
 
-// return 0+ if we find the addr has one of our listed prefixes
-// return -1 if we don't recognise the mac
-int matchPrefix(const uint8_t *addr) {
-  for (size_t i = 0; i < sizeof(macprefixes) / sizeof(*macprefixes); i++) {
-    if (!memcmp(addr, macprefixes[i], 3)) {
-      return i;
-    }
+bool matchPrefix(const uint8_t *addr) {
+  for (const auto *prefix : macprefixes) {
+    if (!memcmp(addr, prefix, 3)) return true;
   }
-  return -1;
+  return false;
 }
 
 bool EQ3Operation(const uint8_t *MAC, const uint8_t *data, int datalen, int cmdtype, int retries_in = 0) {
@@ -907,7 +903,7 @@ int TaskEQ3advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
   }
 
   // if the addr matches the EQ3 mfg prefix, add it?
-  if (!found && EQ3MatchPrefix && (matchPrefix(addr) >= 0)) {
+  if (!found && EQ3MatchPrefix && matchPrefix(addr)) {
     found = true;
   }
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_85_esp32_ble_eq3_trv.ino
@@ -40,11 +40,11 @@ trvMatchPrefix 0/*1 - if set, then it will add trvs to the seen list which have 
 Note: anything with BLEAlias starting "EQ3" will be added to the seen list.
 trvHideFailedPoll 0/*1 - if set, then failed polls will not be sent to EQ3
 trvMinRSSI -n - the minimum RSSI value at which to attempt to poll
+trvReset - clear device list
+trvDevList - report seen devices.  Active scanning required, not passive, as it looks for names
+trvScan - same as trvDevList
 
 
-trv reset - clear device list
-trv devlist - report seen devices.  Active scanning required, not passive, as it looks for names
-trv scan - same as devlist
 trv <mac> state - report general state (see below for MQTT)
 trv <mac> raw <hex to send> - send a raw command
 trv <mac> on - set temp to 30 -> display ON on EQ3
@@ -136,12 +136,21 @@ print("".join(pin))
 #ifdef USE_BLE_ESP32
 
 #define XDRV_85                    85
-#define D_CMND_EQ3 "trv"
+#define D_CMND_EQ3 "Trv"
 
 // uncomment for more debug messages
 //#define EQ3_DEBUG
 
+// Simulation - uncomment to simulate a device
+//#define EQ3_SIMULATION
+#ifdef EQ3_SIMULATION
+#define TESTADDR1 (uint8_t[]){0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+#endif // EQ3_SIMULATION
+
 namespace EQ3_ESP32 {
+
+int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char* param2, int useAlias);
+int EQ3GenericOpCompleteFn(BLE_ESP32::generic_sensor_t *pStruct);
 
 void CmndTrv(void);
 void CmndTrvPeriod(void);
@@ -150,15 +159,20 @@ void CmndTrvOnlyAliased(void);
 void CmndTrvMatchPrefix(void);
 void CmndTrvMinRSSI(void);
 void CmndTrvHideFailedPoll(void);
+void CmndTrvReset(void);
+void CmndTrvDevList(void);
 
 constexpr const char kEQ3_Commands[] = D_CMND_EQ3 "|"
   "|"
-  "period|"
-  "retries|"
-  "onlyaliased|"
+  "Period|"
+  "Retries|"
+  "OnlyAliased|"
   "MatchPrefix|"
   "MinRSSI|"
-  "HideFailedPoll";
+  "HideFailedPoll|"
+  "Reset|"
+  "DevList|"
+  "Scan";  // same as devlist
 
 constexpr void (*EQ3_Commands[])(void) = {
   &CmndTrv,
@@ -167,7 +181,10 @@ constexpr void (*EQ3_Commands[])(void) = {
   &CmndTrvOnlyAliased,
   &CmndTrvMatchPrefix,
   &CmndTrvMinRSSI,
-  &CmndTrvHideFailedPoll
+  &CmndTrvHideFailedPoll,
+  &CmndTrvReset,
+  &CmndTrvDevList,
+  &CmndTrvDevList  // trvScan
 };
 
 enum TrvSubCommand : uint8_t {
@@ -232,29 +249,51 @@ constexpr const char* const TrvSubCmds[] = {
   "setprofile"
 };
 
+enum TrvResponse : uint8_t {
+  TRV_DONE = 0,
+  TRV_QUEUED,
+  TRV_IGNOREDBUSY,
+  TRV_INVCMD,
+  TRV_CMDFAIL,
+  TRV_INVADDR
+};
+ 
+constexpr const char* const TrvResponses[] = {
+  "Done",
+  "queued",
+  "ignoredbusy",
+  "invcmd",
+  "cmdfail",
+  "invaddr"
+};
+
 const uint8_t *const macprefixes[] = {
   (uint8_t *)"\x00\x1a\x22"
 };
-
-int EQ3GenericOpCompleteFn(BLE_ESP32::generic_sensor_t *pStruct);
 
 constexpr const char EQ3_Svc[]         = "3e135142-654f-9090-134a-a6ff5bb77046";
 constexpr const char EQ3_rw_Char[]     = "3fa4585a-ce4a-3bad-db4b-b8df8179ea09";
 constexpr const char EQ3_notify_Char[] = "d0e8434d-cd29-0996-af41-6c90f4e0eb2a";
 
-struct eq3_device_tag{
-  uint8_t addr[7];
-  int8_t RSSI;
-  uint64_t timeoutTime;
-  uint8_t pairing;
-  uint8_t lastStatus[16]; // last received 02 stat
-  uint8_t lastStatusLen;
-  uint32_t lastStatusTime; // in utc
-  uint8_t nextDiscoveryData;
-  float TargetTemp;
-  uint8_t DutyCycle;
-  bool Battery;
-} eq3_device_t;
+constexpr const char* const EQ3Names[] = {
+  "CC-RT-BLE",
+  "CC-RT-BLE-EQ",
+  "CC-RT-M-BLE"
+};
+
+struct eq3_device_t {
+  uint64_t timeoutTime;      // 8 Bytes
+  float TargetTemp;          // 4 Bytes
+  uint32_t lastStatusTime;   // 4 Bytes
+  int8_t RSSI;               // 1 Byte
+  uint8_t nextDiscoveryData; // 1 Byte
+  uint8_t DutyCycle;         // 1 Byte
+  uint8_t lastStatusLen;     // 1 Byte
+  bool pairing;              // 1 Byte
+  bool Battery;              // 1 Byte
+  uint8_t addr[6];           // 6 Bytes
+  uint8_t lastStatus[16];    // 16 Bytes
+};
 
 /*********************************************************************************************\
  * variables to control operation
@@ -263,20 +302,19 @@ int retries = 0;
 // allow 240s before timeout of sa device - based on that we restart BLE if we don't see adverts for 120s
 #define EQ3_TIMEOUT 240L
 
-uint8_t pairingaddr[7] = {0,0,0,0,0,0};
+uint8_t pairingaddr[6] = {};
 char pairingserial[20];
-uint8_t pairing = 0;
+bool pairing = false;
 
 #define EQ3_NUM_DEVICESLOTS 16
-eq3_device_tag EQ3Devices[EQ3_NUM_DEVICESLOTS];
+eq3_device_t EQ3Devices[EQ3_NUM_DEVICESLOTS];
 SemaphoreHandle_t EQ3mutex = nullptr;
 
-int EQ3Period = 300;
+uint16_t EQ3Period = 300;
 int EQ3Retries = 4;
 uint8_t EQ3OnlyAliased = 0;
 uint8_t EQ3MatchPrefix = 1;
-uint8_t opInProgress = 0;
-int seconds = 20;
+bool opInProgress = false;
 int EQ3CurrentSingleSlot = 0;
 
 uint8_t EQ3TopicStyle = 1;
@@ -285,21 +323,17 @@ int8_t trvMinRSSI = -99;
 
 // control of timing of sending polling.
 // we leave an interval between polls to allow scans to take place
-int intervalSeconds = 10; // min seconds between operations
-int intervalSecondsCounter = 0; // set when an operation is over to intervalSeconds
-int nextEQ3Poll = EQ3_NUM_DEVICESLOTS; // set to zero to start a poll cycle
+uint8_t nextEQ3Poll = 0;
+uint16_t NextPollSeconds = 20;
 
-#pragma pack( push, 1 )  // aligned structures for size
 struct op_t {
-  uint8_t addr[7];
+  uint8_t addr[6];
   uint8_t towrite[16];
   uint8_t writelen;
   uint8_t cmdtype;
 };
-#pragma pack(pop)
 
-std::deque<EQ3_ESP32::op_t*> opQueue;
-
+std::deque<std::unique_ptr<EQ3_ESP32::op_t>> opQueue;
 
 /*********************************************************************************************\
  * Functions
@@ -312,15 +346,15 @@ const char *addrStr(const uint8_t *addr, int useAlias = 0) {
   if (useAlias) {
     id = BLE_ESP32::getAlias(addr);
   }
-  if (!id || !(*id)) {
+  if (!id || !*id) {
     id = addrstr;
     BLE_ESP32::dump(addrstr, 13, addr, 6);
   }
   return id;
 }
 
-uint8_t TrvCmdtoIdx(const char* input) {
-  if (!input || !input[0]) return TRV_UNKNOWN;
+uint8_t TrvCmdToIdx(const char* input) {
+  if (!input || !*input) return TRV_UNKNOWN;
   for (uint8_t i = 0; i < TRV_COUNT; i++)
     if (!strcasecmp(input, TrvSubCmds[i])) return i;
   return TRV_UNKNOWN;
@@ -331,10 +365,10 @@ const char* IdxToTrvCmd(uint8_t index) {
   return TrvSubCmds[index];
 }
 
-char *topicPrefix(int prefix, const uint8_t *addr, int useAlias){
+char *topicPrefix(int prefix, const uint8_t *addr, int useAlias) {
   static char stopic[TOPSZ];
   const char *id = addrStr(addr, useAlias);
-  if (!EQ3TopicStyle){
+  if (!EQ3TopicStyle) {
     GetTopic_P(stopic, prefix, TasmotaGlobal.mqtt_topic, "");
     strlcat(stopic, "EQ3/", sizeof(stopic));
     strlcat(stopic, id, sizeof(stopic));
@@ -361,7 +395,7 @@ bool EQ3Operation(const uint8_t *MAC, const uint8_t *data, int datalen, int cmdt
 
   // ALWAYS use this function to create a new one.
   int res = BLE_ESP32::newOperation(&op);
-  if (!res){
+  if (!res) {
     AddLog(LOG_LEVEL_ERROR, "EQ3: %s: Can't get a newOperation \"%s\" from BLE", addrStr(MAC, cmdtype & 0x80), IdxToTrvCmd(cmdtype & 0x7f));
     retries = 0;
     return 0;
@@ -393,13 +427,13 @@ bool EQ3Operation(const uint8_t *MAC, const uint8_t *data, int datalen, int cmdt
   op->context = (void *)cmdtype;
 
   res = BLE_ESP32::extQueueOperation(&op);
-  if (!res){
+  if (!res) {
     // if it fails to add to the queue, do please delete it
     BLE_ESP32::freeOperation(&op);
     AddLog(LOG_LEVEL_ERROR, "EQ3: %s: Failed to queue new operation \"%s\" - deleted", addrStr(MAC, cmdtype & 0x80), IdxToTrvCmd(cmdtype & 0x7f));
     retries = 0;
   } else {
-    if (retries_in){
+    if (retries_in) {
       retries = retries_in;
     }
   }
@@ -407,52 +441,57 @@ bool EQ3Operation(const uint8_t *MAC, const uint8_t *data, int datalen, int cmdt
   return res;
 }
 
-int EQ3DoOp(){
-  if (!opInProgress){
-    if (opQueue.size()){
-      op_t* op = opQueue[0];
-      if (EQ3Operation(op->addr, op->towrite, op->writelen, op->cmdtype, EQ3Retries)){
-        opQueue.pop_front();
-        opInProgress = 1;
-        AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation \"%s\" dequeued - len now %d", addrStr(op->addr, (op->cmdtype & 0x80)), IdxToTrvCmd(op->cmdtype & 0x7f), opQueue.size());
-        delete op;
-        return 1;
-      } else {
-        AddLog(LOG_LEVEL_ERROR, "EQ3: %s: Operation \"%s\" BLE could not start op queue - len %d", addrStr(op->addr, (op->cmdtype & 0x80)), IdxToTrvCmd(op->cmdtype & 0x7f), opQueue.size());
-      }
+void EQ3DoOp() {
+  if (!opInProgress && !opQueue.empty()) {
+    op_t* op = opQueue.front().get();
+
+/// Simulation
+#ifdef EQ3_SIMULATION
+    if (!memcmp(op->addr, TESTADDR1, 6)) {
+      AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation 1/%u \"%s\" only simulated -> removed", addrStr(op->addr, (op->cmdtype & 0x80)), opQueue.size(), IdxToTrvCmd(op->cmdtype & 0x7f));
+      opQueue.pop_front(); 
+      return;
+    }
+#endif // EQ3_SIMULATION
+
+    if (EQ3Operation(op->addr, op->towrite, op->writelen, op->cmdtype, EQ3Retries)) {
+      opInProgress = true;
+      AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation 1/%u \"%s\" processing", addrStr(op->addr, (op->cmdtype & 0x80)), opQueue.size(), IdxToTrvCmd(op->cmdtype & 0x7f));
+    } else {
+      AddLog(LOG_LEVEL_ERROR, "EQ3: %s: Operation 1/%u \"%s\" not started -> removed", addrStr(op->addr, (op->cmdtype & 0x80)), opQueue.size(), IdxToTrvCmd(op->cmdtype & 0x7f));
+      opQueue.pop_front(); 
     }
   }
-  return 0;
 }
 
 int EQ3QueueOp(const uint8_t *MAC, const uint8_t *data, int datalen, int cmdtype, int useAlias) {
-  op_t* newop = new op_t;
+  auto newop = std::make_unique<op_t>();
   memcpy(newop->addr, MAC, 6);
   memcpy(newop->towrite, data, datalen);
   newop->writelen = datalen;
-  newop->cmdtype = cmdtype | (useAlias?0x80:0);
-  opQueue.push_back(newop);
-  int qlen = opQueue.size();
-  AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation \"%s\" queued - len now %d", addrStr(newop->addr, (newop->cmdtype & 0x80)), IdxToTrvCmd(newop->cmdtype & 0x7f), qlen);
+  newop->cmdtype = cmdtype | (useAlias ? 0x80 : 0);
+  size_t qlen = opQueue.size() + 1;
+  AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation 1/%u \"%s\" queued", addrStr(newop->addr, (newop->cmdtype & 0x80)), qlen, IdxToTrvCmd(newop->cmdtype & 0x7f));
+  opQueue.push_back(std::move(newop));
   EQ3DoOp();
   return qlen;
 }
 
-int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
+int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries) {
   int res = 0;
-  opInProgress = 0;
+  opInProgress = false;
   ResponseClear();
 
-  uint8_t addrev[7];
+  uint8_t addrev[6];
   const uint8_t *native = op->addr.getVal();
   memcpy(addrev, native, 6);
   BLE_ESP32::ReverseMAC(addrev);
 
-  eq3_device_tag *eq3 = nullptr;
+  eq3_device_t *eq3 = nullptr;
 
   int free = -1;
-  for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++){
-    if (!memcmp(EQ3Devices[i].addr, addrev, 6)){
+  for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
+    if (!memcmp(EQ3Devices[i].addr, addrev, 6)) {
       eq3 = &EQ3Devices[i];
       break;
     }
@@ -478,9 +517,9 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
   uint8_t statlen = 0;
   uint32_t stattime = 0;
 
-  if (success){
-    if ((op->notifylen >= 6) && (op->dataNotify[0] == 2) && (op->dataNotify[1] == 1)){
-      if (eq3){
+  if (success) {
+    if ((op->notifylen >= 6) && (op->dataNotify[0] == 2) && (op->dataNotify[1] == 1)) {
+      if (eq3) {
         memcpy(eq3->lastStatus, op->dataNotify, (op->notifylen <= 10)?op->notifylen:16);
         eq3->lastStatusLen = (op->notifylen <= 10)?op->notifylen:16;
         eq3->lastStatusTime = UtcTime();
@@ -492,7 +531,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
     stattime = UtcTime();
   }
 
-  if (eq3){
+  if (eq3) {
     status = eq3->lastStatus;
     statlen = eq3->lastStatusLen;
     stattime = eq3->lastStatusTime;
@@ -507,7 +546,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
     ResponseAppend_P(",\"posn\":%d", eq3->DutyCycle);
     int stat = status[2];
     ResponseAppend_P(",\"mode\":");
-    switch (stat & 3){
+    switch (stat & 3) {
       case 0:
         ResponseAppend_P("\"auto\"");
         break;
@@ -559,7 +598,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
     ResponseAppend_P(",\"battery\":\"%s\"", eq3->Battery ? "LOW" : "GOOD");
   }
 
-  if ((statlen >= 10) && (status[0] == 2) && (status[1] == 1)){
+  if ((statlen >= 10) && (status[0] == 2) && (status[1] == 1)) {
     int mm = status[8] * 30;
     int hh = mm / 60;
     mm = mm % 60;
@@ -577,16 +616,15 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
       f_temp = ((float)status[14] - 7) / 2;
       ResponseAppend_P(",\"offset\":%1_f", &f_temp);
     }
-
   }
 
   if (success) {
     // now to parse other data - this may not have been a stat message
-    if ((op->notifylen >= 3) && (op->dataNotify[0] == 2) && (op->dataNotify[1] == 2)){
+    if ((op->notifylen >= 3) && (op->dataNotify[0] == 2) && (op->dataNotify[1] == 2)) {
       ResponseAppend_P(",\"profiledayset\":%d", op->dataNotify[2]);
     }
 
-    if ((op->notifylen >= 16) && (op->dataNotify[0] == 0x21)){
+    if ((op->notifylen >= 16) && (op->dataNotify[0] == 0x21)) {
 //YY is the time, coded as (minutes/10), up to which to maintain the temperature declared in XX
 //XX represents the temperature to be maintained until then, codified as (temperature*2)
 // byte 0: 21 (default value)
@@ -600,7 +638,7 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
 // byte (14,15): 22 90 (unused)
       ResponseAppend_P(",\"profileday%d\":\"", op->dataNotify[1]);
       uint8_t *data = op->dataNotify + 2;
-      for (int i = 0; i < 7; i++){
+      for (int i = 0; i < 7; i++) {
         float t = *(data++);
         t /= 2;
         int mm = *(data++);
@@ -609,11 +647,11 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
         mm = mm % 60;
         ResponseAppend_P("%1_f-%02d:%02d", &t, hh, mm);
         // stop if the last one is 24.
-        if (hh == 24){
+        if (hh == 24) {
           break;
         }
 
-        if (i < 6){
+        if (i < 6) {
           ResponseAppend_P(",");
         }
       }
@@ -626,12 +664,12 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
   ResponseAppend_P("}");
 
   int type = STAT;
-  if (cmdtype){
+  if (cmdtype) {
     type = STAT;
   } else {
     // it IS a poll command
-    if (EQ3HideFailedPoll){
-      if (!success){
+    if (EQ3HideFailedPoll) {
+      if (!success) {
         AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Poll fail not sent because EQ3HideFailedPoll", addrStr(addrev));
         return res;
       }
@@ -643,66 +681,66 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
   return res;
 }
 
-int EQ3GenericOpCompleteFn(BLE_ESP32::generic_sensor_t *op){
-  uint32_t context = (uint32_t) op->context;
-  opInProgress = 0;
+int EQ3GenericOpCompleteFn(BLE_ESP32::generic_sensor_t *op) {
+  const bool is_failed = (op->state <= GEN_STATE_FAILED);
+  const uint32_t context = (uintptr_t)op->context;
 
-  if (op->state <= GEN_STATE_FAILED){
-    uint8_t addrev[7];
-    const uint8_t *native = op->addr.getVal();
-    memcpy(addrev, native, 6);
-    BLE_ESP32::ReverseMAC(addrev);
+  uint8_t addrev[6];
+  std::copy_n(op->addr.getVal(), 6, addrev);
+  BLE_ESP32::ReverseMAC(addrev);
 
-    if (retries > 1){
-      retries--;
+  if (is_failed && retries > 1) {
+    retries--;
 
-      if (EQ3Operation(addrev, op->dataToWrite, op->writelen, (int)op->context)){
-        //EQ3ParseOp(op, false, retries);
-        AddLog(LOG_LEVEL_ERROR, "EQ3: %s: TRV operation \"%s\" failed - retries left: %d - State: %d", addrStr(addrev), IdxToTrvCmd(context & 0x7f), retries, op->state);
-        opInProgress = 1;
-      } else {
-        retries = 0;
-        EQ3ParseOp(op, false, 0);
-        AddLog(LOG_LEVEL_ERROR, "EQ3: %s: TRV operation \"%s\" failed to send - State: %d", addrStr(addrev), IdxToTrvCmd(context & 0x7f), op->state);
-      }
-    } else {
-      retries = 0;
-      EQ3ParseOp(op, false, 0);
-      AddLog(LOG_LEVEL_ERROR, "EQ3: %s: TRV operation \"%s\" failed - no more retries - State: %d", addrStr(addrev), IdxToTrvCmd(context & 0x7f), op->state);
+    if (EQ3Operation(addrev, op->dataToWrite, op->writelen, (int)context)) {
+      AddLog(LOG_LEVEL_INFO, "EQ3: %s: Operation 1/%u \"%s\" failed - retries left: %d - State: %d", addrStr(addrev), opQueue.size(), IdxToTrvCmd(context & 0x7f), retries, op->state);
+      opInProgress = true;
+      return 0; 
     }
-    return 0;
+    retries = 0; 
   }
 
+  if (is_failed) {
+    AddLog(LOG_LEVEL_ERROR, "EQ3: %s: Operation 1/%u \"%s\" final fail - State: %d", addrStr(addrev), opQueue.size(), IdxToTrvCmd(context & 0x7f), op->state);
+  } else {
+    AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation 1/%u \"%s\" done", addrStr(addrev), opQueue.size(), IdxToTrvCmd(context & 0x7f));
+  }
+  
+  EQ3ParseOp(op, !is_failed, 0);
   retries = 0;
+  opInProgress = false;
 
-  EQ3ParseOp(op, true, 0);
+  if (!opQueue.empty()) opQueue.pop_front();
+
+  if (opQueue.empty()) {
+    AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: Operation queue is empty", addrStr(addrev));
+  }
+
   return 0;
 }
-
-
 
 /*********************************************************************************************\
  * Functons actualy called from within the BLE task
 \*********************************************************************************************/
 
-int ispairing2(const uint8_t *payload, int len, char *name, int namelen, char *serial, int seriallen ){
-  while (len){
+int ispairing2(const uint8_t *payload, int len, char *name, int nameLen, char *serial, int serialLen ) {
+  while (len) {
     int l = *payload;
     //BLE_ESP32::dump(temp, 40, payload, l+1);
     //AddLog(LOG_LEVEL_ERROR, PSTR("EQ3: %s"), temp);
 
     payload++;
     len--;
-    if (len < l){
+    if (len < l) {
       //AddLog(LOG_LEVEL_ERROR, PSTR("EQ3: part len er %d<%d"),len, l);
       return 0;
     }
-    switch (*payload){
+    switch (*payload) {
       case 0xff: {// parse the EQ3 advert payload looking for nnFF01ssssssss
         payload++;
         len--;
         l--;
-        if (*payload == 1){
+        if (*payload == 1) {
           payload++;
           len--;
           l--;
@@ -710,9 +748,8 @@ int ispairing2(const uint8_t *payload, int len, char *name, int namelen, char *s
           //strncpy(serialstr, (const char *)payload, l);
           //AddLog(LOG_LEVEL_DEBUG, PSTR("EQ3: adv part FF01 detected %s"), serialstr);
           // we don;t use these, but that's what they seem to be....
-          uint8_t copylen = (l > seriallen)?seriallen:l;
-          strncpy(serial, (const char *)payload, copylen);
-          serial[seriallen-1] = 0;
+          strncpy(serial, (const char *)payload, tmin(l, serialLen));
+          serial[serialLen - 1] = 0;
           payload += l;
           len -= l;
           return 1;
@@ -725,7 +762,7 @@ int ispairing2(const uint8_t *payload, int len, char *name, int namelen, char *s
         payload++;
         len--;
         l--;
-        if (*payload == 1){
+        if (*payload == 1) {
           payload++;
           len--;
           l--;
@@ -733,9 +770,8 @@ int ispairing2(const uint8_t *payload, int len, char *name, int namelen, char *s
           //strncpy(serialstr, (const char *)payload, l);
           //AddLog(LOG_LEVEL_DEBUG, PSTR("EQ3: adv part FF01 detected %s"), serialstr);
           // we don;t use these, but that's what they seem to be....
-          uint8_t copylen = (l > namelen)?namelen:l;
-          strncpy(name, (const char *)payload, copylen);
-          name[namelen-1] = 0;
+          strncpy(serial, (const char *)payload, tmin(l, serialLen));
+          name[nameLen - 1] = 0;
           payload += l;
           len -= l;
           //return 1;
@@ -753,26 +789,26 @@ int ispairing2(const uint8_t *payload, int len, char *name, int namelen, char *s
   return 0;
 }
 
-int ispairing(const uint8_t *payload, int len){
+int ispairing(const uint8_t *payload, int len) {
   //char temp[40];
   //BLE_ESP32::dump(temp, 40, payload, len);
   //AddLog(LOG_LEVEL_DEBUG, PSTR("EQ3: pair%d %s"), len, temp);
-  while (len){
+  while (len) {
     int l = *payload;
     //BLE_ESP32::dump(temp, 40, payload, l+1);
     //AddLog(LOG_LEVEL_ERROR, PSTR("EQ3: %s"), temp);
 
     payload++;
     len--;
-    if (len < l){
+    if (len < l) {
       //AddLog(LOG_LEVEL_ERROR, PSTR("EQ3: part len er %d<%d"),len, l);
       return 0;
     }
-    if (*payload == 0xff){
+    if (*payload == 0xff) {
       payload++;
       len--;
       l--;
-      if (*payload == 1){
+      if (*payload == 1) {
         payload++;
         len--;
         l--;
@@ -781,7 +817,7 @@ int ispairing(const uint8_t *payload, int len){
         //AddLog(LOG_LEVEL_DEBUG, PSTR("EQ3: adv part FF01 detected %s"), serialstr);
         // we don;t use these, but that's what they seem to be....
         const uint8_t *serial = payload;
-        uint8_t seriallen = l;
+        uint8_t serialLen = l;
         payload += l;
         len -= l;
         return 1;
@@ -797,63 +833,45 @@ int ispairing(const uint8_t *payload, int len){
   return 0;
 }
 
-int TaskEQ3AddDevice(int8_t RSSI, const uint8_t* addr, char *serial){
-  int free = -1;
-  int i = 0;
-  uint64_t now = esp_timer_get_time();
+void TaskEQ3AddDevice(int8_t RSSI, const uint8_t* addr, char *serial) {
+  eq3_device_t* targetDevice = nullptr;
+  eq3_device_t* firstFreeSlot = nullptr;
 
-  if (serial && serial[0] && !pairing){
+  if (serial && *serial && !pairing) {
     memcpy(pairingaddr, addr, 6);
     strncpy(pairingserial, serial, sizeof(pairingserial));
-    pairingserial[sizeof(pairingserial)-1] = 0;
-    pairing = 1;
+    pairingserial[sizeof(pairingserial) - 1] = 0;
+    pairing = true;
   }
 
-  for(i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
-    if(!memcmp(addr, EQ3Devices[i].addr, 6)) {
-      break;
+  for (auto& device : EQ3Devices) {
+    if (!memcmp(addr, device.addr, 6)) {
+      targetDevice = &device;
+      break; 
     }
-    if (EQ3Devices[i].timeoutTime && (EQ3Devices[i].timeoutTime < now)) {
+    if (!device.timeoutTime && !firstFreeSlot) {
+      firstFreeSlot = &device;
+    }
+  }
+
+  if (!targetDevice) {
+    if (firstFreeSlot) {
+      targetDevice = firstFreeSlot;
+      NextPollSeconds = 1;
 #ifdef EQ3_DEBUG
-    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], "EQ3: %s: timeout at %d", addrStr(EQ3Devices[i].addr), i);
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], "EQ3: %s: New TRV at #%d", addrStr(addr), targetDevice - EQ3Devices);
 #endif
-      EQ3Devices[i].timeoutTime = 0;
-    }
-    if (!EQ3Devices[i].timeoutTime){
-      if (free == -1){
-        free = i;
-      }
-    }
-  }
-
-  if (i == EQ3_NUM_DEVICESLOTS){
-    if (free >= 0){
-      i = free;
     } else {
-      AddLog(LOG_LEVEL_ERROR, "EQ3: %s: lost > %d devices", addrStr(addr), EQ3_NUM_DEVICESLOTS);
-      return 0;
+      AddLog(LOG_LEVEL_ERROR, "EQ3: %s: All %d slots used", addrStr(addr), EQ3_NUM_DEVICESLOTS);
+      return;
     }
   }
 
-#ifdef EQ3_DEBUG
-  if (!EQ3Devices[i].timeoutTime)
-    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], "EQ3: %s: added at %d", addrStr(addr), i);
-#endif
-
-  EQ3Devices[i].timeoutTime = now + 1000000ULL * EQ3_TIMEOUT;
-  memcpy(EQ3Devices[i].addr, addr, 6);
-  EQ3Devices[i].RSSI = RSSI;
-
-  EQ3Devices[i].pairing = (serial && serial[0])?1:0;
-
-  return 1;
+  targetDevice->timeoutTime = esp_timer_get_time() + 1000000ULL * EQ3_TIMEOUT;
+  memcpy(targetDevice->addr, addr, 6);
+  targetDevice->RSSI = RSSI;
+  targetDevice->pairing = (serial && *serial);
 }
-
-constexpr const char* const EQ3Names[] = {
-  "CC-RT-BLE",
-  "CC-RT-BLE-EQ",
-  "CC-RT-M-BLE"
-};
 
 int TaskEQ3advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
 {
@@ -869,27 +887,27 @@ int TaskEQ3advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
 
 
   const char *alias = BLE_ESP32::getAlias(addr);
-  if (EQ3OnlyAliased){
+  if (EQ3OnlyAliased) {
     // ignore unless we have an alias.
-    if (!alias || !(*alias)){
+    if (!alias || !*alias) {
       return 0;
     }
   }
   if (!alias) alias = "";
 
   for (size_t i = 0; i < sizeof(EQ3Names) / sizeof(*EQ3Names); i++) {
-    if (!strcmp(nameStr, EQ3Names[i])){
+    if (!strcmp(nameStr, EQ3Names[i])) {
       found = true;
       break;
     }
   }
 
-  if (!found && !strncmp(alias, "EQ3", 3)){
+  if (!found && !strncmp(alias, "EQ3", 3)) {
     found = true;
   }
 
   // if the addr matches the EQ3 mfg prefix, add it?
-  if (!found && EQ3MatchPrefix && (matchPrefix(addr) >= 0)){
+  if (!found && EQ3MatchPrefix && (matchPrefix(addr) >= 0)) {
     found = true;
   }
 
@@ -904,7 +922,7 @@ int TaskEQ3advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
 
   char name[20] = {0};
   char serial[20] = {0};
-  int pairing = 0;
+  bool pairing = false;
   ispairing2(payload, payloadlen, name, 20, serial, 20);
 
   // this will take and keep the mutex until the function is over
@@ -927,7 +945,7 @@ void EQ3Init(void) {
   AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], "EQ3: init: request callbacks");
 #endif
 
-  EQ3Period = Settings->tele_period;
+  EQ3Period = tmax(Settings->tele_period, EQ3_NUM_DEVICESLOTS);
 
   return;
 }
@@ -936,7 +954,7 @@ void EQ3Init(void) {
  * Regular
 \***********************************************************************/
 
-void EQ3Every50mSecond(){
+void EQ3Every50mSecond() {
 
 }
 
@@ -944,94 +962,87 @@ void EQ3Every50mSecond(){
  * @brief Main loop of the driver, "high level"-loop
  *
  */
-int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char* param2, int useAlias);
 
-void EQ3EverySecond(bool restart){
-  if (pairing){
-    char p[40]; // used in dump
-    BLE_ESP32::dump(p, 20, pairingaddr, 6);
-    Response_P("{\"pairing\":\"%s\",\"serial\":\"%s\"}", p, pairingserial);
-    char addrstr[4+8*2+2] = "EQ3/";
-    BLE_ESP32::dump(&addrstr[4], 8*2+2, pairingaddr, 6);
+void EQ3EverySecond(void) {
+
+/// Handle pairing ////
+  if (pairing) {
+    Response_P("{\"pairing\":\"%s\",\"serial\":\"%s\"}", addrStr(pairingaddr), pairingserial);
+    char addrstr[4 + 8 * 2 + 2] = "EQ3/";
+    BLE_ESP32::dump(&addrstr[4], 8 * 2 + 2, pairingaddr, 6);
     char *topic = topicPrefix(STAT, pairingaddr, 1);
     MqttPublish(topic, false);
-    pairing = 0;
+    pairing = false;
   }
 
-  seconds --;
-  if (seconds <= 0){
-    if (EQ3Period){
-      if (nextEQ3Poll >= EQ3_NUM_DEVICESLOTS){
-        AddLog(LOG_LEVEL_DEBUG, "EQ3: poll cycle starting");
-        nextEQ3Poll = 0;
-      } else {
-        AddLog(LOG_LEVEL_ERROR, "EQ3: poll overrun, deferred - last loop only got to %d, not %d", nextEQ3Poll, EQ3_NUM_DEVICESLOTS);
-      }
+/// Check for timeout and cleanup devices ////
+  for (auto& device : EQ3Devices) {
+    if (device.timeoutTime && device.timeoutTime < esp_timer_get_time()) {
+      AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], "EQ3: %s: timed out", addrStr(device.addr));
+      device = eq3_device_t{}; 
     }
-    seconds = EQ3Period;
   }
 
-  if (EQ3Period){
-    int qlen = opQueue.size();
-    if ((nextEQ3Poll < EQ3_NUM_DEVICESLOTS) && (qlen == 0) && (!opInProgress)){
-      if (intervalSecondsCounter){
-        intervalSecondsCounter--;
-      } else {
-        // queue a EQ3Status op against each known EQ3.
-        // mark it as a regular stat rather than a use cmd.
-        for(int i = nextEQ3Poll; i < EQ3_NUM_DEVICESLOTS; i++) {
-          if (!EQ3Devices[i].timeoutTime){
-            nextEQ3Poll = i+1;
-            continue;
-          }
-
-          // trvMinRSSI
-          // find the device in BLE to get RSSI
-          if (EQ3Devices[i].RSSI < trvMinRSSI){
-            AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: RSSI %d < min %d, poll suppressed", addrStr(EQ3Devices[i].addr), EQ3Devices[i].RSSI, trvMinRSSI);
-            nextEQ3Poll = i+1;
-            continue;
-          }
-
-          EQ3Send(EQ3Devices[i].addr, TRV_POLL, nullptr, nullptr, 1);
-          nextEQ3Poll = i + 1;
-          intervalSecondsCounter = intervalSeconds;
-          break;
+/// Handle polling ////
+  if (NextPollSeconds) NextPollSeconds--;
+  if (!NextPollSeconds && EQ3Period && opQueue.empty() && !opInProgress && !pairing) {
+    uint8_t activeDevices = 0;
+    for (const auto& dev : EQ3Devices) {
+      if (dev.timeoutTime) activeDevices++;
+    }
+    if (activeDevices) {
+      for (uint8_t i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
+        uint8_t currentIdx = (nextEQ3Poll + i) % EQ3_NUM_DEVICESLOTS;
+        auto& device = EQ3Devices[currentIdx];
+        if (!device.timeoutTime) continue;
+        if (device.RSSI < trvMinRSSI) {
+          AddLog(LOG_LEVEL_DEBUG, "EQ3: %s: RSSI %d < min %d, poll suppressed", addrStr(device.addr), device.RSSI, trvMinRSSI);
+          continue; 
         }
+        EQ3Send(device.addr, TRV_POLL, nullptr, nullptr, 1);
+        nextEQ3Poll = (currentIdx + 1) % EQ3_NUM_DEVICESLOTS;
+        NextPollSeconds = tmax(EQ3Period / activeDevices, 3);
+        break;
       }
+    } else {
+      NextPollSeconds = EQ3Period; 
     }
   }
 
-  // start next op now, if we have any queued
+//// start next op now, if we have any queued ////
   EQ3DoOp();
+
+//// Simulation ////
+#ifdef EQ3_SIMULATION
+  TaskEQ3AddDevice(-RtcTime.second - 30, TESTADDR1, nullptr);
+  if (TasmotaGlobal.uptime < 120) {
+    for (auto& dev : EQ3Devices) {
+      if (!memcmp(dev.addr, TESTADDR1, 6)) dev.lastStatusTime = UtcTime();
+    }
+  }
+#endif // EQ3_SIMULATION
 
 }
 
 /*********************************************************************************************\
  * Presentation
 \*********************************************************************************************/
-int EQ3SendCurrentDevices(){
-  // send the active devices
+
+void EQ3SendCurrentDevices(void) {
+  bool added = false;
   ResponseClear();
   ResponseAppend_P("{\"devices\":{");
-  int added = 0;
-  for(int i = 0; i < EQ3_NUM_DEVICESLOTS; i++){
-    char p[40];
-    if (!EQ3Devices[i].timeoutTime)
-      continue;
-    if (added){
-      ResponseAppend_P(",");
-    }
-    BLE_ESP32::dump(p, 20, EQ3Devices[i].addr, 6);
-    ResponseAppend_P("\"%s\":%d", p, EQ3Devices[i].RSSI);
-    added = 1;
+  for (const auto& device : EQ3Devices) {
+    if (!device.timeoutTime) continue;
+    if (added) ResponseAppend_P(",");
+    ResponseAppend_P("\"%s\":%d", addrStr(device.addr), device.RSSI);
+    added = true;
   }
   ResponseAppend_P("}}");
   MqttPublishPrefixTopic_P(STAT, "EQ3", false);
-  return 0;
 }
 
-int EQ3SendResult(char *requested, const char *result){
+int EQ3SendResult(char *requested, const char *result) {
   // send the result
   Response_P("{\"result\":\"%s\"}", result);
   static char stopic[TOPSZ];
@@ -1057,25 +1068,27 @@ void EQ3Show(void)
   char c_unit = D_UNIT_CELSIUS[0]; // ToDo: Check if fahrenheit is possible -> temp_format==TEMP_CELSIUS ? D_UNIT_CELSIUS[0] : D_UNIT_FAHRENHEIT[0];
   bool FirstSensorShown = false;
 
-  for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++) {
-    if (EQ3Devices[i].timeoutTime) {
+  for (const auto& device : EQ3Devices) {
+    if (device.timeoutTime) {
       if (FirstSensorShown) WSContentSend_P(HTTP_SNS_HR_THIN);
       FirstSensorShown = true;
       const char *label;
-      const char *alias = BLE_ESP32::getAlias(EQ3Devices[i].addr);
-      if (alias && *alias){
+      const char *alias = BLE_ESP32::getAlias(device.addr);
+      char tlabel[8];
+      if (alias && *alias) {
         label = alias;
         WSContentSend_P(HTTP_EQ3_TYPE, label);
       } else {
-        char tlabel[8];
-        snprintf(tlabel, sizeof(tlabel), "EQ3-%d", i + 1);
+        snprintf(tlabel, sizeof(tlabel), "EQ3-%d", (&device - EQ3Devices) + 1);
         label = tlabel;
       }
-      WSContentSend_P(HTTP_EQ3_MAC, label, addrStr(EQ3Devices[i].addr));
-      WSContentSend_PD(HTTP_EQ3_RSSI, label, WifiGetRssiAsQuality(EQ3Devices[i].RSSI), EQ3Devices[i].RSSI);
-      WSContentSend_PD(HTTP_EQ3_TEMPERATURE, label, Settings->flag2.temperature_resolution, &EQ3Devices[i].TargetTemp, c_unit);
-      WSContentSend_P(HTTP_EQ3_DUTY_CYCLE, label, EQ3Devices[i].DutyCycle);
-      WSContentSend_P(HTTP_EQ3_BATTERY, label, EQ3Devices[i].Battery ? D_NEOPOOL_LOW : D_OK);
+      WSContentSend_P(HTTP_EQ3_MAC, label, addrStr(device.addr));
+      WSContentSend_PD(HTTP_EQ3_RSSI, label, WifiGetRssiAsQuality(device.RSSI), device.RSSI);
+      if (!EQ3Period || device.lastStatusTime + (EQ3Period * 10) > UtcTime()) {
+        WSContentSend_PD(HTTP_EQ3_TEMPERATURE, label, Settings->flag2.temperature_resolution, &device.TargetTemp, c_unit);
+        WSContentSend_P(HTTP_EQ3_DUTY_CYCLE, label, device.DutyCycle);
+        WSContentSend_P(HTTP_EQ3_BATTERY, label, device.Battery ? D_NEOPOOL_LOW : D_OK);
+      }
     }
   }
 }
@@ -1094,7 +1107,7 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
   if (!param2) param2 = "";
   uint8_t d[20];
   memset(d, 0, sizeof(d));
-  int dlen = 0;
+  uint8_t dlen = 0;
 #ifdef EQ3_DEBUG
   AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], "EQ3: %s: cmd: [%s] [%s] [%s]", addrStr(addr), IdxToTrvCmd(CmdIdx), param1, param2);
 #endif
@@ -1104,7 +1117,7 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
       if (!*param1) return -1;
 
       int len = strlen(param1) / 2;
-      if (len > 20){
+      if (len > 20) {
         AddLog(LOG_LEVEL_ERROR, "EQ3: raw len of %s = %d > 20", param1, len);
         return -1;
       }
@@ -1306,7 +1319,7 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
 
     case TRV_MODE: {
       if (!*param1) return -1;
-      return EQ3Send(addr, TrvCmdtoIdx(param1), nullptr, nullptr, useAlias);
+      return EQ3Send(addr, TrvCmdToIdx(param1), nullptr, nullptr, useAlias);
     }
 
     case TRV_DAY: {
@@ -1341,8 +1354,8 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
 
       // 20.5-17:30,
       const char *p = param2;
-      int i = 0;
-      while (p && p[0]) {
+      uint8_t i = 0;
+      while (p && *p) {
         char *p1 = nullptr, *p2 = nullptr, *p3 = nullptr;
         float ftemp = strtof(p, &p1);
         uint8_t hh = (p1 && *p1 == '-') ? (int)strtol(p1 + 1, &p2, 10) : 255;
@@ -1363,7 +1376,7 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
       }
 
       // remaining left at 00 00
-      for (int j = 0; j < 7; j++) {
+      for (uint8_t j = 0; j < 7; j++) {
         d[2 + j * 2] = temps[j];
         d[2 + j * 2 + 1] = times[j];
       }
@@ -1386,165 +1399,142 @@ int EQ3Send(const uint8_t* addr, uint8_t CmdIdx, const char* param1, const char*
   return -1;
 }
 
-constexpr const char* const responses[] = {
-  "Done",
-  "queued",
-  "ignoredbusy",
-  "invcmd",
-  "cmdfail",
-  "invidx",
-  "invaddr"
-};
+uint8_t CmndTrvNext(char *data) {
 
-uint8_t CmndTrvNext(uint32_t index, char *data){
-  AddLog(LOG_LEVEL_DEBUG, "EQ3: cmd index: %d", index);
-
-  switch(index){
-    case 0:
-    case 1: {
-
-      char *p = strtok(data, " ");
-      bool trigger = false;
-      if (!strcasecmp(p, "reset")){
-        retries = 0;
-        for (int i = 0; i < EQ3_NUM_DEVICESLOTS; i++){
-          EQ3Devices[i].timeoutTime = 0;
-        }
-        return 0;
-      }
-
-      if (!strcasecmp(p, "scan")){
-#ifdef EQ3_DEBUG
-        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], "EQ3: cmd: %s", p);
-#endif
-        EQ3SendCurrentDevices();
-        return 0;
-      }
-      if (!strcasecmp(p, "devlist")){
-#ifdef EQ3_DEBUG
-        AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], "EQ3: cmd: %s", p);
-#endif
-        EQ3SendCurrentDevices();
-        return 0;
-      }
-
-      // only allow one command in progress
-      //if (retries) return 2;
-
-      int useAlias = 0;
-      uint8_t addrbin[7];
-      int addrres = BLE_ESP32::getAddr(addrbin, p);
-      if (addrres){
-        if (addrres == 2){
-          AddLog(LOG_LEVEL_DEBUG, "EQ3: addr used alias: %s", p);
-          useAlias = 1;
-        }
-        NimBLEAddress addr(addrbin, addrbin[6]);
-
-#ifdef EQ3_DEBUG
-        //AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("EQ3: cmd addr: %s -> %s"), p, addr.toString().c_str());
-#endif
-      } else {
-        AddLog(LOG_LEVEL_ERROR, "EQ3: addr invalid: %s", p);
-        return 3;
-      }
-
-      // get index of next part of cmd
-      char *cmd = strtok(nullptr, " ");
-      uint8_t CmdIdx = TrvCmdtoIdx(cmd);
-      if (CmdIdx == TRV_UNKNOWN) return 3;
-
-      char *param1 = strtok(nullptr, " ");
-      char *param2 = nullptr;
-      if (param1){
-        param2 = strtok(nullptr, " ");
-      }
-
-      int res = EQ3Send(addrbin, CmdIdx, param1, param2, useAlias);
-
-      if (res > 0) { // succeeded to queue
-        AddLog(LOG_LEVEL_INFO, "EQ3: Command \"%s\" queued", IdxToTrvCmd(CmdIdx));
-        return 1;
-      }
-
-      if (res < 0) { // invalid in some way
-        AddLog(LOG_LEVEL_ERROR, "EQ3: Command \"%s\" failed", IdxToTrvCmd(CmdIdx));
-        return 3;
-      }
-
-      // failed to queue
-      AddLog(LOG_LEVEL_ERROR, "EQ3: Command \"%s\" failed to queue", IdxToTrvCmd(CmdIdx));
-      return 4;
-    } break;
-
-    case 2:
-      retries = 0;
-      return 0;
-      break;
+  char *p = strtok(data, " ");
+  if (!strcasecmp(p, "reset")) {
+    CmndTrvReset(); // only for compability and will removed in future - new command is TrvReset
+    return TRV_DONE;
   }
 
-  return 4;
+  if (!strcasecmp(p, "devlist") || !strcasecmp(p, "scan")) {
+#ifdef EQ3_DEBUG
+    AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_DEBUG], "EQ3: cmd: %s", p);
+#endif
+    CmndTrvDevList(); // only for compability and will removed in future - new commands are TrvDevList or TrvScan
+    return TRV_DONE;
+  }
+
+  // only allow one command in progress
+  //if (retries) return TRV_IGNOREDBUSY;
+
+  int useAlias = 0;
+  uint8_t addrbin[6];
+  int addrres = BLE_ESP32::getAddr(addrbin, p);
+  if (addrres) {
+    if (addrres == 2) {
+      AddLog(LOG_LEVEL_DEBUG, "EQ3: addr used alias: %s", p);
+      useAlias = 1;
+    }
+    NimBLEAddress addr(addrbin, addrbin[6]);
+
+#ifdef EQ3_DEBUG
+    //AddLog(BLE_ESP32::BLELogLevel[LOG_LEVEL_INFO], PSTR("EQ3: cmd addr: %s -> %s"), p, addr.toString().c_str());
+#endif
+  } else {
+    AddLog(LOG_LEVEL_ERROR, "EQ3: addr invalid: %s", p);
+    return TRV_INVADDR;
+  }
+
+  // get index of next part of cmd
+  char *cmd = strtok(nullptr, " ");
+  uint8_t CmdIdx = TrvCmdToIdx(cmd);
+  if (CmdIdx == TRV_UNKNOWN) return TRV_INVCMD;
+
+  char *param1 = strtok(nullptr, " ");
+  char *param2 = nullptr;
+  if (param1) {
+    param2 = strtok(nullptr, " ");
+  }
+
+  int res = EQ3Send(addrbin, CmdIdx, param1, param2, useAlias);
+
+  if (res > 0) { // succeeded to queue
+    AddLog(LOG_LEVEL_INFO, "EQ3: Command \"%s\" queued", IdxToTrvCmd(CmdIdx));
+    return TRV_QUEUED;
+  }
+
+  if (res < 0) { // invalid in some way
+    AddLog(LOG_LEVEL_ERROR, "EQ3: Command \"%s\" failed", IdxToTrvCmd(CmdIdx));
+    return TRV_INVCMD;
+  }
+
+  // failed to queue
+  AddLog(LOG_LEVEL_ERROR, "EQ3: Command \"%s\" failed to queue", IdxToTrvCmd(CmdIdx));
+  return TRV_CMDFAIL;
 }
 
 void CmndTrv(void) {
-  uint8_t res = CmndTrvNext(XdrvMailbox.index, XdrvMailbox.data);
-  ResponseCmndChar(responses[res]);
+  uint8_t res = CmndTrvNext(XdrvMailbox.data);
+  ResponseCmndChar(TrvResponses[res]);
 }
 
 void CmndTrvPeriod(void) {
-  if (XdrvMailbox.data_len > 0) {
-    if (1 == XdrvMailbox.payload){
-      seconds = 0;
+  if (XdrvMailbox.data_len) {
+    if (XdrvMailbox.payload == 1) {
+      NextPollSeconds = 1;
     } else {
       EQ3Period = XdrvMailbox.payload;
-      if (seconds > EQ3Period){
-        seconds = EQ3Period;
-      }
+      if (EQ3Period) EQ3Period = tmax(EQ3Period, EQ3_NUM_DEVICESLOTS);
+      NextPollSeconds = tmin(NextPollSeconds, EQ3Period);
     }
   }
   ResponseCmndNumber(EQ3Period);
 }
 
 void CmndTrvRetries(void) {
-  if (XdrvMailbox.data_len > 0) {
+  if (XdrvMailbox.data_len) {
     EQ3Retries = XdrvMailbox.payload;
   }
   ResponseCmndNumber(EQ3Retries);
 }
 
-void CmndTrvOnlyAliased(void){
-  if (XdrvMailbox.data_len > 0) {
+void CmndTrvOnlyAliased(void) {
+  if (XdrvMailbox.data_len) {
     EQ3OnlyAliased = XdrvMailbox.payload;
   }
   ResponseCmndNumber(EQ3OnlyAliased);
 }
 
-void CmndTrvMatchPrefix(void){
-  if (XdrvMailbox.data_len > 0) {
+void CmndTrvMatchPrefix(void) {
+  if (XdrvMailbox.data_len) {
     EQ3MatchPrefix = XdrvMailbox.payload;
   }
   ResponseCmndNumber(EQ3MatchPrefix);
 }
 
-void CmndTrvMinRSSI(void){
-  if (XdrvMailbox.data_len > 0) {
+void CmndTrvMinRSSI(void) {
+  if (XdrvMailbox.data_len) {
     trvMinRSSI = atoi(XdrvMailbox.data);
   }
   // signed number
   Response_P("{\"%s\":%d}", XdrvMailbox.command, trvMinRSSI);
 }
 
-void CmndTrvHideFailedPoll(void){
-  if (XdrvMailbox.data_len > 0) {
+void CmndTrvHideFailedPoll(void) {
+  if (XdrvMailbox.data_len) {
     EQ3HideFailedPoll = XdrvMailbox.payload;
   }
   ResponseCmndNumber(EQ3HideFailedPoll);
 }
 
+void CmndTrvReset(void) {
+  retries = 0;
+  for (auto& device : EQ3Devices) device = eq3_device_t{};
+  opQueue.clear();
+  opInProgress = false;
+  ResponseCmndDone();
+}
+
+void CmndTrvDevList(void) {
+  EQ3SendCurrentDevices();
+  ResponseCmndDone();
+}
+
 #define EQ3_TOPIC "EQ3"
 static char tmp[120];
 
-bool mqtt_direct(){
+bool mqtt_direct() {
   char stopic[TOPSZ];
   strncpy(stopic, XdrvMailbox.topic, TOPSZ);
   XdrvMailbox.topic[TOPSZ-1] = 0;
@@ -1561,12 +1551,12 @@ bool mqtt_direct(){
   } while (items[cnt-1]);
   cnt--; // represents the number of items
 
-  if (cnt < 4){ // not for us?
+  if (cnt < 4) { // not for us?
     //AddLog(LOG_LEVEL_INFO, PSTR("cnt: %d < 4"), cnt);
     return false;
   }
 
-  for (int i = 0; i < cnt; i++){
+  for (int i = 0; i < cnt; i++) {
     //AddLog(LOG_LEVEL_INFO, PSTR("cnt %d:%s"), i, items[i]);
   }
 
@@ -1591,18 +1581,18 @@ bool mqtt_direct(){
   int remains = 120;
   memset(tmp, 0, sizeof(tmp));
   p = tmp;
-  uint8_t addr[7];
+  uint8_t addr[6];
   int useAlias = BLE_ESP32::getAddr(addr, items[MACindex]);
   int res = 6; // invalid address/alias
 
   // if address or alias valid
-  if (useAlias){
+  if (useAlias) {
     strncpy(p, items[MACindex], remains - 6);
     p += strlen(p);
     *(p++) = 0x20;
     remains = 120 - (p - tmp);
 
-    if (CMDindex){
+    if (CMDindex) {
       strncpy(p, items[CMDindex], remains - 6);
       p += strlen(p);
       *(p++) = 0x20;
@@ -1616,11 +1606,11 @@ bool mqtt_direct(){
     *(p++) = 0;
 
     AddLog(LOG_LEVEL_DEBUG, "EQ3: mqtt->cmdstr %s", tmp);
-    res = CmndTrvNext(1, tmp);
+    res = CmndTrvNext(tmp);
   }
 
   // post result to stat/tas/EQ3/<MAC> {"result":"<string>"}
-  EQ3SendResult(items[MACindex], responses[res]);
+  EQ3SendResult(items[MACindex], TrvResponses[res]);
 
   return true;
 }
@@ -1647,30 +1637,30 @@ constexpr const char EQ3_HA_DISCOVERY_TEMPLATE[] =
   "\"val_tpl\":\"{{ value_json.%s }}\"}";
 
 ///////////TODO - unfinished.....
-void EQ3DiscoveryOneEQ3(){
+void EQ3DiscoveryOneEQ3() {
   // don't detect half-added ones here
-  if (EQ3CurrentSingleSlot >= EQ3_NUM_DEVICESLOTS){
+  if (EQ3CurrentSingleSlot >= EQ3_NUM_DEVICESLOTS) {
     // if we got to the end of the sensors, then don't send more
     return;
   }
 
 #ifdef USE_HOME_ASSISTANT
-  if(Settings->flag.hass_discovery){
-    eq3_device_tag *p;
+  if(Settings->flag.hass_discovery) {
+    eq3_device_t *p;
     do {
       p = &EQ3Devices[EQ3CurrentSingleSlot];
-      if (0 == p->timeoutTime){
+      if (0 == p->timeoutTime) {
         EQ3CurrentSingleSlot++;
       }
     } while ((0 == p->timeoutTime) && (EQ3CurrentSingleSlot <= EQ3_NUM_DEVICESLOTS));
 
-    if (EQ3CurrentSingleSlot >= EQ3_NUM_DEVICESLOTS){
+    if (EQ3CurrentSingleSlot >= EQ3_NUM_DEVICESLOTS) {
       return;
     }
 
     // careful - a missing comma causes a crash!!!!
     // because of the way we loop?
-    const char *classes[] = {
+    constexpr const char* classes[] = {
       "temperature",
       "temp",
       "°C",
@@ -1681,7 +1671,7 @@ void EQ3DiscoveryOneEQ3(){
 
     constexpr size_t datacount = sizeof(classes) / sizeof(*classes) / 3;
 
-    if (p->nextDiscoveryData >= datacount){
+    if (p->nextDiscoveryData >= datacount) {
       p->nextDiscoveryData = 0;
     }
 
@@ -1691,7 +1681,7 @@ void EQ3DiscoveryOneEQ3(){
     char idstr[32];
     const char *alias = BLE_ESP32::getAlias(p->addr);
     const char *id = idstr;
-    if (alias && *alias){
+    if (alias && *alias) {
       id = alias;
     } else {
       sprintf(idstr, "%s%02x%02x%02x",
@@ -1778,7 +1768,7 @@ bool Xdrv85(uint32_t function)
       EQ3_ESP32::EQ3Every50mSecond();
       break;
     case FUNC_EVERY_SECOND:
-      EQ3_ESP32::EQ3EverySecond(false);
+      EQ3_ESP32::EQ3EverySecond();
       break;
     case FUNC_COMMAND:
       result = DecodeCommand(EQ3_ESP32::kEQ3_Commands, EQ3_ESP32::EQ3_Commands);


### PR DESCRIPTION
## Description:
Here is the next major refactoring of the EQ3/TRV ESP32 BLE driver.

Below are the key highlights, alongside many other changes:

* **Optimize data presentation:** Hide sensor data in the Web UI if it is too old.
* **Minimize RAM footprint:** Sort `eq3_device_t` structure members to eliminate compiler memory padding.
* **Robust subcommand queue:** Rework command queue handling utilizing C++ container types to completely prevent memory leaks and minimize heap fragmentation.
* **Streamline device discovery:** Rework `Add device` logic to improve search performance and adapt to an index-free approach.
* **Decouple timeout handling:** Move slot cleanup into the cyclic `EQ3EverySecond` task for deterministic background execution.
* **Smart poll scheduling:** Rewrite polling routines to distribute requests evenly over `EQ3Period` while preventing Bluetooth stack congestion.
* **Unify command syntax:** Change CLI/MQTT commands from `TRV <CMD>` to `TRV<CMD>`.
* **Improve type safety:** Introduce strongly-typed `enum` definitions for driver operation results.
* **Modern C++ practices:** Replace legacy index-based arrays with range-based for loops (*for-each*) when possible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).