### PR TITLE
NeoPool add AuxMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - MiEL HVAC climate control panel on the web UI main page (mode, target temperature, fan, vanes, air direction) with live state (#24984)
 - Support for TFA Dostmann Marbella 868MHz pool thermometer using a CC1101 (#24959)
 - Berry virtual button support
+- NeoPool add AuxMode
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_83_neopool.ino
@@ -536,6 +536,7 @@ enum NeoPoolConstAndBitMask {
   MBV_PAR_CTIMER_ENABLED_LINKED           = 2,      // Timer enabled and linked to relay from timer 0
   MBV_PAR_CTIMER_ALWAYS_ON                = 3,      // Relay assigned to this timer always on
   MBV_PAR_CTIMER_ALWAYS_OFF               = 4,      // Relay assigned to this timer always off
+  MBV_PAR_CTIMER_COUNTDOWN_KEY            = 5,      // Relay assigned to this timer countdown mode
   MBV_PAR_CTIMER_COUNTDOWN_KEY_PLUS       = 0x0105, // Timer in countdown mode using + key
   MBV_PAR_CTIMER_COUNTDOWN_KEY_MINUS      = 0x0205, // Timer in countdown mode using - key
   MBV_PAR_CTIMER_COUNTDOWN_KEY_ARROWDOWN  = 0x0405, // Timer in countdown mode using arrow-down key
@@ -781,6 +782,20 @@ enum NeoPoolModbusCode {
   } NeoPoolStats;
 #endif
 
+// Aux modes
+enum NeoPoolAuxMode {
+  NEOPOOL_AUX_MODE_UNKNOWN = -1,
+  NEOPOOL_AUX_MODE_MANUAL,
+  NEOPOOL_AUX_MODE_TIMER,
+  NEOPOOL_AUX_MODE_COUNTDOWN
+};
+const uint16_t sNeoPoolAuxMode[] PROGMEM = {
+  MBF_PAR_TIMER_BLOCK_AUX1_INT1,
+  MBF_PAR_TIMER_BLOCK_AUX2_INT1,
+  MBF_PAR_TIMER_BLOCK_AUX3_INT1,
+  MBF_PAR_TIMER_BLOCK_AUX4_INT1
+};
+
 // NPResult possible values
 enum NeoPoolResult {
   NEOPOOL_RESULT_DEC = false,
@@ -863,6 +878,7 @@ TNeoPoolSettings NeoPoolSettings;
 #define D_NEOPOOL_JSON_RELAY_UV               "UV"
 #define D_NEOPOOL_JSON_RELAY_FILTVALVE        "Valve"
 #define D_NEOPOOL_JSON_AUX                    "Aux"
+#define D_NEOPOOL_JSON_AUXMODE                "AuxMode"
 #define D_NEOPOOL_JSON_STATE                  "State"
 #define D_NEOPOOL_JSON_TYPE                   "Type"
 #define D_NEOPOOL_JSON_UNIT                   "Unit"
@@ -2259,6 +2275,29 @@ void NeoPoolShow(bool json)
     ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_AUX  "\":["));
     for(uint16_t i = 3; i < NEOPOOL_RELAY_MAX; i++) {
       ResponseAppend_P(PSTR("%s%d"), i > 3 ? PSTR(",") : PSTR(""), (NeoPoolGetData(MBF_RELAY_STATE) >> i) & 1);
+    }
+    ResponseAppend_P(PSTR("]"));
+    ResponseAppend_P(PSTR(",\""  D_NEOPOOL_JSON_AUXMODE  "\":["));
+    for(uint16_t i = 3; i < NEOPOOL_RELAY_MAX; i++) {
+      uint16_t aux_mode;
+      switch (NeoPoolGetData(sNeoPoolAuxMode[i-3] + MBV_TIMER_OFFMB_TIMER_ENABLE) & 0x00FF) {
+        case MBV_PAR_CTIMER_ALWAYS_OFF:
+        case MBV_PAR_CTIMER_ALWAYS_ON:
+          aux_mode = NEOPOOL_AUX_MODE_MANUAL;
+          break;
+        case MBV_PAR_CTIMER_DISABLE:
+        case MBV_PAR_CTIMER_ENABLED:
+        case MBV_PAR_CTIMER_ENABLED_LINKED:
+          aux_mode = NEOPOOL_AUX_MODE_TIMER;
+          break;
+        case MBV_PAR_CTIMER_COUNTDOWN_KEY:
+          aux_mode = NEOPOOL_AUX_MODE_COUNTDOWN;
+          break;
+        default:
+          aux_mode = NEOPOOL_AUX_MODE_UNKNOWN;
+          break;
+      }
+      ResponseAppend_P(PSTR("%s%d"), i > 3 ? PSTR(",") : PSTR(""), aux_mode);
     }
     ResponseAppend_P(PSTR("]"));
     if (0 != NeoPoolGetData(MBF_PAR_PH_ACID_RELAY_GPIO)) {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** Request from Home Assistant integration ha-sugar-valley-neopool [#16](https://github.com/alexdelprete/ha-sugar-valley-neopool/discussions/16)  enhancement

Add JSON array for Aux 1-4 mode

`Relay.AuxMode[]`:
0: Manual
1: Timer
2: Countdown

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
