### PR TITLE
MiEL HVAC: publish HVACSettings after an optimistic settings apply

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_44_miel_hvac.ino
@@ -39,8 +39,8 @@
  *
  * A control change is written to sc_settings straight away, before the unit confirms with
  * the next 0x62 0x02, so the panel, the Modbus registers and SENSOR show the intent
- * instead of the stale pre-change state for ~1s; the unit's next report wins if it
- * rejects the change.
+ * instead of the stale pre-change state for ~1s, and HVACSettings / SENSOR are published
+ * at that point; the unit's next report wins (and republishes) if it rejects the change.
  *
  * --- Modbus RTU slave (USE_MIEL_HVAC_MODBUS_SLAVE, ESP32) ---------------------------------
  * Optional second RS485 port that mirrors every driver state as read registers and maps
@@ -4690,6 +4690,20 @@ miel_hvac_tick(struct miel_hvac_softc *sc)
 				set->widevane = update->widevane;
 			if (f & htons(MIEL_HVAC_SETTINGS_F_AIRDIRECTION))
 				set->airdirection = update->airdirection;
+
+			/*
+			 * Publish the new state now.  The confirming 0x62 0x02
+			 * normally equals the optimistically applied sc_settings,
+			 * so miel_hvac_input_settings()'s memcmp() would not fire
+			 * and HVACSettings / SENSOR would not go out until the
+			 * next TelePeriod.  If the unit rejects or changes the
+			 * request its report still differs and republishes.
+			 */
+			if (sc->sc_settings_set)
+			{
+				miel_hvac_publish_settings(sc);
+				MqttPublishSensor();
+			}
 		}
 
 		miel_hvac_init_update_settings(update);


### PR DESCRIPTION
## Summary

Follow-up to #25004. That PR made `miel_hvac_tick()` copy the fields of an
outgoing `0x41` set-settings request into `sc_settings` straight away, so the web
panel, the Modbus registers and `SENSOR` show the intended state during the ~1 s
before the unit confirms with the next `0x62 0x02`.

Side effect: when the confirming `0x62 0x02` arrives it now normally equals the
already-updated `sc_settings`, so the `memcmp()` in `miel_hvac_input_settings()`
no longer fires and the `HVACSettings` tele topic (and `SENSOR`) are not
published after an `HVACSet*` command. A manual `TelePeriod` shows the correct
state, so only the push was lost. Reported by @mamrai1.

Fix: publish `HVACSettings` + `SENSOR` right after the optimistic apply, the same
messages `miel_hvac_input_settings()` would have sent. If the unit rejects or
modifies the request, its `0x62 0x02` still differs from `sc_settings` and the
existing comparison republishes the corrected state. One publish per command,
matching the pre-#25004 behaviour.

## Testing

- `tasmota` (ESP8266) and `tasmota32s3` compile without warnings.
- `HVACSetMode` / `HVACSetTemp` from console and web panel: `HVACSettings` is
  published immediately again; no duplicate publish when the unit confirms an
  unchanged value; a unit-modified value still triggers a second publish.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
