### PR TITLE
Matter: Add RGB+CCT Light5 support

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -224,6 +224,7 @@ extern const bclass be_class_Matter_TLV;   // need to declare it upfront because
 #include "solidify/solidified_Matter_Plugin_4_Light2.h"
 #include "solidify/solidified_Matter_Plugin_9_Virt_Light2.h"
 #include "solidify/solidified_Matter_Plugin_4_Light3.h"
+#include "solidify/solidified_Matter_Plugin_4_Light5.h"
 #include "solidify/solidified_Matter_Plugin_9_Virt_Light3.h"
 #include "solidify/solidified_Matter_Plugin_2_Shutter.h"
 #include "solidify/solidified_Matter_Plugin_3_ShutterTilt.h"

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light5.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_4_Light5.be
@@ -1,0 +1,538 @@
+#
+# Matter_Plugin_Light5.be - implements the behavior for a Light with 5 channels (RGB+CCT)
+#
+# Copyright (C) 2023  Stephan Hadinger & Theo Arends
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#################################################################################
+# Matter 1.4.1 Device Specification
+#################################################################################
+# Device Type: Extended Color Light (0x010D)
+# Device Type Revision: 4 (Matter 1.4.1)
+# Class: Simple | Scope: Endpoint
+# Superset: Color Temperature Light (0x010C)
+#
+# CLUSTERS (Server):
+# - 0x0003: Identify (M)
+# - 0x0004: Groups (M)
+# - 0x0062: Scenes Management (P, M)
+# - 0x0006: On/Off (M)
+# - 0x0008: Level Control (M)
+# - 0x0300: Color Control (M)
+# - 0x0406: Occupancy Sensing (C, O)
+#
+# ELEMENT OVERRIDES:
+# - Identify: TriggerEffect cmd M
+# - Scenes Management: CopyScene cmd P, M
+# - On/Off: Lighting feature M
+# - Level Control: OnOff feature M, Lighting feature M, CurrentLevel 1-254, MinLevel 1, MaxLevel 254
+# - Color Control: HueSaturation and ColorTemperature modes implemented
+#
+# IMPORTANT (Matter 1.4.1):
+# Extended Color Light MUST support BOTH HueSaturation AND ColorTemperature modes.
+# This is a change from earlier versions where one mode was sufficient.
+#################################################################################
+
+#################################################################################
+# Matter 1.4.1 Color Control Cluster (0x0300) - HueSaturation + ColorTemperature
+#################################################################################
+# Cluster Revision: 7 (Matter 1.4.1)
+# Role: Application | Scope: Endpoint
+#
+# FEATURES:
+# - Bit 0 (HS): HueSaturation (M for this device)
+# - Bit 4 (CT): ColorTemperature (M for Extended Color Light in Matter 1.4.1)
+#
+# ATTRIBUTES:
+# ID     | Name                          | Type   | Constraint        | Quality | Default | Access | Conf
+# -------|-------------------------------|--------|-------------------|---------|---------|--------|-----
+# 0x0000 | CurrentHue                    | uint8  | 0-254             | SN      | 0       | RW VO  | HS
+# 0x0001 | CurrentSaturation             | uint8  | 0-254             | SN      | 0       | RW VO  | HS
+# 0x0007 | ColorTemperatureMireds        | uint16 | 0,PhysMin-PhysMax | SN      | 0x00FA  | RW VO  | CT
+# 0x0008 | ColorMode                     | enum8  | desc              | S       | 0       | R V    | M
+# 0x000F | Options                       | map8   | all               |         | 0       | RW VO  | M
+# 0x0010 | NumberOfPrimaries             | uint8  | 0-6               | FX      | null    | R V    | O
+# 0x4001 | EnhancedColorMode             | enum8  | desc              | S       | 0       | R V    | M
+# 0x400A | ColorCapabilities             | map16  | all               | F       | 0       | R V    | M
+# 0x400B | ColorTempPhysicalMinMireds    | uint16 | 0-0xFEFF          | F       | 0       | R V    | CT
+# 0x400C | ColorTempPhysicalMaxMireds    | uint16 | 0-0xFEFF          | F       | 0xFEFF  | R V    | CT
+# 0xFFFC | FeatureMap                    | map32  | all               | F       | 0       | R V    | M
+#
+# ColorMode/EnhancedColorMode values:
+# - 0: CurrentHue and CurrentSaturation (used by this device for HS mode)
+# - 1: CurrentX and CurrentY
+# - 2: ColorTemperatureMireds
+#
+# ColorCapabilities bitmap:
+# - Bit 0: HueSaturation (0x01)
+# - Bit 1: EnhancedHue
+# - Bit 2: ColorLoop
+# - Bit 3: XY
+# - Bit 4: ColorTemperature (0x10)
+#
+# COMMANDS:
+# ID   | Name                    | Dir  | Response | Access | Conf
+# -----|-------------------------|------|----------|--------|-----
+# 0x0000 | MoveToHue              | C→S  | Y        | O      | HS
+# 0x0001 | MoveHue                | C→S  | Y        | O      | HS
+# 0x0002 | StepHue                | C→S  | Y        | O      | HS
+# 0x0003 | MoveToSaturation       | C→S  | Y        | O      | HS
+# 0x0004 | MoveSaturation         | C→S  | Y        | O      | HS
+# 0x0005 | StepSaturation         | C→S  | Y        | O      | HS
+# 0x0006 | MoveToHueAndSaturation | C→S  | Y        | O      | HS
+# 0x000A | MoveToColorTemperature | C→S  | Y        | O      | CT
+# 0x0047 | StopMoveStep           | C→S  | Y        | O      | M
+#
+# MoveToHue: {Hue:uint8(0-254), Direction:enum8, TransitionTime:uint16, OptionsMask:map8, OptionsOverride:map8}
+# MoveToSaturation: {Saturation:uint8(0-254), TransitionTime:uint16, OptionsMask:map8, OptionsOverride:map8}
+# MoveToHueAndSaturation: {Hue:uint8(0-254), Saturation:uint8(0-254), TransitionTime:uint16, OptionsMask:map8, OptionsOverride:map8}
+# MoveToColorTemperature: {ColorTemperatureMireds:uint16, TransitionTime:uint16, OptionsMask:map8, OptionsOverride:map8}
+#
+# NOTES:
+# - Hue: 0-254 maps to 0-360 degrees (254 = 360°, not 255)
+# - Saturation: 0-254 maps to 0-100% (254 = 100%, not 255)
+# - Value 255 is reserved and should not be used
+# - Extended Color Light must support both HS and CT modes (Matter 1.4.1 requirement)
+#################################################################################
+
+import matter
+
+# Matter plug-in for core behavior
+
+#@ solidify:Matter_Plugin_Light5,weak
+
+class Matter_Plugin_Light5 : Matter_Plugin_Light1
+  static var TYPE = "light5"                                # name of the plug-in in json
+  static var DISPLAY_NAME = "Light 5 RGB+CCT"                   # display name of the plug-in
+
+  static var SCHEMA = nil                                   # no parameter
+  static var CLUSTERS  = matter.consolidate_clusters(_class, {
+    # 0x001D: inherited                                     # Descriptor Cluster 9.5 p.453
+    # 0x0003: inherited                                     # Identify 1.2 p.16
+    # 0x0004: inherited                                     # Groups 1.3 p.21
+    # 0x0062: inherited                                     # Scenes Management 1.4 (PROVISIONAL) - replaces 0x0005
+    # 0x0006: inherited                                     # On/Off 1.5 p.48
+    # 0x0008: inherited                                     # Level Control 1.6 p.57
+    0x0300: [0,1,7,8,0xF,0x4001,0x400A,0x400B,0x400C],      # Color Control 3.2 p.111 - HS + CT
+  })
+  static var UPDATE_COMMANDS = matter.UC_LIST(_class, "Hue", "Sat", "CT")
+  static var TYPES = { 0x010D: 4 }                  # Extended Color Light - Matter 1.4.1 Device Library Rev 4
+
+  # Inherited
+  # var device                                        # reference to the `device` global object
+  # var endpoint                                      # current endpoint
+  # var clusters                                      # map from cluster to list of attributes, typically constructed from CLUSTERS hierachy
+  # var tick                                          # tick value when it was last updated
+  # var node_label                                    # name of the endpoint, used only in bridge mode, "" if none
+  # var virtual                                       # (bool) is the device pure virtual (i.e. not related to a device implementation by Tasmota)
+  # var shadow_onoff                                  # (bool) status of the light power on/off
+  # var shadow_bri                                    # (int 0..254) brightness before Gamma correction - as per Matter 255 is not allowed
+  var shadow_hue                                    # (int 0..254) hue of color, may need to be extended to 0..360 for value in degrees
+  var shadow_sat                                    # (int 0..254) saturation of color
+  var shadow_ct
+  var ct_min
+  var ct_max
+  var shadow_color_mode
+
+  #############################################################
+  # Constructor
+  def init(device, endpoint, arguments)
+    super(self).init(device, endpoint, arguments)
+
+    self.shadow_hue = nil
+    self.shadow_sat = nil
+    self.shadow_ct = nil
+    self.shadow_color_mode = nil
+
+    self.update_ct_minmax()
+  end
+
+  def update_ct_minmax()
+    var ct_alexa_mode = tasmota.get_option(82)
+    self.ct_min = ct_alexa_mode ? 200 : 153
+    self.ct_max = ct_alexa_mode ? 380 : 500
+  end
+
+  def set_ct(ct)
+    self.update_ct_minmax()
+
+    if ct < self.ct_min
+      ct = self.ct_min
+    end
+
+    if ct > self.ct_max
+      ct = self.ct_max
+    end
+
+    if self.BRIDGE
+      var ret = self.call_remote_sync("CT", str(ct))
+      if ret != nil
+        self.parse_status(ret, 11)
+      end
+
+    elif self.VIRTUAL
+      if ct != self.shadow_ct
+        self.attribute_updated(0x0300, 0x0007)
+        self.shadow_ct = ct
+      end
+
+    else
+      tasmota.cmd("CT " + str(ct))
+
+      self.shadow_ct = ct
+
+      if self.shadow_color_mode != 2
+        self.shadow_color_mode = 2
+        self.attribute_updated(0x0300, 0x0008)
+        self.attribute_updated(0x0300, 0x4001)
+      end
+
+      self.attribute_updated(0x0300, 0x0007)
+
+      self.update_shadow()
+    end
+  end
+
+  #############################################################
+  # Update shadow
+  #
+  def update_shadow()
+    if !self.VIRTUAL && !self.BRIDGE
+      import light
+      super(self).update_shadow()
+
+      var light_status = light.get(self.light_index)
+
+      if light_status != nil
+        var hue = light_status.find('hue', nil)
+        var sat = light_status.find('sat', nil)
+        var ct = light_status.find('ct', nil)
+        var colormode = light_status.find('colormode', nil)
+
+        # Detect the actual color mode restored by Tasmota
+        if colormode == 'ct'
+          if self.shadow_color_mode != 2
+            self.shadow_color_mode = 2
+            self.attribute_updated(0x0300, 0x0008)
+            self.attribute_updated(0x0300, 0x4001)
+          end
+
+        elif colormode == 'rgb'
+          if self.shadow_color_mode != 0
+            self.shadow_color_mode = 0
+            self.attribute_updated(0x0300, 0x0008)
+            self.attribute_updated(0x0300, 0x4001)
+          end
+        end
+
+        # In RGB mode, synchronize Hue/Saturation only
+        if self.shadow_color_mode == 0
+          if hue != nil
+            hue = tasmota.scale_uint(hue, 0, 360, 0, 254)
+
+            if hue != self.shadow_hue
+              self.shadow_hue = hue
+              self.attribute_updated(0x0300, 0x0000)
+            end
+          end
+
+          if sat != nil
+            sat = tasmota.scale_uint(sat, 0, 255, 0, 254)
+
+            if sat != self.shadow_sat
+              self.shadow_sat = sat
+              self.attribute_updated(0x0300, 0x0001)
+            end
+          end
+
+        # In CT mode, synchronize Color Temperature only
+        elif self.shadow_color_mode == 2
+          if ct != nil
+            self.update_ct_minmax()
+
+            if ct < self.ct_min
+              ct = self.ct_min
+            end
+
+            if ct > self.ct_max
+              ct = self.ct_max
+            end
+
+            if ct != self.shadow_ct
+              self.shadow_ct = ct
+              self.attribute_updated(0x0300, 0x0007)
+            end
+          end
+        end
+      end
+
+    else
+      super(self).update_shadow()
+    end
+  end
+
+  #############################################################
+  # set_hue_sat
+  #
+  # `hue` 0..254 or `nil`
+  # `sat` 0..255 or `nil`
+  def set_hue_sat(hue_254, sat_254)
+    # sanity checks on values
+    if hue_254 != nil
+      if hue_254 < 0      hue_254 = 0     end
+      if hue_254 > 254    hue_254 = 254   end
+    end
+    if sat_254 != nil
+      if sat_254 < 0      sat_254 = 0     end
+      if sat_254 > 254    sat_254 = 254   end
+    end
+
+    if self.BRIDGE
+      if hue_254 != nil
+        var hue_360 = tasmota.scale_uint(hue_254, 0, 254, 0, 360)
+        var ret = self.call_remote_sync("HSBColor1", hue_360)
+        if ret != nil
+          self.parse_status(ret, 11)        # update shadow from return value
+        end
+      end
+      if sat_254 != nil
+        var sat_100 = tasmota.scale_uint(sat_254, 0, 254, 0, 100)
+        var ret = self.call_remote_sync("HSBColor2", sat_100)
+        if ret != nil
+          self.parse_status(ret, 11)        # update shadow from return value
+        end
+      end
+    elif self.VIRTUAL
+      if hue_254 != nil
+        if hue_254 != self.shadow_hue   self.attribute_updated(0x0300, 0x0000)   self.shadow_hue = hue_254   end
+      end
+      if sat_254 != nil
+        if sat_254 != self.shadow_sat   self.attribute_updated(0x0300, 0x0001)   self.shadow_sat = sat_254   end
+      end
+    else
+      var hue_360 = (hue_254 != nil) ? tasmota.scale_uint(hue_254, 0, 254, 0, 360) : nil
+      var sat_255 = (sat_254 != nil) ? tasmota.scale_uint(sat_254, 0, 254, 0, 255) : nil
+
+      if (hue_360 != nil) && (sat_255 != nil)
+        light.set({'hue': hue_360, 'sat': sat_255}, self.light_index)
+      elif (hue_360 != nil)
+        light.set({'hue': hue_360}, self.light_index)
+      else
+        light.set({'sat': sat_255}, self.light_index)
+      end
+      if self.shadow_color_mode != 0
+        self.shadow_color_mode = 0
+        self.attribute_updated(0x0300, 0x0008)
+        self.attribute_updated(0x0300, 0x4001)
+      end
+      self.update_shadow()
+    end
+  end
+
+  #############################################################
+  # read an attribute
+  #
+  def read_attribute(session, ctx, tlv_solo)
+    var cluster = ctx.cluster
+    var attribute = ctx.attribute
+      
+    # ====================================================================================================
+    if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
+      self.update_shadow_lazy()
+      if   attribute == 0x0000          #  ---------- CurrentHue / u1 ----------
+        return tlv_solo.set_or_nil(0x04 #-TLV.U1-#, self.shadow_hue)
+      elif attribute == 0x0001          #  ---------- CurrentSaturation / u2 ----------
+        return tlv_solo.set_or_nil(0x04 #-TLV.U1-#, self.shadow_sat)
+      elif attribute == 0x0007          # ---------- ColorTemperatureMireds ----------
+        self.update_ct_minmax()
+        return tlv_solo.set_or_nil(0x05 #-TLV.U2-#, self.shadow_ct)
+
+      elif attribute == 0x0008          # ---------- ColorMode ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, self.shadow_color_mode)
+
+      elif attribute == 0x000F          # ---------- Options ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, 0)
+
+      elif attribute == 0x4001          # ---------- EnhancedColorMode ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, self.shadow_color_mode)
+
+      elif attribute == 0x400A          # ---------- ColorCapabilities ----------
+        return tlv_solo.set(0x05 #-TLV.U2-#, 0x11)    # HS + CT
+
+      elif attribute == 0x400B          # ---------- ColorTempPhysicalMinMireds ----------
+        self.update_ct_minmax()
+        return tlv_solo.set(0x05 #-TLV.U2-#, self.ct_min)
+
+      elif attribute == 0x400C          # ---------- ColorTempPhysicalMaxMireds ----------
+        self.update_ct_minmax()
+        return tlv_solo.set(0x05 #-TLV.U2-#, self.ct_max)
+      
+      # Defined Primaries Information Attribute Set
+      elif attribute == 0x0010          #  ---------- NumberOfPrimaries / u1 ----------
+        return tlv_solo.set(0x04 #-TLV.U1-#, 0)
+
+      elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
+        return tlv_solo.set(0x06 #-TLV.U4-#, 0x11)    # HS + CT
+      end
+
+    end
+    return super(self).read_attribute(session, ctx, tlv_solo)
+  end
+
+  #############################################################
+  # Invoke a command
+  #
+  # returns a TLV object if successful, contains the response
+  #   or an `int` to indicate a status
+  def invoke_request(session, val, ctx)
+    var TLV = matter.TLV
+    var cluster = ctx.cluster
+    var command = ctx.command
+
+    # ====================================================================================================
+    if   cluster == 0x0300              # ========== Color Control 3.2 p.111 ==========
+      if !self.mqtt_command_ready(ctx)   return nil   end
+      self.update_shadow_lazy()
+      if   command == 0x0000            # ---------- MoveToHue ----------
+        var hue_in = val.findsubval(0)  # Hue 0..254
+        self.set_hue_sat(hue_in, nil)
+        ctx.log = "hue:"+str(hue_in)
+        self.publish_command('Hue', hue_in)
+        return true
+      elif command == 0x0001            # ---------- MoveHue ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x0002            # ---------- StepHue ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x0003            # ---------- MoveToSaturation ----------
+        var sat_in = val.findsubval(0)  # Sat 0..254
+        self.set_hue_sat(nil, sat_in)
+        ctx.log = "sat:"+str(sat_in)
+        self.publish_command('Sat', sat_in)
+        return true
+      elif command == 0x0004            # ---------- MoveSaturation ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x0005            # ---------- StepSaturation ----------
+        # TODO, we don't really support it
+        return true
+      elif command == 0x0006            # ---------- MoveToHueAndSaturation ----------
+        var hue_in = val.findsubval(0)  # Hue 0..254
+        var sat_in = val.findsubval(1)  # Sat 0..254
+        self.set_hue_sat(hue_in, sat_in)
+        ctx.log = "hue:"+str(hue_in)+" sat:"+str(sat_in)
+        self.publish_command('Hue', hue_in, 'Sat', sat_in)
+        return true
+      elif command == 0x000A            # ---------- MoveToColorTemperature ----------
+        var ct_in = val.findsubval(0)
+
+        if ct_in < self.ct_min  ct_in = self.ct_min  end
+        if ct_in > self.ct_max  ct_in = self.ct_max  end
+
+        self.set_ct(ct_in)
+
+        ctx.log = "ct:"+str(ct_in)
+        self.publish_command('CT', ct_in)
+
+        return true
+      elif command == 0x0047            # ---------- StopMoveStep ----------
+        # TODO, we don't really support it
+        return true
+      end
+
+    else
+      return super(self).invoke_request(session, val, ctx)
+    end
+
+  end
+
+  #############################################################
+  # update_virtual
+  #
+  # Update internal state for virtual devices
+  def update_virtual(payload)
+    var val_hue = int(payload.find("Hue"))
+    var val_sat = int(payload.find("Sat"))
+    var val_ct = int(payload.find("CT"))
+
+    if (val_hue != nil) || (val_sat != nil)
+      self.set_hue_sat(val_hue, val_sat)
+    end
+
+    if val_ct != nil
+      self.set_ct(val_ct)
+    end
+
+    super(self).update_virtual(payload)
+  end
+
+  #############################################################
+  # For Bridge devices
+  #############################################################
+  #############################################################
+  # Stub for updating shadow values (local copies of what we published to the Matter gateway)
+  #
+  # This call is synnchronous and blocking.
+  def parse_status(data, index)
+    super(self).parse_status(data, index)
+
+    if index == 11                              # Status 11
+      var hsb = data.find("HSBColor")
+      if hsb
+        import string
+        var hsb_list = string.split(hsb, ",")
+        var hue = int(hsb_list[0])
+        var sat = int(hsb_list[1])
+        # dimmer is already available
+
+        if hue != nil     hue = tasmota.scale_uint(hue, 0, 360, 0, 254)   else hue = self.shadow_hue      end
+        if sat != nil     sat = tasmota.scale_uint(sat, 0, 100, 0, 254)   else sat = self.shadow_sat      end
+        if hue != self.shadow_hue   self.attribute_updated(0x0300, 0x0000)   self.shadow_hue = hue   end
+        if sat != self.shadow_sat   self.attribute_updated(0x0300, 0x0001)   self.shadow_sat = sat   end
+      end
+    end
+  end
+  
+  #############################################################
+  # web_values
+  #
+  # Show values of the remote device as HTML
+  def web_values()
+    import webserver
+    self.web_values_prefix()        # display '| ' and name if present
+    webserver.content_send(format("%s %s %s",
+                              self.web_value_onoff(self.shadow_onoff), self.web_value_dimmer(),
+                              self.web_value_RGB()))
+  end
+
+  # Show on/off value as html
+  def web_value_RGB()
+    if self.shadow_hue != nil && self.shadow_sat != nil
+      var l = light_state(3)      # RGB virtual light state object
+      l.set_bri(255)              # set full brightness to get full range RGB
+      l.set_huesat(tasmota.scale_uint(self.shadow_hue, 0, 254, 0, 360), tasmota.scale_uint(self.shadow_sat, 0, 254, 0, 255))
+      var rgb_hex = format("#%02X%02X%02X", l.r, l.g, l.b)
+      var rgb_html = format('<i class="bxm" style="--cl:%s"></i>%s', rgb_hex, rgb_hex)
+      return rgb_html
+    end
+    return ""
+  end
+  #############################################################
+  #############################################################
+
+end
+matter.Plugin_Light5 = Matter_Plugin_Light5

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -187,7 +187,7 @@ class Matter_UI
   "</script>"
 
   static var _CLASSES_TYPES_STD =
-                              "|relay|light0|light1|light2|light3|shutter|shutter+tilt"
+                              "|relay|light0|light1|light2|light3|light5|shutter|shutter+tilt"
                               "|gensw_btn"
                               "|temperature|pressure|illuminance|humidity|occupancy|onoff|contact|flow|rain|waterleak"
                               "|airquality"
@@ -1112,15 +1112,22 @@ class Matter_UI
     # Now `power_cnt` contains the number of Relays including light
 
     # detect lights
-    var light1, light2, light3    # contains a relay number of nil
-    if status11.contains("HSBColor")
+    var light1, light2, light3, light5    # contains a relay number or nil
+
+    if status11.contains("HSBColor") && status11.contains("CT")
+      light5 = power_cnt
+      power_cnt -= 1
+
+    elif status11.contains("HSBColor")
       light3 = power_cnt
       power_cnt -= 1
+
     elif status11.contains("CT")
-      light2 =  power_cnt
+      light2 = power_cnt
       power_cnt -= 1
+
     elif status11.contains("Dimmer")
-      light1 =  power_cnt
+      light1 = power_cnt
       power_cnt -= 1
     end
 
@@ -1138,6 +1145,9 @@ class Matter_UI
     end
     if light3 != nil
       config_list.push({'type': 'light3', 'relay': light3})
+    end
+    if light5 != nil
+      config_list.push({'type': 'light5', 'relay': light5})
     end
 
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_z_Autoconf.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_z_Autoconf.be
@@ -125,8 +125,9 @@ class Matter_Autoconf
           end
         elif channels_count == 4
           # not supported yet
-        else # only option left is 5 channels
-          # not supported yet
+        elif channels_count == 5
+          m[str(endpoint)] = {'type':'light5'}
+          endpoint += 1
         end
       end
     end


### PR DESCRIPTION
## Description:

Add Matter support for 5-channel RGB+CCT lights through a new `light5` plugin.

Matter autoconfiguration currently supports 1-channel (dimmable), 2-channel (color temperature), and 3-channel (RGB) lights, while 5-channel lights are explicitly left unsupported.

This PR adds support for 5-channel RGB+CCT devices as a single Matter Extended Color Light endpoint, supporting both Hue/Saturation and Color Temperature control.

Changes:

* Add `Matter_Plugin_Light5` for RGB+CCT lights.
* Support Hue/Saturation and Color Temperature through the Matter Color Control cluster.
* Add `light5` to the Matter UI plugin types.
* Automatically detect 5-channel local lights as `light5`.
* Add the Light5 plugin to the Matter module.

Tested on an ESP32-C3 5-channel RGB+CCT bulb with Tasmota core ESP32 V.3.3.8 / Platform 2026.05.50.

Verified:

* On/Off
* Brightness
* Hue/Saturation control
* Color Temperature control
* Switching between RGB and Color Temperature modes
* Matter state feedback
* State restoration after reboot/power cycle
* Automatic 5-channel detection as `light5`

**Related issue (if applicable):** N/A

## Checklist:

* [x] The pull request is done against the latest development branch
* [x] Only relevant files were touched
* [x] Only one feature/fix was added per PR and the code change compiles without warnings
* [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
* [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
* [x] I accept the [[CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla)](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

*NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass***