### PR TITLE
MiEL HVAC: hide the redundant power toggle from the web UI

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
@@ -27,6 +27,10 @@
  * https://muart-group.github.io/developer/it-protocol/
  * Compile with USE_MIEL_HVAC; GPIOs "MiEl HVAC Rx" / "MiEl HVAC Tx".
  *
+ * The web panel's Off button replaces the generic Tasmota power toggle, which is hidden
+ * together with its ON/OFF state row; the POWER command and its MQTT / Home Assistant
+ * state sync are unchanged.
+ *
  * --- Modbus RTU slave (USE_MIEL_HVAC_MODBUS_SLAVE, ESP32) ---------------------------------
  * Optional second RS485 port that mirrors every driver state as read registers and maps
  * every driver function to write registers / coils, so the unit can be driven from a PLC
@@ -4211,6 +4215,23 @@ miel_hvac_web_select(const char *label, const char *id, const char *key,
 static void
 miel_hvac_web_panel(struct miel_hvac_softc *sc)
 {
+	/*
+	 * The Mode segment (with its Off button) replaces the generic power
+	 * toggle, so hide that button and its ON/OFF state row.  When the HVAC
+	 * is the only device the whole button table and the state row go; with
+	 * other relays present only this device's button cell is hidden.  The
+	 * POWER command and its MQTT state sync stay in place for rules and
+	 * Home Assistant.
+	 */
+	if (TasmotaGlobal.devices_present == 1)
+		WSContentSend_P(PSTR("<style>"
+			"table:has(#o1){display:none}"
+			"#l1>table:last-of-type{display:none}"
+			"</style>"));
+	else
+		WSContentSend_P(PSTR("<style>td:has(>#o%u){display:none}</style>"),
+			sc->sc_device + 1);
+
 	if (sc->sc_settings.type == 0)
 		return;
 


### PR DESCRIPTION
## Summary

The MiEL HVAC web control panel (#24984) has a Mode segment with its own **Off** button,
so the generic Tasmota power toggle above it — and the large ON/OFF state text — are now
redundant duplicates of the same relay.

This hides them from the main page with a small scoped stylesheet emitted from the panel
(`FUNC_WEB_ADD_MAIN_BUTTON`):

- HVAC is the only device → the whole button table and the state row are hidden
  (`table:has(#o1)`, `#l1 > table:last-of-type`)
- other relays present → only this device's button cell is hidden (`td:has(> #oN)`)

Nothing else changes: `POWER` / `POWER1` still work from the console, MQTT and rules, the
relay state still tracks the HVAC power for Home Assistant discovery — only the on-page
widgets are removed.

`:has()` is Baseline-supported; on a browser without it the rule is ignored and the toggle
simply stays visible.

## Testing

- `tasmota` (ESP8266) and `tasmota32s3` builds compile without warnings.
- Verified on hardware: toggle button and state row gone, `POWER TOGGLE` from the console
  still switches the unit and updates `stat/.../POWER`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
