### PR TITLE
Matter: Fix autoconfiguration after configuration reset

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_zz_Device.be
@@ -553,13 +553,17 @@ class Matter_Device
       self.ipv4only = bool(j.find("ipv4only", false))
       self.disable_bridge_mode = bool(j.find("disable_bridge_mode", false))
       self.next_ep = j.find("nextep", self.next_ep)
-      self.plugins_config = j.find("config", {})
-      self.debug = bool(j.find("debug"))    # bool converts nil to false
+      self.plugins_config = j.find("config", nil)
+      self.debug = bool(j.find("debug"))
+
       if self.plugins_config != nil
         log(f"MTR: Load_config = {self.plugins_config}", 3)
         self.adjust_next_ep()
         dirty = self.check_config_ep()
         self.plugins_persist = true
+      else
+        self.plugins_config = {}
+        self.plugins_persist = false
       end
       self.plugins_config_remotes = j.find("remotes", {})
       if self.plugins_config_remotes


### PR DESCRIPTION
## Description:

Fix Matter autoconfiguration after resetting the plugin configuration.

When `reset_param()` clears the persisted Matter plugin configuration, the `config` key is omitted from the saved parameters. On the next boot, `load_param()` currently uses an empty map as the default value for a missing `config` key:

`j.find("config", {})`

This makes a missing configuration indistinguishable from an explicitly persisted empty configuration. As a result, `plugins_persist` becomes `true` and `autoconf_device_map()` is skipped.

After using **"Reset all and Auto-discover"**, the device could therefore restart without rediscovering its local endpoints, leaving the Matter configuration with no device endpoints.

This change preserves the distinction between:

* a missing `config` key, which means autoconfiguration should run;
* an explicitly persisted configuration, including an empty map.

After the change, using **"Reset all and Auto-discover"** correctly triggers autoconfiguration again after restart and the local endpoints are automatically rediscovered.

Tested on ESP32 hardware by resetting an existing Matter configuration and verifying that the device endpoints were automatically rediscovered after restart. Before the fix, the same procedure resulted in no local device endpoints being configured.

**Related issue (if applicable):** N/A

## Checklist:

* [x] The pull request is done against the latest development branch
* [x] Only relevant files were touched
* [x] Only one feature/fix was added per PR and the code change compiles without warnings
* [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
* [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
* [x] I accept the [[CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla)](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

*NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass***