### PR TITLE
Keep the first panic in the ESP32 crash recorder

### DIFF
--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -250,18 +250,16 @@ static const char *edesc[] = {
 
 // exccause values set by the interrupt based entry points (int wdt, cache error, double exception, ...)
 // before they call panicHandler(), see esp_private/panic_reason.h
-static const char *pseudo_edesc[] = {
-    "Unknown", "DebugException", "DoubleException", "KernelException",
-    "CoprocException", "IntWdtCpu0", "IntWdtCpu1", "CacheError"
-};
-#define NUM_PSEUDO_EDESCS (sizeof(pseudo_edesc) / sizeof(char *))
+const char kPseudoEdesc[] PROGMEM = "Unknown|DebugException|DoubleException|KernelException|CoprocException|IntWdtCpu0|IntWdtCpu1|CacheError";
+#define NUM_PSEUDO_EDESCS 8
 
 void CrashDump(void)
 {
   if (crash_recorder.magic == crash_magic) {
+    char pseudo_reason[20];
     const char *reason = "Unknown";
     if (crash_recorder.pseudo_excause) {
-      if (crash_recorder.exccause < NUM_PSEUDO_EDESCS) { reason = pseudo_edesc[crash_recorder.exccause]; }
+      reason = GetTextIndexed(pseudo_reason, sizeof(pseudo_reason), (crash_recorder.exccause < NUM_PSEUDO_EDESCS) ? crash_recorder.exccause : 0, kPseudoEdesc);
     } else if (crash_recorder.exccause < NUM_EDESCS) {
       reason = edesc[crash_recorder.exccause];
     }

--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -135,7 +135,13 @@ RTC_NOINIT_ATTR volatile struct {
   uint32_t pc;
   uint32_t exccause;
   uint32_t excvaddr;
+  uint32_t pseudo_excause;                 // recorded through panicHandler(): exccause is a PANIC_RSN_* pseudo cause, not an Xtensa one
 } crash_recorder;
+
+// Only the first panic of a boot is recorded. The interrupt watchdog can fire while the panic handler
+// is still running and re-enter through panicHandler(); that frame only shows the panic handler itself
+// and would replace the one that shows the original exception.
+static bool crash_recorded = false;
 
 bool CrashFlag(void)
 {
@@ -179,11 +185,14 @@ extern "C" {
   void __real_xt_unhandled_exception(XtExcFrame *frame);
 }
 
-extern "C" IRAM_ATTR void custom_crash_recorder(XtExcFrame *exc_frame) {
+extern "C" IRAM_ATTR void custom_crash_recorder(XtExcFrame *exc_frame, bool pseudo_excause) {
+  if (crash_recorded) { return; }
+  crash_recorded = true;
   crash_recorder.magic = crash_magic;   // crash occured
   crash_recorder.pc = exc_frame->pc;
   crash_recorder.exccause = exc_frame->exccause;
   crash_recorder.excvaddr = exc_frame->excvaddr;
+  crash_recorder.pseudo_excause = pseudo_excause;
   for (uint32_t i=0; i<crash_dump_max_len; i++) {
     crash_recorder.stack[i] = 0;
   }
@@ -215,13 +224,12 @@ extern "C" IRAM_ATTR void custom_crash_recorder(XtExcFrame *exc_frame) {
 }
 
 extern "C" IRAM_ATTR void __wrap_panicHandler(XtExcFrame *frame) {
-  custom_crash_recorder(frame);
+  custom_crash_recorder(frame, true);
   __real_panicHandler(frame);  // call the actual panic handler
 }
 
 extern "C" IRAM_ATTR void __wrap_xt_unhandled_exception(XtExcFrame *frame) {
-  crash_recorder.magic = crash_magic;   // crash occured
-  custom_crash_recorder(frame);
+  custom_crash_recorder(frame, false);
   __real_xt_unhandled_exception(frame);  // call the actual panic handler
 }
 
@@ -240,12 +248,26 @@ static const char *edesc[] = {
 };
 #define NUM_EDESCS (sizeof(edesc) / sizeof(char *))
 
+// exccause values set by the interrupt based entry points (int wdt, cache error, double exception, ...)
+// before they call panicHandler(), see esp_private/panic_reason.h
+static const char *pseudo_edesc[] = {
+    "Unknown", "DebugException", "DoubleException", "KernelException",
+    "CoprocException", "IntWdtCpu0", "IntWdtCpu1", "CacheError"
+};
+#define NUM_PSEUDO_EDESCS (sizeof(pseudo_edesc) / sizeof(char *))
+
 void CrashDump(void)
 {
   if (crash_recorder.magic == crash_magic) {
+    const char *reason = "Unknown";
+    if (crash_recorder.pseudo_excause) {
+      if (crash_recorder.exccause < NUM_PSEUDO_EDESCS) { reason = pseudo_edesc[crash_recorder.exccause]; }
+    } else if (crash_recorder.exccause < NUM_EDESCS) {
+      reason = edesc[crash_recorder.exccause];
+    }
     ResponseAppend_P("{\"Exception\":%d,\"Reason\":\"%s\",\"EPC\":\"%08x\",\"EXCVADDR\":\"%08x\"",
       crash_recorder.exccause,    // Exception Cause
-      crash_recorder.exccause < NUM_EDESCS ? edesc[crash_recorder.exccause] : "Unknown",
+      reason,
       crash_recorder.pc,          // Exception Progam Counter
       crash_recorder.excvaddr     // Exception Virtual Address Register - Virtual address that caused last fetch, load, or store exception
     );
@@ -291,13 +313,16 @@ const char *esp32c3_crash_reason[] = {
 #define NUM_C3_REASONS (sizeof(esp32c3_crash_reason) / sizeof(char *))
 
 #include <riscv/rvruntime-frames.h>
-extern "C" IRAM_ATTR void custom_crash_recorder(void *exc_frame) {
+extern "C" IRAM_ATTR void custom_crash_recorder(void *exc_frame, bool pseudo_excause) {
   RvExcFrame *regs = (RvExcFrame *)exc_frame;
 
+  if (crash_recorded) { return; }
+  crash_recorded = true;
   crash_recorder.magic = crash_magic;   // crash occured
   crash_recorder.pc = regs->mepc;
   crash_recorder.exccause = regs->mcause;
   crash_recorder.excvaddr = regs->mtval;
+  crash_recorder.pseudo_excause = pseudo_excause;
   for (uint32_t i=0; i<crash_dump_max_len; i++) {
     crash_recorder.stack[i] = 0;
   }
@@ -317,13 +342,12 @@ extern "C" IRAM_ATTR void custom_crash_recorder(void *exc_frame) {
 }
 
 extern "C" IRAM_ATTR void __wrap_panicHandler(void *frame) {
-  custom_crash_recorder(frame);
+  custom_crash_recorder(frame, true);
   __real_panicHandler(frame);  // call the actual panic handler
 }
 
 extern "C" IRAM_ATTR void __wrap_xt_unhandled_exception(void *frame) {
-  crash_recorder.magic = crash_magic;   // crash occured
-  custom_crash_recorder(frame);
+  custom_crash_recorder(frame, false);
   __real_xt_unhandled_exception(frame);  // call the actual panic handler
 }
 


### PR DESCRIPTION
## Description:

On ESP32 the crash recorder can lose the frame of the original exception. When the panic handler stalls (seen repeatedly on a Sonoff ZBBridge Pro running `tasmota32-zbbrdgpro` 15.5.0.2: the `callx8 panic_handler` in `xt_unhandled_exception` never completed), the interrupt watchdog fires, re-enters through `panicHandler()` and `custom_crash_recorder()` overwrites the RTC record with a frame that only shows the panic handler itself. `Status 12` then reports this for every crash:

```
{"StatusSTK":{"Exception":6,"Reason":"IntegerDivideByZero","EPC":"40082307","EXCVADDR":"3ffda0b4","CallChain":["40082304","40081017","401ef59f","7ffda0b1"]}}
```

`40082307` is `xt_unhandled_exception`+0xf, `40081017` is `__wrap_xt_unhandled_exception`, and exccause 6 on the `panicHandler()` path is `PANIC_RSN_INTWDT_CPU1`, not an integer division — `edesc[]` only knows the Xtensa causes. The original exception (an `InstrFetchProhibited` from `esp_vApplicationIdleHook`) could only be reconstructed from the stale `EXCVADDR` and the tail of the call chain.

Changes in `support_crash_recorder.ino`:

- record only the first panic of a boot (`static bool crash_recorded`), so a nested entry cannot replace the useful frame;
- remember whether the record came in through `panicHandler()` (`pseudo_excause` in the RTC struct) and decode `exccause` with the `PANIC_RSN_*` names in that case (Xtensa `CrashDump()`);
- drop the duplicated `crash_recorder.magic = crash_magic` in `__wrap_xt_unhandled_exception`, the recorder sets it.

Same guard applied to the RISC-V branch; its decoding is unchanged.

Not compiled locally (no toolchain on this machine), relying on CI for the build. ESP8266 is not affected (ESP32-only code path).

**Related issue (if applicable):** none

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [ ] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
