### PR TITLE
[MI32BLE] Add unit/battery support for LYWSD02MMC

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_ble.ino
@@ -819,6 +819,8 @@ int genericBatReadFn(int slot){
 
   switch(MIBLEsensors[slot].type) {
     // these use notify for battery read, and it comes in the temp packet
+    case MI_LYWSD02MMC:
+    case MI_LYWSD02MMC2:
     case MI_LYWSD03MMC:
       res = MI32Operation(slot, OP_BATT_READ, LYWSD03_Svc, nullptr, LYWSD03_BattNotifyChar);
       break;
@@ -983,6 +985,8 @@ int genericUnitWriteFn(int slot, int unit){
   uint8_t writeData[1];
   writeData[0] = unit;
   switch (MIBLEsensors[slot].type){
+    case MI_LYWSD02MMC:
+    case MI_LYWSD02MMC2:
     case MI_LYWSD02:
       res = MI32Operation(slot, op, LYWSD02_Svc, LYWSD02_UnitChar, nullptr, writeData, 1);
       break;
@@ -1001,6 +1005,8 @@ int genericUnitWriteFn(int slot, int unit){
 int genericUnitReadFn(int slot){
   int res = 0;
   switch (MIBLEsensors[slot].type){
+    case MI_LYWSD02MMC:
+    case MI_LYWSD02MMC2:
     case MI_LYWSD02:
       res = MI32Operation(slot, OP_UNIT_READ, LYWSD02_Svc, LYWSD02_UnitChar);
       break;


### PR DESCRIPTION
## Description:
Add unit/battery support for LYWSD02MMC
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.8
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.3.8 from Platform 2026.05.50
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).