### PR TITLE
Fix Zigbee deferred timer use after free, and the truncated backtrace that hid it

### DIFF
--- a/tasmota/tasmota_support/support_crash_recorder.ino
+++ b/tasmota/tasmota_support/support_crash_recorder.ino
@@ -210,9 +210,13 @@ extern "C" IRAM_ATTR void custom_crash_recorder(XtExcFrame *exc_frame, bool pseu
 
   static const uint32_t depth = 100;
   //Check if first frame is valid
-  bool corrupted = (esp_stack_ptr_is_sane(stk_frame.sp) &&
-                    esp_ptr_executable((void*)esp_cpu_process_stack_pc(stk_frame.pc))) ?
-                    false : true;
+  // On an instruction fetch exception the pc is the bad address the CPU jumped to, not code, while a0/a1
+  // still describe the frame that made the jump. Keep walking so the caller stays visible, same as
+  // esp_backtrace_print_from_frame() does.
+  bool corrupted = !(esp_stack_ptr_is_sane(stk_frame.sp) &&
+                     (esp_ptr_executable((void*)esp_cpu_process_stack_pc(stk_frame.pc)) ||
+                      exc_frame->exccause == EXCCAUSE_INSTR_PROHIBITED ||
+                      exc_frame->exccause == EXCCAUSE_INSTR_ERROR));
   uint32_t i = ((depth <= 0) ? INT32_MAX : depth) - 1;    //Account for stack frame that's already printed
   while (i-- > 0 && stk_frame.next_pc != 0 && !corrupted) {
       if (!esp_backtrace_get_next_frame(&stk_frame)) {    //Get next stack frame

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -525,15 +525,21 @@ void Z_Devices::queueTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait
 }
 
 // Run timer at each tick
-// WARNING: don't set a new timer within a running timer, this causes memory corruption
 void Z_Devices::runTimer(void) {
-  // visit all timers
+  // A timer callback can add or remove timers: publishing attributes runs the Rules and the
+  // Berry handlers, which can send Zigbee commands, which in turn re-arm the read-back and
+  // reachability timers of the target device. Removing an element frees it and leaves the
+  // `next` pointer cached by the iterator dangling, so detach the due timers first and only
+  // then run them.
+  LList<Z_Deferred> due;
   for (auto & defer : _deferred) {
-    uint32_t timer = defer.timer;
-    if (TimeReached(timer)) {
-      (*defer.func)(defer.shortaddr, defer.groupaddr, defer.cluster, defer.endpoint, defer.value);
-      _deferred.remove(&defer);
+    if (TimeReached(defer.timer)) {
+      due.addToLast() = defer;      // keep the original order
+      _deferred.remove(&defer);     // safe, no callback has run yet
     }
+  }
+  for (auto & defer : due) {
+    (*defer.func)(defer.shortaddr, defer.groupaddr, defer.cluster, defer.endpoint, defer.value);
   }
 
   // check if we need to save to Flash


### PR DESCRIPTION
## Description

Two commits. The second one is a real crash in the Zigbee driver; the first is the crash recorder change this PR originally opened for, and is what made that crash findable. Follow-up to #24976.

### Zigbee: use after free in the deferred timer list

`Z_Devices::runTimer()` runs the timer callbacks while iterating `_deferred`:

```cpp
for (auto & defer : _deferred) {
  uint32_t timer = defer.timer;
  if (TimeReached(timer)) {
    (*defer.func)(defer.shortaddr, defer.groupaddr, defer.cluster, defer.endpoint, defer.value);
    _deferred.remove(&defer);
  }
}
```

`LList::iterator` caches `next` on construction and on `++`, so removing the **current** element is safe by design. Removing any **other** element is not, and a callback can do exactly that:

```
Z_PublishAttributes
  -> Z_Devices::jsonPublishFlush
    -> Z_Device::jsonPublishAttrList          callBerryZigbeeDispatcher("attributes_final"), XdrvRulesProcess(0)
      -> a rule or a Berry handler sends a Zigbee command
        -> zigbeeZCLSendCmd -> sendHueUpdate
          -> queueTimer(Z_CAT_READ_CLUSTER) / setTimer(Z_CAT_REACHABILITY)
            -> resetTimersForDevice -> _deferred.remove()      frees the node cached as `next`
```

The next turn of the loop then reads a freed node and calls whatever the allocator left in `func`. The comment above the function ("don't set a new timer within a running timer, this causes memory corruption") describes the hazard, but nothing enforces it and the path above is entered from user rules rather than from the driver itself.

On my ZBBridge Pro, 55 devices and several `ZbReceived` rules that send `ZbSend`, this rebooted about once a day. The bad pointer is always a leftover from the freed block: sometimes a free list pointer (`0x3ffd7114`, `0x3ffd7f24`, `0x3ffda0b4`), sometimes a data field (`0x354`, `0xc88f8924`, and that one appears nowhere in the image). It is always an instruction fetch exception and never a load exception, because the freed node stays mapped.

The fix detaches the due timers into a local list and runs them afterwards, so no iterator is held across a callback. The removal in the first loop only touches the current element, which the iterator already handles, and `addToLast()` keeps the original order.

### ESP32: keep the backtrace going when the crash pc is not code

On an instruction fetch exception the recorded call chain has a single entry that only repeats EPC, so the code that used the bad pointer stays invisible.

`custom_crash_recorder()` starts the walk with `pc = exc_frame->pc`, `sp = exc_frame->a1`, `next_pc = exc_frame->a0` and then validates the first frame:

```cpp
bool corrupted = (esp_stack_ptr_is_sane(stk_frame.sp) &&
                  esp_ptr_executable((void*)esp_cpu_process_stack_pc(stk_frame.pc))) ?
                  false : true;
```

When the CPU jumped through a bad function pointer, `pc` *is* the bad address, so `esp_ptr_executable()` is false by definition and the loop never runs. `a0` and `a1` still describe the frame that made the jump, which is what `esp_backtrace_get_next_frame()` needs, so the callers are recoverable. IDF's own `esp_backtrace_print_from_frame()` skips the same check for `EXCCAUSE_INSTR_PROHIBITED`; this mirrors that and also covers `EXCCAUSE_INSTR_ERROR`, which has the same shape. Both constants come from `xtensa/corebits.h`, already reachable through the `xtensa_api.h` include at the top of the file.

These are the records the ZBBridge Pro produced before the change, both useless as they stand:

```json
{"StatusSTK":{"Exception":20,"Reason":"InstrFetchProhibited","EPC":"00000354","EXCVADDR":"00000354","CallChain":["00000351"]}}
{"StatusSTK":{"Exception":2,"Reason":"InstructionFetchError","EPC":"3ffd7114","EXCVADDR":"3ffd7114","CallChain":["3ffd7111"]}}
```

and this is the next one, after the change:

```json
{"StatusSTK":{"Exception":20,"Reason":"InstrFetchProhibited","EPC":"c88f8924","EXCVADDR":"c88f8924","CallChain":["488f8921","4012271e","400df4b8","400da20a","40157d20"]}}
```

which resolves to

```
488f8921  the bad pointer
4012271e  XdrvCall
400df4b8  XdrvXsnsCall          support_tasmota.ino:226
400da20a  Scheduler / loop      tasmota.ino:823, XdrvXsnsCall(FUNC_EVERY_50_MSECOND)
40157d20  loopTask
```

`runTimer()` is inlined into `Xdrv23`, and `CALLX8` leaves the return address in the callee's `a0`, so the frame at `4012271e` is the faulting function itself returning into `XdrvCall`. That is what pointed at the deferred timer list.

I kept both changes in one PR because the second is the evidence for the first. Happy to split them if you prefer.

## Testing

Built for `tasmota32-zbbrdgpro` and running on the affected device. I will report back after a few days; before the fix it never lasted more than a day.

## Checklist

  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.7
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.x
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla)
