### PR TITLE
Berry `sortedmap` support for `json.dump`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - MiEL HVAC climate control panel on the web UI main page (mode, target temperature, fan, vanes, air direction) with live state (#24984)
 - Support for TFA Dostmann Marbella 868MHz pool thermometer using a CC1101 (#24959)
 - Berry virtual button support
+- Berry `sortedmap` support for `json.dump`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/berry_port/be_jsonlib.py
+++ b/lib/libesp32/berry/berry_port/be_jsonlib.py
@@ -635,6 +635,108 @@ def string_dump(vm, index):
         be_strlib.be_toescape(vm, index, 'u')
     be_api.be_pushvalue(vm, index)
 
+# /* Custom serialization of instances through a `tojson()` method.
+#  *
+#  * Any instance can control how `json.dump()` serializes it by implementing:
+#  *
+#  *     def tojson(indent)
+#  *
+#  * Argument (optional, a `tojson()` declared without argument is valid since
+#  * Berry silently ignores extra arguments):
+#  *   `indent`: `nil` when `json.dump()` was called without the `"format"` option,
+#  *             i.e. the output must be compact.
+#  *             Otherwise an `int`, the current nesting level of this value, `0`
+#  *             at top-level, each level being `INDENT_WIDTH` (2) spaces. The
+#  *             opening indentation is already emitted by the caller, so only
+#  *             continuation lines need to be indented (at `indent`, and
+#  *             `indent+1` for nested content).
+#  *             `nil` and `0` must be distinguished, hence `nil` rather than `0`
+#  *             for the compact case: a top-level value is at level `0` in both
+#  *             modes, so the type of `indent` is what carries the mode.
+#  *             In compact mode the argument is simply not passed, and Berry
+#  *             defaults it to `nil`, so a vararg `tojson(*a)` sees `[]`.
+#  *
+#  * Return value:
+#  *   A `string` inserted *verbatim* in the output. No JSON syntax check is done,
+#  *   and no quoting nor escaping is applied: the method is fully responsible for
+#  *   emitting valid JSON. This is what allows returning a JSON object, array,
+#  *   number or `null`, and not only a JSON string. Note that returning a JSON
+#  *   string requires the quotes to be part of the returned value, and the content
+#  *   to be escaped, e.g. `return '"hello"'`.
+#  *   `nil` means "no custom serialization", and `json.dump()` falls back to its
+#  *   default behavior for this value.
+#  *   Any other type raises `type_error`.
+#  *
+#  * Instances without a `tojson()` method are unaffected and keep being dumped as
+#  * the JSON string of their `tostring()` representation.
+#  *
+#  * This function returns `btrue` if the value was serialized by `tojson()`, and
+#  * the resulting string is left on top of the stack. It returns `bfalse` if the
+#  * value is not an instance, has no `tojson` method, or `tojson()` returned
+#  * `nil`, and the stack is left unchanged. */
+# static bbool instance_dump(bvm *vm, int *indent, int idx, int fmt)
+# {
+#     if (!be_isinstance(vm, idx)) { return bfalse; }
+#     be_stack_require(vm, 3 + BE_STACK_FREE_MIN); /* method + self + 1 arg */
+#     idx = be_absindex(vm, idx); /* we push values below, `idx` must not be relative */
+#     if (!be_getmethod(vm, idx, "tojson")) {
+#         be_pop(vm, 1); /* `be_getmethod` always pushes a value, remove it */
+#         return bfalse;
+#     }
+#     be_pushvalue(vm, idx); /* push instance as first argument (self) */
+#     int argc = 1; /* self */
+#     if (fmt) {
+#         be_pushint(vm, *indent);
+#         argc++;
+#     } /* else don't pass `indent` at all, Berry defaults missing arguments to `nil` */
+#     be_call(vm, argc);
+#     be_pop(vm, argc); /* remove self and arg, the return value is now on top */
+#     if (be_isnil(vm, -1)) { /* `nil` means: use the default serialization */
+#         be_pop(vm, 1);
+#         return bfalse;
+#     }
+#     if (!be_isstring(vm, -1)) {
+#         const char *name = be_classname(vm, idx);
+#         be_raise(vm, "type_error", be_pushfstring(vm,
+#             "the value of `%s::tojson()` is not a 'string'",
+#             (name && strlen(name)) ? name : "<anonymous>"));
+#     }
+#     return btrue;
+# }
+def instance_dump(vm, indent, idx, fmt):
+    """Serialize an instance through its `tojson(indent)` method.
+
+    Returns True if `tojson()` produced the output (left on top of the stack),
+    False if the value is not an instance, has no `tojson` method, or `tojson()`
+    returned nil (fall back to the default serialization). Raises `type_error`
+    if `tojson()` returns anything other than a string or nil.
+    """
+    be_api = _lazy_be_api()
+    if not be_api.be_isinstance(vm, idx):
+        return False
+    be_api.be_stack_require(vm, 3 + BE_STACK_FREE_MIN)  # method + self + 1 arg
+    idx = be_api.be_absindex(vm, idx)  # we push values below, `idx` must not be relative
+    if not be_api.be_getmethod(vm, idx, "tojson"):
+        be_api.be_pop(vm, 1)  # `be_getmethod` always pushes a value, remove it
+        return False
+    be_api.be_pushvalue(vm, idx)  # push instance as first argument (self)
+    argc = 1  # self
+    if fmt:
+        be_api.be_pushint(vm, indent[0])
+        argc += 1
+    # else don't pass `indent` at all, Berry defaults missing arguments to `nil`
+    be_api.be_call(vm, argc)
+    be_api.be_pop(vm, argc)  # remove self and arg, the return value is now on top
+    if be_api.be_isnil(vm, -1):  # `nil` means: use the default serialization
+        be_api.be_pop(vm, 1)
+        return False
+    if not be_api.be_isstring(vm, -1):
+        name = be_api.be_classname(vm, idx)
+        be_api.be_raise(vm, "type_error", be_api.be_pushfstring(
+            vm, "the value of `%s::tojson()` is not a 'string'",
+            name if name else "<anonymous>"))
+    return True
+
 # static void object_dump(bvm *vm, int *indent, int idx, int fmt)
 # {
 #     be_stack_require(vm, 3 + BE_STACK_FREE_MIN);
@@ -780,7 +882,9 @@ def array_dump(vm, indent, idx, fmt):
 # static void value_dump(bvm *vm, int *indent, int idx, int fmt)
 # {
 #     be_stack_require(vm, 1 + BE_STACK_FREE_MIN);
-#     if (be_ismapinstance(vm, idx)) {
+#     if (instance_dump(vm, indent, idx, fmt)) {
+#         /* the result was pushed by `instance_dump` */
+#     } else if (be_ismapinstance(vm, idx)) {
 #         object_dump(vm, indent, idx, fmt);
 #     } else if (be_islistinstance(vm, idx)) {
 #         array_dump(vm, indent, idx, fmt);
@@ -811,7 +915,9 @@ def value_dump(vm, indent, idx, fmt):
     # `be_ismapinstance()` / `be_islistinstance()` walk the class hierarchy and
     # compare against the actual builtin `map` / `list` classes, so subclasses
     # are handled, and a user class that merely shares the name is not.
-    if be_api.be_ismapinstance(vm, idx):
+    if instance_dump(vm, indent, idx, fmt):
+        pass  # an explicit `tojson()` method takes precedence, result already pushed
+    elif be_api.be_ismapinstance(vm, idx):
         object_dump(vm, indent, idx, fmt)
     elif be_api.be_islistinstance(vm, idx):
         array_dump(vm, indent, idx, fmt)

--- a/lib/libesp32/berry/src/be_jsonlib.c
+++ b/lib/libesp32/berry/src/be_jsonlib.c
@@ -490,6 +490,75 @@ void string_dump(bvm *vm, int index)
     be_pushvalue(vm, index);
 }
 
+/* Custom serialization of instances through a `tojson()` method.
+ *
+ * Any instance can control how `json.dump()` serializes it by implementing:
+ *
+ *     def tojson(indent)
+ *
+ * Argument (optional, a `tojson()` declared without argument is valid since
+ * Berry silently ignores extra arguments):
+ *   `indent`: `nil` when `json.dump()` was called without the `"format"` option,
+ *             i.e. the output must be compact.
+ *             Otherwise an `int`, the current nesting level of this value, `0`
+ *             at top-level, each level being `INDENT_WIDTH` (2) spaces. The
+ *             opening indentation is already emitted by the caller, so only
+ *             continuation lines need to be indented (at `indent`, and
+ *             `indent+1` for nested content).
+ *             `nil` and `0` must be distinguished, hence `nil` rather than `0`
+ *             for the compact case: a top-level value is at level `0` in both
+ *             modes, so the type of `indent` is what carries the mode.
+ *             In compact mode the argument is simply not passed, and Berry
+ *             defaults it to `nil`, so a vararg `tojson(*a)` sees `[]`.
+ *
+ * Return value:
+ *   A `string` inserted *verbatim* in the output. No JSON syntax check is done,
+ *   and no quoting nor escaping is applied: the method is fully responsible for
+ *   emitting valid JSON. This is what allows returning a JSON object, array,
+ *   number or `null`, and not only a JSON string. Note that returning a JSON
+ *   string requires the quotes to be part of the returned value, and the content
+ *   to be escaped, e.g. `return '"hello"'`.
+ *   `nil` means "no custom serialization", and `json.dump()` falls back to its
+ *   default behavior for this value.
+ *   Any other type raises `type_error`.
+ *
+ * Instances without a `tojson()` method are unaffected and keep being dumped as
+ * the JSON string of their `tostring()` representation.
+ *
+ * This function returns `btrue` if the value was serialized by `tojson()`, and
+ * the resulting string is left on top of the stack. It returns `bfalse` if the
+ * value is not an instance, has no `tojson` method, or `tojson()` returned
+ * `nil`, and the stack is left unchanged. */
+static bbool instance_dump(bvm *vm, int *indent, int idx, int fmt)
+{
+    if (!be_isinstance(vm, idx)) { return bfalse; }
+    be_stack_require(vm, 3 + BE_STACK_FREE_MIN); /* method + self + 1 arg */
+    idx = be_absindex(vm, idx); /* we push values below, `idx` must not be relative */
+    if (!be_getmethod(vm, idx, "tojson")) {
+        be_pop(vm, 1); /* `be_getmethod` always pushes a value, remove it */
+        return bfalse;
+    }
+    be_pushvalue(vm, idx); /* push instance as first argument (self) */
+    int argc = 1; /* self */
+    if (fmt) {
+        be_pushint(vm, *indent);
+        argc++;
+    } /* else don't pass `indent` at all, Berry defaults missing arguments to `nil` */
+    be_call(vm, argc);
+    be_pop(vm, argc); /* remove self and arg, the return value is now on top */
+    if (be_isnil(vm, -1)) { /* `nil` means: use the default serialization */
+        be_pop(vm, 1);
+        return bfalse;
+    }
+    if (!be_isstring(vm, -1)) {
+        const char *name = be_classname(vm, idx);
+        be_raise(vm, "type_error", be_pushfstring(vm,
+            "the value of `%s::tojson()` is not a 'string'",
+            (name && strlen(name)) ? name : "<anonymous>"));
+    }
+    return btrue;
+}
+
 static void object_dump(bvm *vm, int *indent, int idx, int fmt)
 {
 
@@ -571,7 +640,9 @@ static void value_dump(bvm *vm, int *indent, int idx, int fmt)
     /* `be_ismapinstance()` / `be_islistinstance()` walk the class hierarchy and
      * compare against the actual builtin `map` / `list` classes, so subclasses
      * are handled, and a user class that merely shares the name is not. */
-    if (be_ismapinstance(vm, idx)) { /* convert to json object */
+    if (instance_dump(vm, indent, idx, fmt)) { /* an explicit `tojson()` method takes precedence */
+        /* the result was pushed by `instance_dump` */
+    } else if (be_ismapinstance(vm, idx)) { /* convert to json object */
         object_dump(vm, indent, idx, fmt);
     } else if (be_islistinstance(vm, idx)) { /* convert to json array */
         array_dump(vm, indent, idx, fmt);

--- a/lib/libesp32/berry/tests/json.be
+++ b/lib/libesp32/berry/tests/json.be
@@ -61,8 +61,8 @@ json.load(text) # do nothing, just check that it doesn't crash
 
 # dump tests
 
-def assert_dump(value, text, format)
-    assert(json.dump(value, format) == text)
+def assert_dump(value, text, fmt)
+    assert(json.dump(value, fmt) == text)
 end
 
 assert_dump(nil, 'null');
@@ -80,6 +80,111 @@ class map2 : map def init() super(self).init() end end
 var m = map2()
 m['key'] = 1
 assert_dump(m, '{"key":1}')
+
+# dump of instances implementing `tojson(format, indent)`
+
+def assert_dump_error(value, error_type, fmt)
+    try
+        json.dump(value, fmt)
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == error_type)
+    end
+end
+
+# the returned string is inserted verbatim, it can be any JSON fragment
+class J_str def tojson() return '"raw"' end end
+assert_dump(J_str(), '"raw"')
+class J_int def tojson() return '42' end end
+assert_dump(J_int(), '42')
+class J_null def tojson() return 'null' end end
+assert_dump(J_null(), 'null')
+class J_obj def tojson() return '{"a":1}' end end
+assert_dump(J_obj(), '{"a":1}')
+class J_arr def tojson() return '[1,2]' end end
+assert_dump(J_arr(), '[1,2]')
+# no JSON syntax check is done on the returned string
+class J_bad def tojson() return 'not json' end end
+assert_dump(J_bad(), 'not json')
+
+# nested in containers
+assert_dump([J_obj(), J_int()], '[{"a":1},42]')
+assert_dump({'k': J_obj()}, '{"k":{"a":1}}')
+assert_dump({'k': J_obj()}, '{\n  "k": {"a":1}\n}', 'format')
+
+# `tojson()` is not used for map keys, they are always `tostring()` of the key
+class J_key def tostring() return 'thekey' end def tojson() return '{"a":1}' end end
+assert_dump({J_key(): 1}, '{"thekey":1}')
+
+# the `indent` argument is `nil` for compact output, and the nesting level
+# (an `int`, `0` at top-level) when the 'format' option is used
+class J_args def tojson(indent) return string.format('"%s"', str(indent)) end end
+assert_dump(J_args(), '"nil"')
+assert_dump(J_args(), '"0"', 'format')
+assert_dump({'k': J_args()}, '{"k":"nil"}')
+assert_dump({'k': J_args()}, '{\n  "k": "1"\n}', 'format')
+# a top-level value is at level 0 in both modes, so the type of `indent`
+# (`nil` vs `int`) is what carries the mode, not its value
+assert_dump([[J_args()]], '[\n  [\n    "2"\n  ]\n]', 'format')
+assert_dump([[J_args()]], '[["nil"]]')
+# declaring `tojson()` without argument is valid, extra arguments are ignored
+class J_noargs def tojson() return '1' end end
+assert_dump(J_noargs(), '1')
+
+# returning `nil` falls back to the default serialization
+class J_nil def tojson() return nil end def tostring() return 'default' end end
+assert_dump(J_nil(), '"default"')
+class J_noreturn def tojson() end end
+assert_dump(J_noreturn(), '"<instance: J_noreturn()>"')
+# which allows opting out on a per-instance basis
+class J_cond var raw
+    def init(raw) self.raw = raw end
+    def tojson() if self.raw return '1' end return nil end
+    def tostring() return 'str' end
+end
+assert_dump([J_cond(true), J_cond(false)], '[1,"str"]')
+
+# any other return type raises `type_error`
+class J_err_int def tojson() return 42 end end
+assert_dump_error(J_err_int(), 'type_error')
+class J_err_list def tojson() return [1] end end
+assert_dump_error(J_err_list(), 'type_error')
+assert_dump_error([{'k': J_err_int()}], 'type_error')
+# exceptions raised by `tojson()` propagate
+class J_raise def tojson() raise 'custom_error' end end
+assert_dump_error(J_raise(), 'custom_error')
+
+# `tojson()` is inherited, and can be overridden
+class J_sub : J_obj end
+assert_dump(J_sub(), '{"a":1}')
+class J_sub2 : J_obj def tojson() return '{"b":2}' end end
+assert_dump(J_sub2(), '{"b":2}')
+
+# `tojson()` can be static
+class J_static static def tojson() return '"static"' end end
+assert_dump(J_static(), '"static"')
+
+# `tojson()` can be provided by a virtual `member()` method
+class J_virtual def member(name) if name == 'tojson' return def () return '"virtual"' end end end end
+assert_dump(J_virtual(), '"virtual"')
+
+# a `tojson` member which is not a function is ignored
+class J_notfunc var tojson def init() self.tojson = 12 end end
+assert_dump(J_notfunc(), '"<instance: J_notfunc()>"')
+
+# `tojson()` takes precedence over `map` and `list` sub-classes
+class J_map : map def init() super(self).init() end def tojson() return '"amap"' end end
+var jm = J_map()
+jm['k'] = 1
+assert_dump(jm, '"amap"')
+class J_list : list def init() super(self).init() end def tojson() return '"alist"' end end
+assert_dump(J_list(), '"alist"')
+
+# instances without `tojson()` are unaffected
+class J_plain end
+assert_dump(J_plain(), '"<instance: J_plain()>"')
+class J_tostr def tostring() return 'a "quoted" str' end end
+assert_dump(J_tostr(), '"a \\"quoted\\" str"')
 
 # sweep dumping nested arrays of diffrent sizes
 # this tests for any unexpanded stack conditions

--- a/lib/libesp32/berry/tests/property/test_json_module.py
+++ b/lib/libesp32/berry/tests/property/test_json_module.py
@@ -309,6 +309,208 @@ class TestJsonDump:
 
 
 # ============================================================================
+# json.dump — custom serialization through `tojson(fmt, indent)`
+# ============================================================================
+
+class TestJsonDumpTojson:
+    """An instance implementing `tojson()` controls its own serialization.
+
+    The returned string is inserted verbatim (no quoting, no escaping, no JSON
+    syntax check), `nil` falls back to the default serialization, and any other
+    return type raises `type_error`.
+    """
+
+    def test_tojson_string(self):
+        run_json_test(
+            "class J def tojson() return '\"raw\"' end end\n"
+            "assert(json.dump(J()) == '\"raw\"')"
+        )
+
+    def test_tojson_raw_fragments(self):
+        """The return value is verbatim, so any JSON type can be emitted."""
+        run_json_test(
+            "class J_int def tojson() return '42' end end\n"
+            "class J_null def tojson() return 'null' end end\n"
+            "class J_obj def tojson() return '{\"a\":1}' end end\n"
+            "class J_arr def tojson() return '[1,2]' end end\n"
+            "assert(json.dump(J_int()) == '42')\n"
+            "assert(json.dump(J_null()) == 'null')\n"
+            "assert(json.dump(J_obj()) == '{\"a\":1}')\n"
+            "assert(json.dump(J_arr()) == '[1,2]')"
+        )
+
+    def test_tojson_no_syntax_check(self):
+        run_json_test(
+            "class J def tojson() return 'not json' end end\n"
+            "assert(json.dump(J()) == 'not json')"
+        )
+
+    def test_tojson_nested_in_containers(self):
+        run_json_test(
+            "class J def tojson() return '{\"a\":1}' end end\n"
+            "assert(json.dump([J(), J()]) == '[{\"a\":1},{\"a\":1}]')\n"
+            "assert(json.dump({'k': J()}) == '{\"k\":{\"a\":1}}')"
+        )
+
+    def test_tojson_not_used_for_map_keys(self):
+        """JSON keys must be strings, so keys always go through tostring()."""
+        run_json_test(
+            "class J\n"
+            "  def tostring() return 'thekey' end\n"
+            "  def tojson() return '{\"a\":1}' end\n"
+            "end\n"
+            "assert(json.dump({J(): 1}) == '{\"thekey\":1}')"
+        )
+
+    def test_tojson_indent_arg(self):
+        """`indent` is nil for compact output, the nesting level in format mode.
+
+        A top-level value is at level 0 in both modes, so the *type* of `indent`
+        is what carries the mode, not its value.
+        """
+        run_json_test(
+            "class J def tojson(indent)\n"
+            "  return string.format('\"%s\"', str(indent))\n"
+            "end end\n"
+            "assert(json.dump(J()) == '\"nil\"')\n"
+            "assert(json.dump(J(), 'format') == '\"0\"')\n"
+            "assert(json.dump({'k': J()}) == '{\"k\":\"nil\"}')\n"
+            "assert(json.dump([[J()]]) == '[[\"nil\"]]')\n"
+            r"assert(json.dump({'k': J()}, 'format') == '{\n  \"k\": \"1\"\n}')"
+            "\n"
+            r"assert(json.dump([[J()]], 'format') == '[\n  [\n    \"2\"\n  ]\n]')"
+        )
+
+    def test_tojson_without_args_is_valid(self):
+        """Berry ignores extra arguments, so a 0-arg tojson() works."""
+        run_json_test(
+            "class J def tojson() return '1' end end\n"
+            "assert(json.dump(J()) == '1')"
+        )
+
+    def test_tojson_nil_falls_back_to_default(self):
+        run_json_test(
+            "class J\n"
+            "  def tojson() return nil end\n"
+            "  def tostring() return 'default' end\n"
+            "end\n"
+            "assert(json.dump(J()) == '\"default\"')"
+        )
+
+    def test_tojson_no_return_falls_back_to_default(self):
+        run_json_test(
+            "class J def tojson() end end\n"
+            "assert(json.dump(J()) == '\"<instance: J()>\"')"
+        )
+
+    def test_tojson_conditional_opt_out(self):
+        """Returning nil per-instance allows opting out selectively."""
+        run_json_test(
+            "class J var raw\n"
+            "  def init(raw) self.raw = raw end\n"
+            "  def tojson() if self.raw return '1' end return nil end\n"
+            "  def tostring() return 'str' end\n"
+            "end\n"
+            "assert(json.dump([J(true), J(false)]) == '[1,\"str\"]')"
+        )
+
+    @pytest.mark.parametrize("ret", ["42", "[1]", "1.5", "true", "{'a':1}"])
+    def test_tojson_non_string_raises_type_error(self, ret):
+        source = (
+            "import json\n"
+            f"class J def tojson() return {ret} end end\n"
+            "try\n"
+            "  json.dump(J())\n"
+            "  assert(false, 'should have raised')\n"
+            "except .. as e, m\n"
+            "  assert(e == 'type_error')\n"
+            "end\n"
+        )
+        rc, stdout, stderr = berry_eval(source)
+        assert rc == 0, f"Berry exited {rc}\nstdout: {stdout}\nstderr: {stderr}"
+
+    def test_tojson_error_from_nested_value(self):
+        run_json_test(
+            "class J def tojson() return 42 end end\n"
+            "try\n"
+            "  json.dump([{'k': J()}])\n"
+            "  assert(false, 'should have raised')\n"
+            "except .. as e, m\n"
+            "  assert(e == 'type_error')\n"
+            "end"
+        )
+
+    def test_tojson_exception_propagates(self):
+        run_json_test(
+            "class J def tojson() raise 'custom_error' end end\n"
+            "try\n"
+            "  json.dump(J())\n"
+            "  assert(false, 'should have raised')\n"
+            "except .. as e, m\n"
+            "  assert(e == 'custom_error')\n"
+            "end"
+        )
+
+    def test_tojson_inherited_and_overridden(self):
+        run_json_test(
+            "class A def tojson() return '{\"a\":1}' end end\n"
+            "class B : A end\n"
+            "class C : A def tojson() return '{\"b\":2}' end end\n"
+            "assert(json.dump(B()) == '{\"a\":1}')\n"
+            "assert(json.dump(C()) == '{\"b\":2}')"
+        )
+
+    def test_tojson_static(self):
+        run_json_test(
+            "class J static def tojson() return '\"static\"' end end\n"
+            "assert(json.dump(J()) == '\"static\"')"
+        )
+
+    def test_tojson_via_virtual_member(self):
+        """A virtual `member()` hook can synthesize `tojson` dynamically."""
+        run_json_test(
+            "class J def member(name)\n"
+            "  if name == 'tojson' return def () return '\"virtual\"' end end\n"
+            "end end\n"
+            "assert(json.dump(J()) == '\"virtual\"')"
+        )
+
+    def test_tojson_non_function_member_ignored(self):
+        run_json_test(
+            "class J var tojson def init() self.tojson = 12 end end\n"
+            "assert(json.dump(J()) == '\"<instance: J()>\"')"
+        )
+
+    def test_tojson_takes_precedence_over_map_subclass(self):
+        run_json_test(
+            "class J : map\n"
+            "  def init() super(self).init() end\n"
+            "  def tojson() return '\"amap\"' end\n"
+            "end\n"
+            "var m = J()\n"
+            "m['k'] = 1\n"
+            "assert(json.dump(m) == '\"amap\"')"
+        )
+
+    def test_tojson_takes_precedence_over_list_subclass(self):
+        run_json_test(
+            "class J : list\n"
+            "  def init() super(self).init() end\n"
+            "  def tojson() return '\"alist\"' end\n"
+            "end\n"
+            "assert(json.dump(J()) == '\"alist\"')"
+        )
+
+    def test_instances_without_tojson_unaffected(self):
+        run_json_test(
+            "class J_plain end\n"
+            "class J_tostr def tostring() return 'a \"quoted\" str' end end\n"
+            "assert(json.dump(J_plain()) == '\"<instance: J_plain()>\"')\n"
+            "assert(json.dump(J_tostr()) == '\"a \\\\\"quoted\\\\\" str\"')"
+        )
+
+
+# ============================================================================
 # Security tests — ported from the new tests in tests/json.be
 # ============================================================================
 

--- a/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/sortedmap.be
@@ -77,33 +77,26 @@ class sortedmap : map
   end
   # String representation, in sorted key order
   def tostring()
-    import string
-    var result = "{"
-    var first = true
-    
-    for key : self._keys
-      var val = super(self).item(key)
-      
-      if !first
-        result += ", "
-      end
-      first = false
-      
-      if type(key) == 'string'
-        result += string.format("'%s': ", key)
-      else
-        result += string.format("%s: ", str(key))
-      end
-      
-      if type(val) == 'string'
-        result += string.format("'%s'", val)
-      else
-        result += str(val)
-      end
+    var r = '{'
+    var sep = ''
+    for k : self._keys
+      r += f'{sep}{k:q}: {self.item(k):q}'
+      sep = ', '
     end
-    
-    result += "}"
-    return result
+    r += '}'
+    return r
+  end
+
+  # Compact JSON representation, in sorted key order
+  def tojson()
+    import json
+    var r = '{'
+    var sep = ''
+    for k : self._keys
+      r += f'{sep}{json.dump(str(k))}:{json.dump(self.item(k))}'
+      sep = ','
+    end
+    return r + '}'
   end
 
   # Return iterator to values in sorted key order
@@ -265,6 +258,30 @@ assert(keys[1] == 2)
 assert(keys[2] == 10)
 assert(keys[3] == 'a')
 assert(keys[4] == 'c')
+
+# Test string representation and escaping
+m = sortedmap()
+m.insert('b', 2)
+m.insert('a', 1)
+assert(str(m) == "{'a': 1, 'b': 2}")
+var key = "k'\"\\\n\r\t\x01é"
+var value = "v'\"\\\n\r\t\x1f世界"
+m = sortedmap()
+m.insert(key, value)
+var plain = {}
+plain.insert(key, value)
+assert(str(m) == str(plain))
+
+# Test JSON serialization
+import json
+m = sortedmap()
+assert(json.dump(m) == '{}')
+m.insert('z', 1)
+m.insert('a', 'x')
+assert(json.dump(m) == '{"a":"x","z":1}')
+assert(json.dump(m, 'format') == '{"a":"x","z":1}')
+m = sortedmap({'z': {'b': 2, 'a': 1}, 'a"b': 'line\n'})
+assert(json.dump(m) == '{"a\\"b":"line\\n","z":{"a":1,"b":2}}')
 
 # Test clear
 m.clear()


### PR DESCRIPTION
## Description:

Berry:
- Add support for custom json dump, when an instance implements `tojson()`
- Added support for custom json dump in `sortedmap`. Now using `json.dump()` on `sortedmap` dumps the map with sorted keys

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
